### PR TITLE
test: fix freeze on assert fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
   "resolutions": {
     "@types/node": "20.14.2",
     "@webcomponents/template-shadowroot": "0.2.1",
+    "@web/dev-server-core": "0.7.1",
     "jackspeak": "2.1.1",
     "lit": "3.1.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3545,34 +3545,10 @@
   resolved "https://registry.yarnpkg.com/@web/config-loader/-/config-loader-0.3.1.tgz#0917fd549c264e565e75bd6c7d73acd7365df26b"
   integrity sha512-IYjHXUgSGGNpO3YJQ9foLcazbJlAWDdJGRe9be7aOhon0Nd6Na5JIOJAej7jsMu76fKHr4b4w2LfIdNQ4fJ8pA==
 
-"@web/dev-server-core@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@web/dev-server-core/-/dev-server-core-0.4.1.tgz#803faff45281ee296d0dda02dfdd905c330db4d8"
-  integrity sha512-KdYwejXZwIZvb6tYMCqU7yBiEOPfKLQ3V9ezqqEz8DA9V9R3oQWaowckvCpFB9IxxPfS/P8/59OkdzGKQjcIUw==
-  dependencies:
-    "@types/koa" "^2.11.6"
-    "@types/ws" "^7.4.0"
-    "@web/parse5-utils" "^1.3.1"
-    chokidar "^3.4.3"
-    clone "^2.1.2"
-    es-module-lexer "^1.0.0"
-    get-stream "^6.0.0"
-    is-stream "^2.0.0"
-    isbinaryfile "^5.0.0"
-    koa "^2.13.0"
-    koa-etag "^4.0.0"
-    koa-send "^5.0.1"
-    koa-static "^5.0.0"
-    lru-cache "^6.0.0"
-    mime-types "^2.1.27"
-    parse5 "^6.0.1"
-    picomatch "^2.2.2"
-    ws "^7.4.2"
-
-"@web/dev-server-core@^0.7.2":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@web/dev-server-core/-/dev-server-core-0.7.2.tgz#a4f4808bd709257f44b1218cd2663de3a7c5b317"
-  integrity sha512-Q/0jpF13Ipk+qGGQ+Yx/FW1TQBYazpkfgYHHo96HBE7qv4V4KKHqHglZcSUxti/zd4bToxX1cFTz8dmbTlb8JA==
+"@web/dev-server-core@0.7.1", "@web/dev-server-core@^0.4.1", "@web/dev-server-core@^0.7.2":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@web/dev-server-core/-/dev-server-core-0.7.1.tgz#181eb3519a66f2bdc6c874b81532b6fe618c0b0c"
+  integrity sha512-alHd2j0f4e1ekqYDR8lWScrzR7D5gfsUZq3BP3De9bkFWM3AELINCmqqlVKmCtlkAdEc9VyQvNiEqrxraOdc2A==
   dependencies:
     "@types/koa" "^2.11.6"
     "@types/ws" "^7.4.0"
@@ -3624,14 +3600,6 @@
     nanocolors "^0.2.1"
     open "^8.0.2"
     portfinder "^1.0.32"
-
-"@web/parse5-utils@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@web/parse5-utils/-/parse5-utils-1.3.1.tgz#6727be4d7875a9ecb96a5b3003bd271da763f8b4"
-  integrity sha512-haCgDchZrAOB9EhBJ5XqiIjBMsS/exsM5Ru7sCSyNkXVEJWskyyKuKMFk66BonnIGMPpDtqDrTUfYEis5Zi3XA==
-  dependencies:
-    "@types/parse5" "^6.0.1"
-    parse5 "^6.0.1"
 
 "@web/parse5-utils@^2.1.0":
   version "2.1.0"


### PR DESCRIPTION
Solves: 
- Tests freeze when an assertion fails

The problem was introduced with the update of the `@web/dev-server-core` package (dependency of `@web/test-runner`).
Specifically, the [faulty change](https://github.com/modernweb-dev/web/commit/feb0c72815bd9f803ef61eab0819c9b6fd4f05d8#diff-f245ba1e1d0627b81dcc9602856b458d1b36f15d8121126f1cfce7f2c96e991f) is the use of `structuredClone`. 
The `stable` function is called before reporting the test suite result which contains a reference to the element on which the assertion failed (in our case, the web component, which cannot be cloned).

TODO: Open an issue in https://github.com/modernweb-dev/web