### PR TITLE
refactor(sbb-notification): add CSS property to define icon size

### DIFF
--- a/src/elements/notification/notification.scss
+++ b/src/elements/notification/notification.scss
@@ -197,6 +197,7 @@ $open-anim-height-to: calc(
   color: var(--sbb-notification-icon-color);
   margin-block-start: var(--sbb-notification-icon-margin-block-start);
 
+  // This is an undocumented feature for sbb.ch, to have the ability to hide the icon.
   --sbb-icon-svg-width: var(--sbb-notification-icon-size);
 }
 

--- a/src/elements/notification/notification.scss
+++ b/src/elements/notification/notification.scss
@@ -196,6 +196,7 @@ $open-anim-height-to: calc(
 .sbb-notification__icon {
   color: var(--sbb-notification-icon-color);
   margin-block-start: var(--sbb-notification-icon-margin-block-start);
+  visibility: var(--sbb-notification-icon-visibility);
 }
 
 .sbb-notification__title {

--- a/src/elements/notification/notification.scss
+++ b/src/elements/notification/notification.scss
@@ -196,7 +196,8 @@ $open-anim-height-to: calc(
 .sbb-notification__icon {
   color: var(--sbb-notification-icon-color);
   margin-block-start: var(--sbb-notification-icon-margin-block-start);
-  visibility: var(--sbb-notification-icon-visibility);
+
+  --sbb-icon-svg-width: var(--sbb-notification-icon-size);
 }
 
 .sbb-notification__title {


### PR DESCRIPTION
This PR addresses a specific requirement from sbb.ch. However, we do not want to generally provide this as a feature, so we do not provide documentation for this.
The property is named `--sbb-notification-icon-size` and can be set to `0` to hide the icon.