### PR TITLE
fix(sbb-calendar): fix wrong width when orientation changes in iOS

### DIFF
--- a/src/components/sbb-calendar/sbb-calendar.scss
+++ b/src/components/sbb-calendar/sbb-calendar.scss
@@ -142,10 +142,6 @@
 
 .sbb-calendar__table {
   width: 100%;
-
-  // Due to a Safari iOS rendering bug we need to define min-width as well.
-  // Otherwise, after orientation change, there is a wrong width if placed in an sbb-dialog.
-  min-width: 100%;
   border-collapse: collapse;
   height: max-content;
 
@@ -165,6 +161,12 @@
       name: hide;
       duration: var(--sbb-calendar-table-animation-duration);
     }
+  }
+
+  :host(:not([data-wide])) & {
+    // Due to a Safari iOS rendering bug we need to define min-width as well.
+    // Otherwise, after orientation change, there is a wrong width if placed in an sbb-dialog.
+    min-width: 100%;
   }
 }
 

--- a/src/components/sbb-calendar/sbb-calendar.tsx
+++ b/src/components/sbb-calendar/sbb-calendar.tsx
@@ -6,6 +6,7 @@ import {
   EventEmitter,
   Fragment,
   h,
+  Host,
   JSX,
   Method,
   Prop,
@@ -1197,6 +1198,10 @@ export class SbbCalendar implements ComponentInterface {
   }
 
   public render(): JSX.Element {
-    return <div class="sbb-calendar__wrapper">{this._getView}</div>;
+    return (
+      <Host data-wide={this._wide}>
+        <div class="sbb-calendar__wrapper">{this._getView}</div>
+      </Host>
+    );
   }
 }


### PR DESCRIPTION
Due to a Safari iOS rendering bug we need to define min-width as well.
Otherwise, after orientation change, there is a wrong width if placed in an sbb-dialog.