### PR TITLE
build: mangle private properties in prod build to reduce size

### DIFF
--- a/src/elements-experimental/vite.config.ts
+++ b/src/elements-experimental/vite.config.ts
@@ -46,6 +46,7 @@ export default defineConfig((config) =>
           ]
         : []),
     ],
+    esbuild: isProdBuild(config) ? { mangleProps: /^_/ } : {},
     build: {
       cssMinify: isProdBuild(config),
       lib: {

--- a/src/elements/vite.config.ts
+++ b/src/elements/vite.config.ts
@@ -78,6 +78,7 @@ export default defineConfig((config) =>
           ]
         : []),
     ],
+    esbuild: isProdBuild(config) ? { mangleProps: /^_/ } : {},
     build: {
       cssMinify: isProdBuild(config),
       lib: {


### PR DESCRIPTION
This PR adds a configuration to mangle private properties in prod builds. Currently this saves about 40kB (of about 800kB total).
This technically also prevents consumers from using private API, as it will be reduced to a single letter usually.

Personal opinion: While this does not have a huge impact, I still feel like we should try to optimize where possible. But I would like to hear your opinions on this @jeripeierSBB, @TomMenga.