### PR TITLE
build: improve test runner concurrency

### DIFF
--- a/tools/web-test-runner/vite-plugin.js
+++ b/tools/web-test-runner/vite-plugin.js
@@ -1,4 +1,5 @@
 import { existsSync } from 'fs';
+import { Readable } from 'stream';
 import { createServer } from 'vite';
 
 // Reference: https://github.com/remcovaes/web-test-runner-vite-plugin
@@ -52,8 +53,8 @@ export function vitePlugin() {
         // Retry once on failure.
         // This can happen when too many http requests are being handled by the operating system.
         const response = await fetch(url).catch(() => Promise.resolve().then(() => fetch(url)));
+        ctx.body = Readable.fromWeb(response.body);
         ctx.set(Object.fromEntries(response.headers));
-        ctx.body = await response.text();
         ctx.status = response.status;
       });
     },

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -4,7 +4,6 @@ import { puppeteerLauncher } from '@web/test-runner-puppeteer';
 import { a11ySnapshotPlugin } from '@web/test-runner-commands/plugins';
 import { visualRegressionPlugin } from '@web/test-runner-visual-regression/plugin';
 import * as sass from 'sass';
-import { cpus } from 'node:os';
 
 import {
   minimalReporter,
@@ -99,13 +98,6 @@ const testRunnerHtml = (testFramework, _config, group) => `
 </html>
 `;
 
-// Slow down fast cpus to not run into too much fetches
-function resolveConcurrency() {
-  const localCpus = cpus();
-  const factor = localCpus.some((el) => el.model.includes('Apple M')) ? 4 : 2;
-  return Math.floor(localCpus.length / factor);
-}
-
 // A list of log messages, that should not be printed to the test console.
 const suppressedLogs = [
   'Lit is in dev mode. Not recommended for production! See https://lit.dev/msg/dev-mode for more information.',
@@ -128,7 +120,6 @@ export default {
   files: ['src/**/*.{e2e,spec,!snapshot.spec}.ts'],
   groups,
   nodeResolve: true,
-  concurrency: resolveConcurrency(),
   reporters:
     isDebugMode || !isCIEnvironment
       ? [defaultReporter(), patchedSummaryReporter()]


### PR DESCRIPTION
By using streaming in our vite to web-test-runner proxy, we can improve the concurrency capabilities of running tests.