### PR TITLE
fix: avoid breaking type declarations due to alias resolution

### DIFF
--- a/tools/vite/dts.ts
+++ b/tools/vite/dts.ts
@@ -7,6 +7,11 @@ export function dts(): Plugin {
     exclude: ['**/*[.-]{stories,spec,test-utils}.ts', '**/private/*', 'vite.config.ts'],
     pathsToAliases: false,
     strictOutput: false,
+    aliasesExclude: [
+      /^@sbb-esta\/lyne-elements\/?/,
+      /^@sbb-esta\/lyne-elements-experimental\/?/,
+      /^@sbb-esta\/lyne-react\/?/,
+    ],
     afterDiagnostic(diagnostics) {
       if (diagnostics.length) {
         throw new Error('dts generation for react package failed! See logs for details.');


### PR DESCRIPTION
Currently the cross-package import paths are resolved by the dts vite plugin. However, the import paths to our packages should remain untouched. Due to this, we add configuration to prevent our aliases from being converted.