### PR TITLE
refactor: replace isolated `SbbSlotStateController` usage with decorator

### DIFF
--- a/src/elements/button/common/button-common.ts
+++ b/src/elements/button/common/button-common.ts
@@ -3,8 +3,7 @@ import { property } from 'lit/decorators.js';
 import { html } from 'lit/static-html.js';
 
 import type { SbbActionBaseElement } from '../../core/base-elements.js';
-import { SbbSlotStateController } from '../../core/controllers.js';
-import { hostAttributes } from '../../core/decorators.js';
+import { hostAttributes, slotState } from '../../core/decorators.js';
 import type {
   AbstractConstructor,
   SbbDisabledMixinType,
@@ -33,17 +32,13 @@ export const SbbButtonCommonElementMixin = <T extends AbstractConstructor<SbbAct
   @hostAttributes({
     'data-sbb-button': '',
   })
+  @slotState()
   abstract class SbbButtonCommonElementClass
     extends SbbNegativeMixin(SbbIconNameMixin(superClass))
     implements Partial<SbbButtonCommonElementMixinType>
   {
     /** Size variant, either l or m. */
     @property({ reflect: true }) public size?: SbbButtonSize = 'l';
-
-    protected constructor(...args: any[]) {
-      super(args);
-      new SbbSlotStateController(this);
-    }
 
     protected override renderTemplate(): TemplateResult {
       return html`

--- a/src/elements/button/mini-button/mini-button.ts
+++ b/src/elements/button/mini-button/mini-button.ts
@@ -2,7 +2,7 @@ import type { CSSResultGroup, TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 import { SbbButtonBaseElement } from '../../core/base-elements.js';
-import { SbbSlotStateController } from '../../core/controllers.js';
+import { slotState } from '../../core/decorators.js';
 import { SbbDisabledTabIndexActionMixin, SbbNegativeMixin } from '../../core/mixins.js';
 import { SbbIconNameMixin } from '../../icon.js';
 
@@ -15,15 +15,11 @@ import style from './mini-button.scss?lit&inline';
  * @slot icon - Slot used to display the icon, if one is set
  */
 @customElement('sbb-mini-button')
+@slotState()
 export class SbbMiniButtonElement extends SbbNegativeMixin(
   SbbIconNameMixin(SbbDisabledTabIndexActionMixin(SbbButtonBaseElement)),
 ) {
   public static override styles: CSSResultGroup = style;
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   protected override renderTemplate(): TemplateResult {
     return super.renderIconSlot();

--- a/src/elements/checkbox/checkbox-group/checkbox-group.ts
+++ b/src/elements/checkbox/checkbox-group/checkbox-group.ts
@@ -3,7 +3,8 @@ import { LitElement, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { getNextElementIndex, interactivityChecker, isArrowKeyPressed } from '../../core/a11y.js';
-import { SbbConnectedAbortController, SbbSlotStateController } from '../../core/controllers.js';
+import { SbbConnectedAbortController } from '../../core/controllers.js';
+import { slotState } from '../../core/decorators.js';
 import type { SbbHorizontalFrom, SbbOrientation } from '../../core/interfaces.js';
 import { SbbDisabledMixin } from '../../core/mixins.js';
 import type { SbbCheckboxPanelElement } from '../checkbox-panel.js';
@@ -19,6 +20,7 @@ import style from './checkbox-group.scss?lit&inline';
  * @slot error - Slot used to render a `sbb-form-error` inside the `sbb-checkbox-group`.
  */
 @customElement('sbb-checkbox-group')
+@slotState()
 export class SbbCheckboxGroupElement extends SbbDisabledMixin(LitElement) {
   public static override styles: CSSResultGroup = style;
 
@@ -46,11 +48,6 @@ export class SbbCheckboxGroupElement extends SbbDisabledMixin(LitElement) {
   }
 
   private _abort: SbbConnectedAbortController = new SbbConnectedAbortController(this);
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   public override connectedCallback(): void {
     super.connectedCallback();

--- a/src/elements/checkbox/checkbox-panel/checkbox-panel.ts
+++ b/src/elements/checkbox/checkbox-panel/checkbox-panel.ts
@@ -8,7 +8,7 @@ import {
 } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-import { SbbSlotStateController } from '../../core/controllers.js';
+import { slotState } from '../../core/decorators.js';
 import { EventEmitter } from '../../core/eventing.js';
 import type {
   SbbCheckedStateChange,
@@ -38,6 +38,7 @@ export type SbbCheckboxPanelStateChange = Extract<
  * @event {InputEvent} input - Event fired on input.
  */
 @customElement('sbb-checkbox-panel')
+@slotState()
 export class SbbCheckboxPanelElement extends SbbPanelMixin(
   SbbCheckboxCommonElementMixin(SbbUpdateSchedulerMixin(LitElement)),
 ) {
@@ -60,11 +61,6 @@ export class SbbCheckboxPanelElement extends SbbPanelMixin(
     SbbCheckboxPanelElement.events.stateChange,
     { bubbles: true },
   );
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   protected override async willUpdate(changedProperties: PropertyValues<this>): Promise<void> {
     super.willUpdate(changedProperties);

--- a/src/elements/checkbox/checkbox/checkbox.ts
+++ b/src/elements/checkbox/checkbox/checkbox.ts
@@ -1,14 +1,14 @@
 import { LitElement, html, type CSSResultGroup, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { SbbSlotStateController } from '../../core/controllers.js';
+import { slotState } from '../../core/decorators.js';
 import type { SbbIconPlacement } from '../../core/interfaces.js';
 import { SbbIconNameMixin } from '../../icon.js';
 import { SbbCheckboxCommonElementMixin, checkboxCommonStyle } from '../common.js';
 
-import '../../visual-checkbox.js';
-
 import checkboxStyle from './checkbox.scss?lit&inline';
+
+import '../../visual-checkbox.js';
 
 /**
  * It displays a checkbox enhanced with the SBB Design.
@@ -20,6 +20,7 @@ import checkboxStyle from './checkbox.scss?lit&inline';
  * @event {InputEvent} input - Event fired on input.
  */
 @customElement('sbb-checkbox')
+@slotState()
 export class SbbCheckboxElement extends SbbCheckboxCommonElementMixin(
   SbbIconNameMixin(LitElement),
 ) {
@@ -32,11 +33,6 @@ export class SbbCheckboxElement extends SbbCheckboxCommonElementMixin(
   /** The label position relative to the labelIcon. Defaults to end */
   @property({ attribute: 'icon-placement', reflect: true })
   public iconPlacement: SbbIconPlacement = 'end';
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   protected override render(): TemplateResult {
     return html`

--- a/src/elements/core/decorators.ts
+++ b/src/elements/core/decorators.ts
@@ -1,1 +1,2 @@
 export * from './decorators/host-attributes.js';
+export * from './decorators/slot-state.js';

--- a/src/elements/core/decorators/host-attributes.ts
+++ b/src/elements/core/decorators/host-attributes.ts
@@ -22,10 +22,10 @@ function applyAttributes(
  *
  * @example
  *
+ * @customElement('my-element)
  * @hostAttributes({
  *   role: 'region'
  * })
- * @customElement('my-element)
  * export class MyElement extends LitElement {
  *   ...
  * }

--- a/src/elements/core/decorators/slot-state.ts
+++ b/src/elements/core/decorators/slot-state.ts
@@ -1,0 +1,25 @@
+import { isServer, type ReactiveElement } from 'lit';
+
+import { SbbSlotStateController } from '../controllers.js';
+import type { AbstractConstructor } from '../mixins.js';
+
+/**
+ * Adds the {@link SbbSlotStateController} to the related element.
+ *
+ * @example
+ *
+ * @customElement('my-element)
+ * @slotState()
+ * export class MyElement extends LitElement {
+ *   ...
+ * }
+ *
+ * @param attributes A record of attributes to apply to the element.
+ */
+export const slotState = () => (target: AbstractConstructor<ReactiveElement>) => {
+  if (!isServer) {
+    (target as typeof ReactiveElement).addInitializer(
+      (instance: ReactiveElement) => new SbbSlotStateController(instance),
+    );
+  }
+};

--- a/src/elements/file-selector/file-selector.ts
+++ b/src/elements/file-selector/file-selector.ts
@@ -6,7 +6,8 @@ import { html, unsafeStatic } from 'lit/static-html.js';
 
 import type { SbbSecondaryButtonStaticElement } from '../button.js';
 import { sbbInputModalityDetector } from '../core/a11y.js';
-import { SbbLanguageController, SbbSlotStateController } from '../core/controllers.js';
+import { SbbLanguageController } from '../core/controllers.js';
+import { slotState } from '../core/decorators.js';
 import { EventEmitter } from '../core/eventing.js';
 import {
   i18nFileSelectorButtonLabel,
@@ -31,6 +32,7 @@ export type DOMEvent = globalThis.Event;
  * @event {CustomEvent<File[]>} fileChanged - An event which is emitted each time the file list changes.
  */
 @customElement('sbb-file-selector')
+@slotState()
 export class SbbFileSelectorElement extends SbbDisabledMixin(LitElement) {
   public static override styles: CSSResultGroup = style;
   public static readonly events = {
@@ -93,11 +95,6 @@ export class SbbFileSelectorElement extends SbbDisabledMixin(LitElement) {
   private _liveRegion!: HTMLParagraphElement;
 
   private _language = new SbbLanguageController(this);
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   private _blockEvent(event: DragEvent): void {
     event.stopPropagation();

--- a/src/elements/form-field/form-field/form-field.ts
+++ b/src/elements/form-field/form-field/form-field.ts
@@ -4,19 +4,17 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 import type { SbbInputModality } from '../../core/a11y.js';
 import { sbbInputModalityDetector } from '../../core/a11y.js';
-import {
-  SbbConnectedAbortController,
-  SbbLanguageController,
-  SbbSlotStateController,
-} from '../../core/controllers.js';
+import { SbbConnectedAbortController, SbbLanguageController } from '../../core/controllers.js';
+import { slotState } from '../../core/decorators.js';
 import { isFirefox, setOrRemoveAttribute } from '../../core/dom.js';
 import { i18nOptional } from '../../core/i18n.js';
 import { SbbNegativeMixin } from '../../core/mixins.js';
 import { AgnosticMutationObserver } from '../../core/observers.js';
 import type { SbbSelectElement } from '../../select.js';
-import '../../icon.js';
 
 import style from './form-field.scss?lit&inline';
+
+import '../../icon.js';
 
 let nextId = 0;
 let nextFormFieldErrorId = 0;
@@ -33,6 +31,7 @@ const supportedPopupTagNames = ['sbb-autocomplete', 'sbb-select'];
  * @slot error - Use this slot to render an error.
  */
 @customElement('sbb-form-field')
+@slotState()
 export class SbbFormFieldElement extends SbbNegativeMixin(LitElement) {
   public static override styles: CSSResultGroup = style;
 
@@ -124,11 +123,6 @@ export class SbbFormFieldElement extends SbbNegativeMixin(LitElement) {
   );
 
   private _inputAbortController = new AbortController();
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   public override connectedCallback(): void {
     super.connectedCallback();

--- a/src/elements/link-list/link-list.ts
+++ b/src/elements/link-list/link-list.ts
@@ -2,7 +2,7 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { SbbSlotStateController } from '../core/controllers.js';
+import { slotState } from '../core/decorators.js';
 import type { SbbHorizontalFrom, SbbOrientation } from '../core/interfaces.js';
 import { SbbNamedSlotListMixin, SbbNegativeMixin, type WithListChildren } from '../core/mixins.js';
 import type {
@@ -24,6 +24,7 @@ import '../title.js';
  * @slot title - Use this slot to provide a title.
  */
 @customElement('sbb-link-list')
+@slotState()
 export class SbbLinkListElement extends SbbNegativeMixin(
   SbbNamedSlotListMixin<
     SbbBlockLinkElement | SbbBlockLinkButtonElement | SbbBlockLinkStaticElement,
@@ -55,11 +56,6 @@ export class SbbLinkListElement extends SbbNegativeMixin(
 
   /** The orientation in which the list will be shown vertical or horizontal. */
   @property({ reflect: true }) public orientation: SbbOrientation = 'vertical';
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   protected override willUpdate(changedProperties: PropertyValues<WithListChildren<this>>): void {
     super.willUpdate(changedProperties);

--- a/src/elements/link/common/link-common.ts
+++ b/src/elements/link/common/link-common.ts
@@ -3,8 +3,7 @@ import { property } from 'lit/decorators.js';
 import { html } from 'lit/static-html.js';
 
 import type { SbbActionBaseElement } from '../../core/base-elements.js';
-import { SbbSlotStateController } from '../../core/controllers.js';
-import { hostAttributes } from '../../core/decorators.js';
+import { hostAttributes, slotState } from '../../core/decorators.js';
 import {
   SbbNegativeMixin,
   type SbbNegativeMixinType,
@@ -24,6 +23,7 @@ export const SbbLinkCommonElementMixin = <T extends AbstractConstructor<SbbActio
   superClass: T,
 ): AbstractConstructor<SbbLinkCommonElementMixinType> & T => {
   @hostAttributes({ 'data-sbb-link': '' })
+  @slotState()
   abstract class SbbLinkCommonElement
     extends SbbNegativeMixin(superClass)
     implements Partial<SbbLinkCommonElementMixinType>
@@ -35,11 +35,6 @@ export const SbbLinkCommonElementMixin = <T extends AbstractConstructor<SbbActio
      * With inline variant, the text size adapts to where it is used.
      */
     @property({ reflect: true }) public size: SbbLinkSize = 's';
-
-    public constructor(...args: any[]) {
-      super(args);
-      new SbbSlotStateController(this);
-    }
 
     protected override renderTemplate(): TemplateResult {
       return html`<slot></slot>`;

--- a/src/elements/navigation/navigation-list/navigation-list.ts
+++ b/src/elements/navigation/navigation-list/navigation-list.ts
@@ -7,7 +7,7 @@ import {
 } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { SbbSlotStateController } from '../../core/controllers.js';
+import { slotState } from '../../core/decorators.js';
 import { SbbNamedSlotListMixin, type WithListChildren } from '../../core/mixins.js';
 import type { SbbNavigationButtonElement } from '../navigation-button.js';
 import type { SbbNavigationLinkElement } from '../navigation-link.js';
@@ -21,6 +21,7 @@ import style from './navigation-list.scss?lit&inline';
  * @slot label - Use this to provide a label element.
  */
 @customElement('sbb-navigation-list')
+@slotState()
 export class SbbNavigationListElement extends SbbNamedSlotListMixin<
   SbbNavigationButtonElement | SbbNavigationLinkElement,
   typeof LitElement
@@ -35,11 +36,6 @@ export class SbbNavigationListElement extends SbbNamedSlotListMixin<
    * The label to be shown before the action list.
    */
   @property({ reflect: true }) public label?: string;
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   protected override willUpdate(changedProperties: PropertyValues<WithListChildren<this>>): void {
     super.willUpdate(changedProperties);

--- a/src/elements/navigation/navigation-section/navigation-section.ts
+++ b/src/elements/navigation/navigation-section/navigation-section.ts
@@ -7,8 +7,8 @@ import {
   getFocusableElements,
   setModalityOnNextFocus,
 } from '../../core/a11y.js';
-import { SbbLanguageController, SbbSlotStateController } from '../../core/controllers.js';
-import { hostAttributes } from '../../core/decorators.js';
+import { SbbLanguageController } from '../../core/controllers.js';
+import { hostAttributes, slotState } from '../../core/decorators.js';
 import { findReferencedElement, isBreakpoint, setOrRemoveAttribute } from '../../core/dom.js';
 import { i18nGoBack } from '../../core/i18n.js';
 import type { SbbOpenedClosedState } from '../../core/interfaces.js';
@@ -37,6 +37,7 @@ let nextId = 0;
 @hostAttributes({
   slot: 'navigation-section',
 })
+@slotState()
 export class SbbNavigationSectionElement extends SbbUpdateSchedulerMixin(LitElement) {
   public static override styles: CSSResultGroup = style;
 
@@ -90,11 +91,6 @@ export class SbbNavigationSectionElement extends SbbUpdateSchedulerMixin(LitElem
   private _navigationSectionController!: AbortController;
   private _windowEventsController!: AbortController;
   private _language = new SbbLanguageController(this);
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   /**
    * Opens the navigation section on trigger click.

--- a/src/elements/notification/notification.ts
+++ b/src/elements/notification/notification.ts
@@ -2,18 +2,20 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { SbbLanguageController, SbbSlotStateController } from '../core/controllers.js';
+import { SbbLanguageController } from '../core/controllers.js';
+import { slotState } from '../core/decorators.js';
 import { EventEmitter } from '../core/eventing.js';
 import { i18nCloseNotification } from '../core/i18n.js';
 import type { SbbOpenedClosedState } from '../core/interfaces.js';
 import { AgnosticResizeObserver } from '../core/observers.js';
 import type { SbbTitleLevel } from '../title.js';
+
+import style from './notification.scss?lit&inline';
+
 import '../button/secondary-button.js';
 import '../divider.js';
 import '../icon.js';
 import '../title.js';
-
-import style from './notification.scss?lit&inline';
 
 const notificationTypes = new Map([
   ['info', 'circle-information-small'],
@@ -37,6 +39,7 @@ const DEBOUNCE_TIME = 150;
  * See style section for more information.
  */
 @customElement('sbb-notification')
+@slotState()
 export class SbbNotificationElement extends LitElement {
   // FIXME inheriting from SbbOpenCloseBaseElement requires: https://github.com/open-wc/custom-elements-manifest/issues/253
   public static override styles: CSSResultGroup = style;
@@ -116,11 +119,6 @@ export class SbbNotificationElement extends LitElement {
     this,
     SbbNotificationElement.events.didClose,
   );
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   private _open(): void {
     if (this._state === 'closed') {

--- a/src/elements/option/option/option.ts
+++ b/src/elements/option/option/option.ts
@@ -8,8 +8,8 @@ import {
 } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
-import { SbbConnectedAbortController, SbbSlotStateController } from '../../core/controllers.js';
-import { hostAttributes } from '../../core/decorators.js';
+import { SbbConnectedAbortController } from '../../core/controllers.js';
+import { hostAttributes, slotState } from '../../core/decorators.js';
 import { isAndroid, isSafari, setOrRemoveAttribute } from '../../core/dom.js';
 import { EventEmitter } from '../../core/eventing.js';
 import { SbbDisabledMixin, SbbHydrationMixin } from '../../core/mixins.js';
@@ -51,6 +51,7 @@ export type SbbOptionVariant = 'autocomplete' | 'select' | null;
 @hostAttributes({
   role: 'option',
 })
+@slotState()
 export class SbbOptionElement extends SbbDisabledMixin(
   SbbIconNameMixin(SbbHydrationMixin(LitElement)),
 ) {
@@ -140,7 +141,6 @@ export class SbbOptionElement extends SbbDisabledMixin(
 
   public constructor() {
     super();
-    new SbbSlotStateController(this);
 
     if (inertAriaGroups) {
       if (this.hydrationRequired) {

--- a/src/elements/radio-button/radio-button-group/radio-button-group.ts
+++ b/src/elements/radio-button/radio-button-group/radio-button-group.ts
@@ -3,8 +3,8 @@ import { LitElement, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { getNextElementIndex, isArrowKeyPressed } from '../../core/a11y.js';
-import { SbbConnectedAbortController, SbbSlotStateController } from '../../core/controllers.js';
-import { hostAttributes } from '../../core/decorators.js';
+import { SbbConnectedAbortController } from '../../core/controllers.js';
+import { hostAttributes, slotState } from '../../core/decorators.js';
 import { EventEmitter } from '../../core/eventing.js';
 import type { SbbHorizontalFrom, SbbOrientation, SbbStateChange } from '../../core/interfaces.js';
 import { SbbDisabledMixin } from '../../core/mixins.js';
@@ -32,6 +32,7 @@ export type SbbRadioButtonGroupEventDetail = {
 @hostAttributes({
   role: 'radiogroup',
 })
+@slotState()
 export class SbbRadioButtonGroupElement extends SbbDisabledMixin(LitElement) {
   public static override styles: CSSResultGroup = style;
   public static readonly events = {
@@ -127,11 +128,6 @@ export class SbbRadioButtonGroupElement extends SbbDisabledMixin(LitElement) {
     this,
     SbbRadioButtonGroupElement.events.input,
   );
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   public override connectedCallback(): void {
     super.connectedCallback();

--- a/src/elements/radio-button/radio-button-panel/radio-button-panel.ts
+++ b/src/elements/radio-button/radio-button-panel/radio-button-panel.ts
@@ -8,7 +8,7 @@ import {
 } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-import { SbbSlotStateController } from '../../core/controllers.js';
+import { slotState } from '../../core/decorators.js';
 import { panelCommonStyle, SbbPanelMixin, SbbUpdateSchedulerMixin } from '../../core/mixins.js';
 import { radioButtonCommonStyle, SbbRadioButtonCommonElementMixin } from '../common.js';
 
@@ -24,6 +24,7 @@ import '../../screen-reader-only.js';
  * @slot badge - Use this slot to provide a `sbb-card-badge` (optional).
  */
 @customElement('sbb-radio-button-panel')
+@slotState()
 export class SbbRadioButtonPanelElement extends SbbPanelMixin(
   SbbRadioButtonCommonElementMixin(SbbUpdateSchedulerMixin(LitElement)),
 ) {
@@ -34,11 +35,6 @@ export class SbbRadioButtonPanelElement extends SbbPanelMixin(
     stateChange: 'stateChange',
     panelConnected: 'panelConnected',
   } as const;
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   protected override async willUpdate(changedProperties: PropertyValues<this>): Promise<void> {
     super.willUpdate(changedProperties);

--- a/src/elements/radio-button/radio-button/radio-button.ts
+++ b/src/elements/radio-button/radio-button/radio-button.ts
@@ -2,7 +2,7 @@ import type { CSSResultGroup, TemplateResult } from 'lit';
 import { LitElement, html, nothing } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-import { SbbSlotStateController } from '../../core/controllers.js';
+import { slotState } from '../../core/decorators.js';
 import { SbbRadioButtonCommonElementMixin, radioButtonCommonStyle } from '../common.js';
 
 import radioButtonStyle from './radio-button.scss?lit&inline';
@@ -13,16 +13,12 @@ import radioButtonStyle from './radio-button.scss?lit&inline';
  * @slot - Use the unnamed slot to add content to the radio label.
  */
 @customElement('sbb-radio-button')
+@slotState()
 export class SbbRadioButtonElement extends SbbRadioButtonCommonElementMixin(LitElement) {
   public static override styles: CSSResultGroup = [radioButtonCommonStyle, radioButtonStyle];
   public static readonly events = {
     stateChange: 'stateChange',
   } as const;
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   protected override render(): TemplateResult {
     return html`

--- a/src/elements/selection-expansion-panel/selection-expansion-panel.ts
+++ b/src/elements/selection-expansion-panel/selection-expansion-panel.ts
@@ -3,11 +3,8 @@ import { html, LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 import type { SbbCheckboxPanelElement } from '../checkbox.js';
-import {
-  SbbConnectedAbortController,
-  SbbLanguageController,
-  SbbSlotStateController,
-} from '../core/controllers.js';
+import { SbbConnectedAbortController, SbbLanguageController } from '../core/controllers.js';
+import { slotState } from '../core/decorators.js';
 import { EventEmitter } from '../core/eventing.js';
 import { i18nCollapsed, i18nExpanded } from '../core/i18n.js';
 import type { SbbOpenedClosedState, SbbStateChange } from '../core/interfaces.js';
@@ -29,6 +26,7 @@ import '../divider.js';
  * @event {CustomEvent<void>} didClose - Emits whenever the content section is closed.
  */
 @customElement('sbb-selection-expansion-panel')
+@slotState()
 export class SbbSelectionExpansionPanelElement extends SbbHydrationMixin(LitElement) {
   // FIXME inheriting from SbbOpenCloseBaseElement requires: https://github.com/open-wc/custom-elements-manifest/issues/253
   public static override styles: CSSResultGroup = style;
@@ -104,11 +102,6 @@ export class SbbSelectionExpansionPanelElement extends SbbHydrationMixin(LitElem
   private get _hasContent(): boolean {
     // We cannot use the NamedSlots because it's too slow to initialize
     return this.querySelectorAll?.('[slot="content"]').length > 0;
-  }
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
   }
 
   public override connectedCallback(): void {

--- a/src/elements/skiplink-list/skiplink-list.ts
+++ b/src/elements/skiplink-list/skiplink-list.ts
@@ -8,7 +8,7 @@ import {
 } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { SbbSlotStateController } from '../core/controllers.js';
+import { slotState } from '../core/decorators.js';
 import { SbbNamedSlotListMixin, type WithListChildren } from '../core/mixins.js';
 import type { SbbBlockLinkButtonElement, SbbBlockLinkElement } from '../link.js';
 import type { SbbTitleLevel } from '../title.js';
@@ -26,6 +26,7 @@ import '../title.js';
  * component is set to `var(--sbb-overlay-default-z-index)` with a value of `1000`.
  */
 @customElement('sbb-skiplink-list')
+@slotState()
 export class SbbSkiplinkListElement extends SbbNamedSlotListMixin<
   SbbBlockLinkElement | SbbBlockLinkButtonElement,
   typeof LitElement
@@ -38,11 +39,6 @@ export class SbbSkiplinkListElement extends SbbNamedSlotListMixin<
 
   /** The semantic level of the title, e.g. 2 = h2. */
   @property({ attribute: 'title-level' }) public titleLevel: SbbTitleLevel = '2';
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   protected override willUpdate(changedProperties: PropertyValues<WithListChildren<this>>): void {
     super.willUpdate(changedProperties);

--- a/src/elements/status/status.ts
+++ b/src/elements/status/status.ts
@@ -2,12 +2,13 @@ import type { CSSResultGroup, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { SbbSlotStateController } from '../core/controllers.js';
+import { slotState } from '../core/decorators.js';
 import { SbbIconNameMixin } from '../icon.js';
 import type { SbbTitleLevel } from '../title.js';
 
-import '../title.js';
 import style from './status.scss?lit&inline';
+
+import '../title.js';
 
 export type SbbStatusType = 'info' | 'success' | 'warning' | 'error';
 
@@ -19,6 +20,7 @@ export type SbbStatusType = 'info' | 'success' | 'warning' | 'error';
  * @slot icon - Use this slot to override the default status icon.
  */
 @customElement('sbb-status')
+@slotState()
 export class SbbStatusElement extends SbbIconNameMixin(LitElement) {
   public static override styles: CSSResultGroup = style;
 
@@ -37,11 +39,6 @@ export class SbbStatusElement extends SbbIconNameMixin(LitElement) {
 
   /** Level of title, it will be rendered as heading tag (e.g. h3). Defaults to level 3. */
   @property({ attribute: 'title-level' }) public titleLevel: SbbTitleLevel = '3';
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   protected override renderIconSlot(): TemplateResult {
     return html`

--- a/src/elements/tabs/tab-label/tab-label.ts
+++ b/src/elements/tabs/tab-label/tab-label.ts
@@ -3,7 +3,7 @@ import { LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { html, unsafeStatic } from 'lit/static-html.js';
 
-import { SbbSlotStateController } from '../../core/controllers.js';
+import { slotState } from '../../core/decorators.js';
 import { SbbDisabledMixin } from '../../core/mixins.js';
 import { SbbIconNameMixin } from '../../icon.js';
 import type { SbbTitleLevel } from '../../title.js';
@@ -18,6 +18,7 @@ import style from './tab-label.scss?lit&inline';
  * @slot amount - Provide a number to show an amount to the right of the title.
  */
 @customElement('sbb-tab-label')
+@slotState()
 export class SbbTabLabelElement extends SbbDisabledMixin(SbbIconNameMixin(LitElement)) {
   public static override styles: CSSResultGroup = style;
 
@@ -32,11 +33,6 @@ export class SbbTabLabelElement extends SbbDisabledMixin(SbbIconNameMixin(LitEle
 
   /** Amount displayed inside the tab. */
   @property({ reflect: true }) public amount?: string;
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   protected override render(): TemplateResult {
     const TAGNAME = `h${Number(this.level) < 7 ? this.level : '1'}`;

--- a/src/elements/tag/tag/tag.ts
+++ b/src/elements/tag/tag/tag.ts
@@ -3,7 +3,8 @@ import { html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { SbbButtonBaseElement } from '../../core/base-elements.js';
-import { SbbConnectedAbortController, SbbSlotStateController } from '../../core/controllers.js';
+import { SbbConnectedAbortController } from '../../core/controllers.js';
+import { slotState } from '../../core/decorators.js';
 import { EventEmitter } from '../../core/eventing.js';
 import { SbbDisabledTabIndexActionMixin } from '../../core/mixins.js';
 import { SbbIconNameMixin } from '../../icon.js';
@@ -24,6 +25,7 @@ export type SbbTagSize = 's' | 'm';
  * @event {CustomEvent<void>} change - Change event emitter
  */
 @customElement('sbb-tag')
+@slotState()
 export class SbbTagElement extends SbbIconNameMixin(
   SbbDisabledTabIndexActionMixin(SbbButtonBaseElement),
 ) {
@@ -70,11 +72,6 @@ export class SbbTagElement extends SbbIconNameMixin(
   });
 
   private _abort = new SbbConnectedAbortController(this);
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   public override connectedCallback(): void {
     super.connectedCallback();

--- a/src/elements/teaser/teaser.ts
+++ b/src/elements/teaser/teaser.ts
@@ -3,7 +3,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { html } from 'lit/static-html.js';
 
 import { SbbLinkBaseElement } from '../core/base-elements.js';
-import { SbbSlotStateController } from '../core/controllers.js';
+import { slotState } from '../core/decorators.js';
 import type { SbbTitleLevel } from '../title.js';
 
 import style from './teaser.scss?lit&inline';
@@ -20,6 +20,7 @@ import '../title.js';
  * @slot - Use the unnamed slot to render the description.
  */
 @customElement('sbb-teaser')
+@slotState()
 export class SbbTeaserElement extends SbbLinkBaseElement {
   public static override styles: CSSResultGroup = style;
 
@@ -35,11 +36,6 @@ export class SbbTeaserElement extends SbbLinkBaseElement {
 
   /** Content of chip. */
   @property({ attribute: 'chip-content', reflect: true }) public chipContent?: string;
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   protected override renderTemplate(): TemplateResult {
     return html`

--- a/src/elements/toast/toast.ts
+++ b/src/elements/toast/toast.ts
@@ -4,19 +4,17 @@ import { customElement, property } from 'lit/decorators.js';
 
 import type { SbbTransparentButtonElement, SbbTransparentButtonLinkElement } from '../button.js';
 import { SbbOpenCloseBaseElement } from '../core/base-elements.js';
-import {
-  SbbConnectedAbortController,
-  SbbLanguageController,
-  SbbSlotStateController,
-} from '../core/controllers.js';
+import { SbbConnectedAbortController, SbbLanguageController } from '../core/controllers.js';
+import { slotState } from '../core/decorators.js';
 import { isFirefox } from '../core/dom.js';
 import { composedPathHasAttribute } from '../core/eventing.js';
 import { i18nCloseAlert } from '../core/i18n.js';
 import { SbbIconNameMixin } from '../icon.js';
 import type { SbbLinkButtonElement, SbbLinkElement, SbbLinkStaticElement } from '../link.js';
-import '../button/transparent-button.js';
 
 import style from './toast.scss?lit&inline';
+
+import '../button/transparent-button.js';
 
 type SbbToastPositionVertical = 'top' | 'bottom';
 type SbbToastPositionHorizontal = 'left' | 'start' | 'center' | 'right' | 'end';
@@ -40,6 +38,7 @@ const toastRefs = new Set<SbbToastElement>();
  * component is set to `var(--sbb-overlay-default-z-index)` with a value of `1000`.
  */
 @customElement('sbb-toast')
+@slotState()
 export class SbbToastElement extends SbbIconNameMixin(SbbOpenCloseBaseElement) {
   public static override styles: CSSResultGroup = style;
 
@@ -119,11 +118,6 @@ export class SbbToastElement extends SbbIconNameMixin(SbbOpenCloseBaseElement) {
     if (closeElement && !closeElement.hasAttribute('disabled')) {
       this.close();
     }
-  }
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
   }
 
   public override connectedCallback(): void {
@@ -217,9 +211,9 @@ export class SbbToastElement extends SbbIconNameMixin(SbbOpenCloseBaseElement) {
   protected override render(): TemplateResult {
     return html`
       <div class="sbb-toast__overlay-container">
+        ${/* Firefox needs 'role' to enable screen readers */ ''}
         <div
           class="sbb-toast"
-          ${/* Firefox needs 'role' to enable screen readers */ ''}
           role=${this._role ?? nothing}
           @animationend=${this._onToastAnimationEnd}
         >

--- a/src/elements/toggle-check/toggle-check.ts
+++ b/src/elements/toggle-check/toggle-check.ts
@@ -2,7 +2,7 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { SbbSlotStateController } from '../core/controllers.js';
+import { slotState } from '../core/decorators.js';
 import { SbbFormAssociatedCheckboxMixin } from '../core/mixins.js';
 import { SbbIconNameMixin } from '../icon.js';
 
@@ -18,6 +18,7 @@ import style from './toggle-check.scss?lit&inline';
  * @event {InputEvent} input - Event fired on input.
  */
 @customElement('sbb-toggle-check')
+@slotState()
 export class SbbToggleCheckElement extends SbbFormAssociatedCheckboxMixin(
   SbbIconNameMixin(LitElement),
 ) {
@@ -35,11 +36,6 @@ export class SbbToggleCheckElement extends SbbFormAssociatedCheckboxMixin(
   /** The label position relative to the toggle. Defaults to 'after' */
   @property({ attribute: 'label-position', reflect: true })
   public labelPosition?: 'before' | 'after' = 'after';
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   protected override async willUpdate(changedProperties: PropertyValues<this>): Promise<void> {
     super.willUpdate(changedProperties);

--- a/src/elements/toggle/toggle-option/toggle-option.ts
+++ b/src/elements/toggle/toggle-option/toggle-option.ts
@@ -2,8 +2,8 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { SbbConnectedAbortController, SbbSlotStateController } from '../../core/controllers.js';
-import { hostAttributes } from '../../core/decorators.js';
+import { SbbConnectedAbortController } from '../../core/controllers.js';
+import { hostAttributes, slotState } from '../../core/decorators.js';
 import { setOrRemoveAttribute } from '../../core/dom.js';
 import { SbbIconNameMixin } from '../../icon.js';
 import type { SbbToggleElement } from '../toggle.js';
@@ -20,6 +20,7 @@ import style from './toggle-option.scss?lit&inline';
 @hostAttributes({
   role: 'radio',
 })
+@slotState()
 export class SbbToggleOptionElement extends SbbIconNameMixin(LitElement) {
   public static override styles: CSSResultGroup = style;
 
@@ -43,11 +44,6 @@ export class SbbToggleOptionElement extends SbbIconNameMixin(LitElement) {
 
   private _toggle?: SbbToggleElement;
   private _abort = new SbbConnectedAbortController(this);
-
-  public constructor() {
-    super();
-    new SbbSlotStateController(this);
-  }
 
   public override connectedCallback(): void {
     super.connectedCallback();


### PR DESCRIPTION
This PR replaces the constructor usage of `SbbSlotStateController` with the decorator `slotChange`, which applies the `SbbSlotStateController` internally.