### PR TITLE
style: fix mini-button mixin

### DIFF
--- a/src/elements/core/styles/mixins/buttons.scss
+++ b/src/elements/core/styles/mixins/buttons.scss
@@ -99,6 +99,8 @@
 // Default state for icon-button in form-field
 @mixin icon-button-base($host-selector, $button-selector, $icon-selector) {
   #{$host-selector} {
+    --sbb-button-display: flex;
+
     display: inline-block;
     -webkit-tap-highlight-color: transparent;
     height: fit-content;

--- a/src/elements/datepicker/datepicker-toggle/datepicker-toggle.scss
+++ b/src/elements/datepicker/datepicker-toggle/datepicker-toggle.scss
@@ -11,8 +11,6 @@
 }
 
 sbb-popover-trigger {
-  --sbb-button-display: flex;
-
   color: var(--sbb-datepicker-control-color);
 
   // Enables taking full height in order to shift the calendar position to the border bottom of the form field.


### PR DESCRIPTION
The two datepicker buttons are not displayed correctly in the disabled and focused state in both Firefox and Safari; perhaps this was not detected before due to browsers being removed from Chromatic.
A similar fix was made to the popover-trigger and is also available in the new autocomplete-grid.

![image](https://github.com/sbb-design-systems/lyne-components/assets/101575400/c0c394d7-e4f4-44b6-9dae-16df0fb49919)
![image](https://github.com/sbb-design-systems/lyne-components/assets/101575400/3149caf0-98d8-4305-9eb7-6e3b57073452)