### PR TITLE
feat(sbb-datepicker): add support for `DateAdapter`

### DIFF
--- a/src/elements/calendar/calendar.ts
+++ b/src/elements/calendar/calendar.ts
@@ -11,6 +11,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
 import { isArrowKeyOrPageKeysPressed, sbbInputModalityDetector } from '../core/a11y.js';
+import { readConfig } from '../core/config.js';
 import { SbbConnectedAbortController, SbbLanguageController } from '../core/controllers.js';
 import type { DateAdapter } from '../core/datetime.js';
 import {
@@ -152,7 +153,7 @@ export class SbbCalendarElement<T = Date> extends SbbHydrationMixin(LitElement) 
   /** A function used to filter out dates. */
   @property({ attribute: 'date-filter' }) public dateFilter?: (date: T | null) => boolean;
 
-  private _dateAdapter: DateAdapter<T> = defaultDateAdapter as unknown as DateAdapter<T>;
+  private _dateAdapter: DateAdapter<T> = readConfig().datetime?.dateAdapter ?? defaultDateAdapter;
 
   /** Event emitted on date selection. */
   private _dateSelected: EventEmitter<T> = new EventEmitter(

--- a/src/elements/core/datetime/native-date-adapter.ts
+++ b/src/elements/core/datetime/native-date-adapter.ts
@@ -164,7 +164,7 @@ export class NativeDateAdapter extends DateAdapter<Date> {
         // The `Date` constructor accepts formats other than ISO 8601, so we need to make sure the
         // string is the right format first.
       } else if (ISO_8601_REGEX.test(date)) {
-        return this.getValidDateOrNull(new Date(date));
+        return this.getValidDateOrNull(new Date(date.includes('T') ? date : date + 'T00:00:00'));
       }
     } else if (typeof date === 'number') {
       return this.getValidDateOrNull(new Date(date * 1000));
@@ -201,26 +201,6 @@ export class NativeDateAdapter extends DateAdapter<Date> {
     return new Date(year, +match[2] - 1, +match[1]);
   }
 
-  public format(value: Date | null | undefined): string {
-    if (!value) {
-      return '';
-    }
-    const locale = `${SbbLanguageController.current}-CH`;
-    const dateFormatter = new Intl.DateTimeFormat('de-CH', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-    });
-    const dayFormatter = new Intl.DateTimeFormat(locale, {
-      weekday: 'short',
-    });
-
-    let weekday = dayFormatter.format(value);
-    weekday = weekday.charAt(0).toUpperCase() + weekday.charAt(1);
-
-    return `${weekday}, ${dateFormatter.format(value)}`;
-  }
-
   public override invalid(): Date {
     return new Date(NaN);
   }
@@ -231,11 +211,7 @@ export class NativeDateAdapter extends DateAdapter<Date> {
    * @param valueFunction The function of array's index used to fill the array.
    */
   private _range<T>(length: number, valueFunction: (index: number) => T): T[] {
-    const valuesArray = Array(length);
-    for (let i = 0; i < length; i++) {
-      valuesArray[i] = valueFunction(i);
-    }
-    return valuesArray;
+    return Array.from({ length }).map((_, i) => valueFunction(i));
   }
 
   /** Creates a date but allows the month and date to overflow. */

--- a/src/elements/datepicker/datepicker-next-day/datepicker-next-day.ts
+++ b/src/elements/datepicker/datepicker-next-day/datepicker-next-day.ts
@@ -16,7 +16,7 @@ import style from './datepicker-next-day.scss?lit&inline';
 @hostAttributes({
   slot: 'suffix',
 })
-export class SbbDatepickerNextDayElement extends SbbDatepickerButton {
+export class SbbDatepickerNextDayElement<T = Date> extends SbbDatepickerButton<T> {
   public static override styles: CSSResultGroup = style;
 
   protected iconName: string = 'chevron-small-right-small';

--- a/src/elements/datepicker/datepicker-next-day/readme.md
+++ b/src/elements/datepicker/datepicker-next-day/readme.md
@@ -35,11 +35,11 @@ both standalone or within the `sbb-form-field`, they must have the same parent e
 
 ## Properties
 
-| Name         | Attribute     | Privacy | Type                                          | Default    | Description                                      |
-| ------------ | ------------- | ------- | --------------------------------------------- | ---------- | ------------------------------------------------ |
-| `datePicker` | `date-picker` | public  | `string \| SbbDatepickerElement \| undefined` |            | Datepicker reference.                            |
-| `form`       | `form`        | public  | `string \| undefined`                         |            | The <form> element to associate the button with. |
-| `name`       | `name`        | public  | `string`                                      |            | The name of the button element.                  |
-| `negative`   | `negative`    | public  | `boolean`                                     | `false`    | Negative coloring variant flag.                  |
-| `type`       | `type`        | public  | `SbbButtonType`                               | `'button'` | The type attribute to use for the button.        |
-| `value`      | `value`       | public  | `string`                                      |            | The value of the button element.                 |
+| Name         | Attribute     | Privacy | Type                                             | Default    | Description                                      |
+| ------------ | ------------- | ------- | ------------------------------------------------ | ---------- | ------------------------------------------------ |
+| `datePicker` | `date-picker` | public  | `string \| SbbDatepickerElement<T> \| undefined` |            | Datepicker reference.                            |
+| `form`       | `form`        | public  | `string \| undefined`                            |            | The <form> element to associate the button with. |
+| `name`       | `name`        | public  | `string`                                         |            | The name of the button element.                  |
+| `negative`   | `negative`    | public  | `boolean`                                        | `false`    | Negative coloring variant flag.                  |
+| `type`       | `type`        | public  | `SbbButtonType`                                  | `'button'` | The type attribute to use for the button.        |
+| `value`      | `value`       | public  | `string`                                         |            | The value of the button element.                 |

--- a/src/elements/datepicker/datepicker-previous-day/datepicker-previous-day.ts
+++ b/src/elements/datepicker/datepicker-previous-day/datepicker-previous-day.ts
@@ -16,7 +16,7 @@ import style from './datepicker-previous-day.scss?lit&inline';
 @hostAttributes({
   slot: 'prefix',
 })
-export class SbbDatepickerPreviousDayElement extends SbbDatepickerButton {
+export class SbbDatepickerPreviousDayElement<T = Date> extends SbbDatepickerButton<T> {
   public static override styles: CSSResultGroup = style;
 
   protected iconName: string = 'chevron-small-left-small';

--- a/src/elements/datepicker/datepicker-previous-day/readme.md
+++ b/src/elements/datepicker/datepicker-previous-day/readme.md
@@ -35,11 +35,11 @@ both standalone or within the `sbb-form-field`, they must have the same parent e
 
 ## Properties
 
-| Name         | Attribute     | Privacy | Type                                          | Default    | Description                                      |
-| ------------ | ------------- | ------- | --------------------------------------------- | ---------- | ------------------------------------------------ |
-| `datePicker` | `date-picker` | public  | `string \| SbbDatepickerElement \| undefined` |            | Datepicker reference.                            |
-| `form`       | `form`        | public  | `string \| undefined`                         |            | The <form> element to associate the button with. |
-| `name`       | `name`        | public  | `string`                                      |            | The name of the button element.                  |
-| `negative`   | `negative`    | public  | `boolean`                                     | `false`    | Negative coloring variant flag.                  |
-| `type`       | `type`        | public  | `SbbButtonType`                               | `'button'` | The type attribute to use for the button.        |
-| `value`      | `value`       | public  | `string`                                      |            | The value of the button element.                 |
+| Name         | Attribute     | Privacy | Type                                             | Default    | Description                                      |
+| ------------ | ------------- | ------- | ------------------------------------------------ | ---------- | ------------------------------------------------ |
+| `datePicker` | `date-picker` | public  | `string \| SbbDatepickerElement<T> \| undefined` |            | Datepicker reference.                            |
+| `form`       | `form`        | public  | `string \| undefined`                            |            | The <form> element to associate the button with. |
+| `name`       | `name`        | public  | `string`                                         |            | The name of the button element.                  |
+| `negative`   | `negative`    | public  | `boolean`                                        | `false`    | Negative coloring variant flag.                  |
+| `type`       | `type`        | public  | `SbbButtonType`                                  | `'button'` | The type attribute to use for the button.        |
+| `value`      | `value`       | public  | `string`                                         |            | The value of the button element.                 |

--- a/src/elements/datepicker/datepicker-toggle/datepicker-toggle.ts
+++ b/src/elements/datepicker/datepicker-toggle/datepicker-toggle.ts
@@ -160,11 +160,14 @@ export class SbbDatepickerToggleElement<T = Date> extends SbbNegativeMixin(
       return;
     }
     this._calendarElement = calendar;
-    if (!this._datePickerElement?.valueAsDate || !this._calendarElement?.resetPosition) {
+    if (
+      !('valueAsDate' in (this._datePickerElement ?? {})) ||
+      !this._calendarElement?.resetPosition
+    ) {
       return;
     }
-    this._calendarElement.selected = this._datePickerElement.valueAsDate;
-    this._configureCalendar(this._calendarElement, this._datePickerElement);
+    this._calendarElement.selected = this._datePickerElement!.valueAsDate ?? undefined;
+    this._configureCalendar(this._calendarElement, this._datePickerElement!);
     this._calendarElement.resetPosition();
   }
 

--- a/src/elements/datepicker/datepicker/datepicker.spec.ts
+++ b/src/elements/datepicker/datepicker/datepicker.spec.ts
@@ -63,7 +63,7 @@ describe(`sbb-datepicker`, () => {
     it('renders and interprets timestamp', async () => {
       const element = await fixture(html`
         <div>
-          <input id="datepicker-input" value="1594512000000" />
+          <input id="datepicker-input" value="1594512000" />
           <sbb-datepicker id="datepicker" input="datepicker-input"></sbb-datepicker>
         </div>
       `);
@@ -355,7 +355,7 @@ describe(`sbb-datepicker`, () => {
         page.querySelector<SbbDatepickerElement>('sbb-datepicker')!;
       const elementNext: SbbDatepickerNextDayElement =
         page.querySelector<SbbDatepickerNextDayElement>('sbb-datepicker-next-day')!;
-      expect(getDatePicker(elementNext)).to.equal(picker);
+      expect(getDatePicker<Date>(elementNext)).to.equal(picker);
     });
 
     it('returns the datepicker if its id is passed as trigger', async () => {
@@ -369,7 +369,7 @@ describe(`sbb-datepicker`, () => {
       const picker: SbbDatepickerElement = page.querySelector<SbbDatepickerElement>('#picker')!;
       const elementPrevious: SbbDatepickerPreviousDayElement =
         page.querySelector<SbbDatepickerPreviousDayElement>('sbb-datepicker-previous-day')!;
-      expect(getDatePicker(elementPrevious, 'picker')).to.equal(picker);
+      expect(getDatePicker<Date>(elementPrevious, 'picker')).to.equal(picker);
     });
   });
 

--- a/src/elements/datepicker/datepicker/datepicker.ssr.spec.ts
+++ b/src/elements/datepicker/datepicker/datepicker.ssr.spec.ts
@@ -43,7 +43,7 @@ describe(`sbb-datepicker ssr`, () => {
       },
     );
     const datepicker = root.querySelector('sbb-datepicker')!;
-    expect(asIso8601(datepicker.getValueAsDate()!)).to.equal(asIso8601(new Date(2023, 0, 1)));
+    expect(asIso8601(datepicker.valueAsDate!)).to.equal(asIso8601(new Date(2023, 0, 1)));
 
     const datepickerToggle = root.querySelector('sbb-datepicker-toggle')!;
     await datepickerToggle.hydrationComplete;

--- a/src/elements/datepicker/datepicker/datepicker.stories.ts
+++ b/src/elements/datepicker/datepicker/datepicker.stories.ts
@@ -298,9 +298,7 @@ const playStory = async ({ canvasElement }: StoryContext): Promise<void> => {
 
 const changeEventHandler = async (event: Event): Promise<void> => {
   const div = document.createElement('div');
-  div.innerText = `valueAsDate is: ${await (
-    event.target as SbbDatepickerElement
-  ).getValueAsDate()}.`;
+  div.innerText = `valueAsDate is: ${await (event.target as SbbDatepickerElement).valueAsDate}.`;
   document.getElementById('container-value')?.append(div);
 };
 

--- a/src/elements/datepicker/datepicker/datepicker.stories.ts
+++ b/src/elements/datepicker/datepicker/datepicker.stories.ts
@@ -298,7 +298,7 @@ const playStory = async ({ canvasElement }: StoryContext): Promise<void> => {
 
 const changeEventHandler = async (event: Event): Promise<void> => {
   const div = document.createElement('div');
-  div.innerText = `valueAsDate is: ${await (event.target as SbbDatepickerElement).valueAsDate}.`;
+  div.innerText = `valueAsDate is: ${(event.target as SbbDatepickerElement).valueAsDate}.`;
   document.getElementById('container-value')?.append(div);
 };
 

--- a/src/elements/datepicker/datepicker/datepicker.ts
+++ b/src/elements/datepicker/datepicker/datepicker.ts
@@ -443,13 +443,16 @@ export class SbbDatepickerElement<T = Date> extends LitElement {
   }
 
   private _parseInput(deserializeAsFallback = false): void {
-    const value = this._inputElement?.value ?? '';
-    this._valueAsDate = this._dateAdapter.getValidDateOrNull(
-      this.dateParser
-        ? this.dateParser(value)
-        : this._dateAdapter.parse(value, this.now) ??
-            (deserializeAsFallback ? this._dateAdapter.deserialize(value) : null),
-    );
+    const value = this._inputElement!.value;
+    const parse = this.dateParser ?? ((v: string) => this._dateAdapter.parse(v, this.now));
+    // We are assigning directly to the private backing property of valueAsDate
+    // as we don't want to trigger a blur event during this time.
+    this._valueAsDate = this._dateAdapter.getValidDateOrNull(parse(value));
+    if (deserializeAsFallback && !this._valueAsDate) {
+      this._valueAsDate = this._dateAdapter.getValidDateOrNull(
+        this._dateAdapter.deserialize(value),
+      );
+    }
   }
 
   private _format(date: T): string {

--- a/src/elements/datepicker/datepicker/datepicker.ts
+++ b/src/elements/datepicker/datepicker/datepicker.ts
@@ -187,14 +187,19 @@ export class SbbDatepickerElement<T = Date> extends LitElement {
   @property({ type: Boolean }) public wide = false;
 
   /** A function used to filter out dates. */
-  @property({ attribute: 'date-filter' }) public dateFilter: (date: T | null) => boolean = () =>
-    true;
+  @property({ attribute: false }) public dateFilter: (date: T | null) => boolean = () => true;
 
-  /** A function used to parse string value into dates. */
-  @property({ attribute: 'date-parser' }) public dateParser?: (value: string) => T | undefined;
+  /**
+   * A function used to parse string value into dates.
+   * @deprecated No longer required.
+   */
+  @property({ attribute: false }) public dateParser?: (value: string) => T | undefined;
 
-  /** A function used to format dates into the preferred string format. */
-  @property() public format?: (date: T) => string;
+  /**
+   * A function used to format dates into the preferred string format.
+   * @deprecated No longer required.
+   */
+  @property({ attribute: false }) public format?: (date: T) => string;
 
   /** Reference of the native input connected to the datepicker. */
   @property() public input?: string | HTMLElement;
@@ -211,7 +216,7 @@ export class SbbDatepickerElement<T = Date> extends LitElement {
   private _now?: T | null;
 
   /** The currently selected date as a Date or custom date provider instance. */
-  @property()
+  @property({ attribute: false })
   public set valueAsDate(value: SbbDateLike<T> | null) {
     this._valueAsDate = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
     if (this._tryApplyFormatToInput()) {
@@ -269,6 +274,7 @@ export class SbbDatepickerElement<T = Date> extends LitElement {
 
   private _inputObserver = new AgnosticMutationObserver((mutationsList) => {
     this._emitInputUpdated();
+    // TODO: Decide whether to remove this logic by adding a value property to the datepicker.
     if (this._inputElement && mutationsList?.some((e) => e.attributeName === 'value')) {
       const value = this._inputElement.getAttribute('value');
       this.valueAsDate = this._dateAdapter.parse(value, this.now) ?? value;
@@ -303,7 +309,7 @@ export class SbbDatepickerElement<T = Date> extends LitElement {
   public override willUpdate(changedProperties: PropertyValues<this>): void {
     super.willUpdate(changedProperties);
 
-    if (changedProperties.has('input') && this.input! !== changedProperties.get('input')!) {
+    if (changedProperties.has('input')) {
       this._attachInput();
     }
     if (

--- a/src/elements/datepicker/datepicker/datepicker.ts
+++ b/src/elements/datepicker/datepicker/datepicker.ts
@@ -15,9 +15,6 @@ import type { SbbDatepickerToggleElement } from '../datepicker-toggle.js';
 
 import style from './datepicker.scss?lit&inline';
 
-const FORMAT_DATE =
-  /(^0?[1-9]?|[12]?[0-9]?|3?[01]?)[.,\\/\-\s](0?[1-9]?|1?[0-2]?)?[.,\\/\-\s](\d{1,4}$)?/;
-
 export interface SbbInputUpdateEvent {
   disabled?: boolean;
   readonly?: boolean;
@@ -25,22 +22,26 @@ export interface SbbInputUpdateEvent {
   max?: string | number;
 }
 
+// TODO(breaking-change): Inline deprecated functions in SbbDatepickerElement as public methods
+// where possible and use these methods where the functions are currently used.
+
 /**
  * Given a SbbDatepickerPreviousDayElement, a SbbDatepickerNextDayElement or a SbbDatepickerToggleElement component,
  * it returns the related SbbDatepickerElement reference, if exists.
  * @param element The element potentially connected to the SbbDatepickerElement.
  * @param trigger The id or the reference of the SbbDatePicker.
  */
-export function getDatePicker(
-  element: SbbDatepickerButton | SbbDatepickerToggleElement,
+export function getDatePicker<T = Date>(
+  element: SbbDatepickerButton<T> | SbbDatepickerToggleElement<T>,
   trigger?: string | HTMLElement,
-): SbbDatepickerElement | null | undefined {
+): SbbDatepickerElement<T> | null | undefined {
   if (!trigger) {
-    const parent = element.closest?.('sbb-form-field');
-    return parent?.querySelector('sbb-datepicker');
+    return element
+      .closest?.('sbb-form-field')
+      ?.querySelector<SbbDatepickerElement<T>>('sbb-datepicker');
   }
 
-  return findReferencedElement<SbbDatepickerElement>(trigger);
+  return findReferencedElement<SbbDatepickerElement<T>>(trigger);
 }
 
 /**
@@ -49,13 +50,15 @@ export function getDatePicker(
  * @param delta The number of days to add/subtract from the starting one.
  * @param dateFilter The dateFilter function from the SbbDatepickerElement.
  * @param dateAdapter The adapter class.
+ *
+ * @deprecated Not intended as public API.
  */
-export function getAvailableDate(
-  date: Date,
+export function getAvailableDate<T = Date>(
+  date: T,
   delta: number,
-  dateFilter: ((date: Date) => boolean) | null,
-  dateAdapter: DateAdapter<Date>,
-): Date {
+  dateFilter: ((date: T) => boolean) | null,
+  dateAdapter: DateAdapter<T>,
+): T {
   let availableDate = dateAdapter.addCalendarDays(date, delta);
 
   if (dateFilter) {
@@ -74,13 +77,15 @@ export function getAvailableDate(
  * @param dateFilter The dateFilter function from the SbbDatepickerElement.
  * @param dateAdapter The adapter class.
  * @param min The minimum value to consider in calculations.
+ *
+ * @deprecated Not intended as public API.
  */
-export function findPreviousAvailableDate(
-  date: Date,
-  dateFilter: ((date: Date) => boolean) | null,
-  dateAdapter: DateAdapter<Date>,
+export function findPreviousAvailableDate<T = Date>(
+  date: T,
+  dateFilter: ((date: T) => boolean) | null,
+  dateAdapter: DateAdapter<T>,
   min: string | number | null,
-): Date {
+): T {
   const previousDate = getAvailableDate(date, -1, dateFilter, dateAdapter);
   const dateMin = dateAdapter.deserialize(min);
 
@@ -100,13 +105,15 @@ export function findPreviousAvailableDate(
  * @param dateFilter The dateFilter function from the SbbDatepickerElement.
  * @param dateAdapter The adapter class.
  * @param max The maximum value to consider in calculations.
+ *
+ * @deprecated Not intended as public API.
  */
-export function findNextAvailableDate(
-  date: Date,
-  dateFilter: ((date: Date) => boolean) | null,
-  dateAdapter: DateAdapter<Date>,
+export function findNextAvailableDate<T = Date>(
+  date: T,
+  dateFilter: ((date: T) => boolean) | null,
+  dateAdapter: DateAdapter<T>,
   max: string | number | null,
-): Date {
+): T {
   const nextDate = getAvailableDate(date, 1, dateFilter, dateAdapter);
   const dateMax = dateAdapter.deserialize(max);
 
@@ -126,15 +133,17 @@ export function findNextAvailableDate(
  * @param dateFilter The dateFilter function from the SbbDatepickerElement.
  * @param min The minimum value to consider in calculations.
  * @param max The maximum value to consider in calculations.
+ *
+ * @deprecated Not intended as public API.
  */
-export function isDateAvailable(
-  date: Date,
-  dateFilter: ((date: Date) => boolean) | null,
+export function isDateAvailable<T = Date>(
+  date: T,
+  dateFilter: ((date: T) => boolean) | null,
   min: string | number | null | undefined,
   max: string | number | null | undefined,
 ): boolean {
   // TODO: Get date adapter from config
-  const dateAdapter: DateAdapter<Date> = defaultDateAdapter;
+  const dateAdapter: DateAdapter<T> = readConfig().datetime?.dateAdapter ?? defaultDateAdapter;
   const dateMin = dateAdapter.deserialize(min);
   const dateMax = dateAdapter.deserialize(max);
 
@@ -164,7 +173,7 @@ export const datepickerControlRegisteredEventFactory = (): CustomEvent =>
  * @event {CustomEvent<SbbValidationChangeEvent>} validationChange - Emits whenever the internal validation state changes.
  */
 @customElement('sbb-datepicker')
-export class SbbDatepickerElement extends LitElement {
+export class SbbDatepickerElement<T = Date> extends LitElement {
   public static override styles: CSSResultGroup = style;
   public static readonly events = {
     didChange: 'didChange',
@@ -178,27 +187,43 @@ export class SbbDatepickerElement extends LitElement {
   @property({ type: Boolean }) public wide = false;
 
   /** A function used to filter out dates. */
-  @property({ attribute: 'date-filter' }) public dateFilter: (date: Date | null) => boolean = () =>
+  @property({ attribute: 'date-filter' }) public dateFilter: (date: T | null) => boolean = () =>
     true;
 
   /** A function used to parse string value into dates. */
-  @property({ attribute: 'date-parser' }) public dateParser?: (value: string) => Date | undefined;
+  @property({ attribute: 'date-parser' }) public dateParser?: (value: string) => T | undefined;
 
   /** A function used to format dates into the preferred string format. */
-  @property() public format?: (date: Date) => string;
+  @property() public format?: (date: T) => string;
 
   /** Reference of the native input connected to the datepicker. */
   @property() public input?: string | HTMLElement;
 
+  // TODO: Change undefined to null as a breaking change.
   /** A configured date which acts as the current date instead of the real current date. Recommended for testing purposes. */
   @property()
-  public set now(value: SbbDateLike | undefined) {
+  public set now(value: SbbDateLike<T> | undefined) {
     this._now = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
   }
-  public get now(): Date {
+  public get now(): T {
     return this._now ?? this._dateAdapter.today();
   }
-  private _now: Date | null = null;
+  private _now?: T | null;
+
+  /** The currently selected date as a Date or custom date provider instance. */
+  @property()
+  public set valueAsDate(value: SbbDateLike<T> | null) {
+    this._valueAsDate = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
+    if (this._tryApplyFormatToInput()) {
+      /* Emit blur event when value is changed programmatically to notify
+      frameworks that rely on that event to update form status. */
+      this._inputElement!.dispatchEvent(new Event('blur', { composed: true }));
+    }
+  }
+  public get valueAsDate(): T | null {
+    return this._valueAsDate ?? null;
+  }
+  private _valueAsDate?: T | null;
 
   /**
    * @deprecated only used for React. Will probably be removed once React 19 is available.
@@ -236,145 +261,50 @@ export class SbbDatepickerElement extends LitElement {
     SbbDatepickerElement.events.validationChange,
   );
 
-  @state() private get _inputElement(): HTMLInputElement | null {
-    return this._inputElementState;
-  }
-
-  private set _inputElement(value) {
-    const oldValue = this._inputElementState;
-    this._inputElementState = value;
-    this._registerInputElement(this._inputElementState, oldValue);
-  }
-
-  private _inputElementState: HTMLInputElement | null = null;
-
-  private _findInput(newValue: string | HTMLElement, oldValue: string | HTMLElement): void {
-    if (newValue !== oldValue) {
-      this._inputElement = findInput(this, this.input);
-    }
-  }
-  private _registerInputElement(
-    newValue: HTMLInputElement | null,
-    oldValue: HTMLInputElement | null,
-  ): void {
-    if (newValue !== oldValue) {
-      this._datePickerController?.abort();
-      this._datePickerController = new AbortController();
-
-      if (!this._inputElement) {
-        return;
-      }
-
-      this._inputObserver?.disconnect();
-      this._inputObserver.observe(this._inputElement, {
-        attributeFilter: ['disabled', 'readonly', 'min', 'max', 'value'],
-      });
-
-      this._inputElement.type = 'text';
-
-      if (!this._inputElement.placeholder) {
-        this._inputElement.placeholder = i18nDatePickerPlaceholder[this._language.current];
-      }
-
-      this._inputElement.addEventListener(
-        'change',
-        (event: Event) => {
-          if (!(event instanceof CustomEvent)) {
-            this._valueChanged(event);
-          }
-        },
-        {
-          signal: this._datePickerController.signal,
-        },
-      );
-    }
-  }
-
-  /** Gets the input value with the correct date format. */
-  public getValueAsDate(): Date | undefined {
-    if (this._inputElement && this._inputElement.value) {
-      return this._parse(this._inputElement.value);
-    }
-    return undefined;
-  }
-
-  /** Set the input value to the correctly formatted value. */
-  public setValueAsDate(date: SbbDateLike): void {
-    const parsedDate = date instanceof Date ? date : new Date(date);
-    if (this._inputElement) {
-      this._formatAndUpdateValue(this._inputElement.value, parsedDate);
-      /* Emit blur event when value is changed programmatically to notify
-      frameworks that rely on that event to update form status. */
-      this._inputElement.dispatchEvent(new Event('blur', { composed: true }));
-    }
-  }
-
-  /**
-   * @internal
-   * Whether a custom now is configured.
-   */
-  public hasCustomNow(): boolean {
-    return !!this._now;
-  }
-
-  private _onInputPropertiesChange(mutationsList?: MutationRecord[]): void {
-    this._inputUpdated.emit({
-      disabled: this._inputElement?.disabled,
-      readonly: this._inputElement?.readOnly,
-      min: this._inputElement?.min,
-      max: this._inputElement?.max,
-    });
-
-    if (
-      this._inputElement &&
-      mutationsList &&
-      Array.from(mutationsList).some((e) => e.attributeName === 'value')
-    ) {
-      this._inputElement.value = this._getValidValue(this._inputElement.getAttribute('value')!);
-    }
-  }
+  @state()
+  private _inputElement: HTMLInputElement | null = null;
+  private _inputElementPlaceholderMutable = false;
 
   private _datePickerController!: AbortController;
 
-  private _inputObserver = new AgnosticMutationObserver(this._onInputPropertiesChange.bind(this));
+  private _inputObserver = new AgnosticMutationObserver((mutationsList) => {
+    this._emitInputUpdated();
+    if (this._inputElement && mutationsList?.some((e) => e.attributeName === 'value')) {
+      const value = this._inputElement.getAttribute('value');
+      this.valueAsDate = this._dateAdapter.parse(value, this.now) ?? value;
+    }
+  });
 
-  private _dateAdapter: DateAdapter<Date> =
-    readConfig().datetime?.dateAdapter ?? defaultDateAdapter;
+  private _dateAdapter: DateAdapter<T> = readConfig().datetime?.dateAdapter ?? defaultDateAdapter;
 
   private _abort = new SbbConnectedAbortController(this);
   private _language = new SbbLanguageController(this).withHandler(() => {
     if (this._inputElement) {
-      this._inputElement.placeholder = i18nDatePickerPlaceholder[this._language.current];
-      const valueAsDate = this.getValueAsDate();
-      if (valueAsDate) {
-        this._inputElement.value = this._format(valueAsDate);
+      if (this._inputElementPlaceholderMutable) {
+        this._inputElement.placeholder = i18nDatePickerPlaceholder[this._language.current];
+      }
+      if (this.valueAsDate) {
+        this._inputElement.value = this._format(this.valueAsDate);
       }
     }
   });
 
   public override connectedCallback(): void {
     super.connectedCallback();
-    const signal = this._abort.signal;
-    this.addEventListener('datepickerControlRegistered', () => this._onInputPropertiesChange(), {
-      signal,
+    this.addEventListener('datepickerControlRegistered', () => this._emitInputUpdated(), {
+      signal: this._abort.signal,
     });
-    this._inputElement = findInput(this, this.input);
+    this._attachInput();
     if (this._inputElement) {
-      this._inputElement.value = this._getValidValue(this._inputElement.value);
-      this._inputUpdated.emit({
-        disabled: this._inputElement.disabled,
-        readonly: this._inputElement.readOnly,
-        min: this._inputElement.min,
-        max: this._inputElement.max,
-      });
+      this._emitInputUpdated();
     }
   }
 
   public override willUpdate(changedProperties: PropertyValues<this>): void {
     super.willUpdate(changedProperties);
 
-    if (changedProperties.has('input')) {
-      this._findInput(this.input!, changedProperties.get('input')!);
+    if (changedProperties.has('input') && this.input! !== changedProperties.get('input')!) {
+      this._attachInput();
     }
     if (
       changedProperties.has('wide') ||
@@ -382,6 +312,9 @@ export class SbbDatepickerElement extends LitElement {
       changedProperties.has('now')
     ) {
       this._datePickerUpdated.emit();
+    }
+    if (changedProperties.has('valueAsDate')) {
+      this._setAriaLiveMessage();
     }
   }
 
@@ -393,110 +326,141 @@ export class SbbDatepickerElement extends LitElement {
 
   protected override firstUpdated(changedProperties: PropertyValues<this>): void {
     super.firstUpdated(changedProperties);
-    this._setAriaLiveMessage(this.getValueAsDate());
+    this._setAriaLiveMessage();
   }
 
-  private _parseAndFormatValue(value: string): string {
-    const d = this._parse(value);
-    return !this._dateAdapter.isValid(d) ? value : this._format(d!);
+  /**
+   * Gets the input value with the correct date format.
+   * @deprecated Use property valueAsDate instead.
+   */
+  public getValueAsDate(): T | undefined {
+    return this.valueAsDate ?? undefined;
   }
 
-  private _createAndComposeDate(value: SbbDateLike): string {
-    const date = new Date(value);
-    return this._format(date);
+  /**
+   * Set the input value to the correctly formatted value.
+   * @deprecated Use property valueAsDate instead.
+   */
+  public setValueAsDate(date: SbbDateLike<T>): void {
+    this.valueAsDate = date;
   }
 
-  private _valueChanged(event: Event): void {
-    const value: string = (event.target as HTMLInputElement).value;
-    this._formatAndUpdateValue(value, this._parse(value));
+  /**
+   * @internal
+   * Whether a custom now is configured.
+   */
+  public hasCustomNow(): boolean {
+    return !!this._now;
   }
 
-  /** Applies the correct format to values and triggers event dispatch. */
-  private _formatAndUpdateValue(value: string, valueAsDate: Date | null | undefined): void {
-    if (this._inputElement) {
-      this._inputElement.value = !this._dateAdapter.isValid(valueAsDate)
-        ? value
-        : this._format(valueAsDate!);
+  private _attachInput(): void {
+    const input = findInput(this, this.input);
+    if (this._inputElement === input) {
+      return;
+    } else if (this._inputElement) {
+      this._datePickerController?.abort();
+      this._inputObserver?.disconnect();
+    }
 
-      const isEmptyOrValid =
-        !value ||
-        (!!valueAsDate &&
-          isDateAvailable(
-            valueAsDate,
-            this.dateFilter,
-            this._inputElement?.min,
-            this._inputElement?.max,
-          ));
-      const wasValid = !this._inputElement.hasAttribute('data-sbb-invalid');
-      this._inputElement.toggleAttribute('data-sbb-invalid', !isEmptyOrValid);
-      if (wasValid !== isEmptyOrValid) {
-        this._validationChange.emit({ valid: isEmptyOrValid });
+    this._inputElement = input;
+    if (input) {
+      this._datePickerController = new AbortController();
+      this._inputObserver.observe(input, {
+        attributeFilter: ['disabled', 'readonly', 'min', 'max', 'value'],
+      });
+
+      this._inputElementPlaceholderMutable = !input.placeholder;
+      input.type = 'text';
+      if (this._inputElementPlaceholderMutable) {
+        input.placeholder = i18nDatePickerPlaceholder[this._language.current];
       }
-      this._emitChange(valueAsDate!);
+
+      const options: AddEventListenerOptions = { signal: this._datePickerController.signal };
+      input.addEventListener('input', () => this._parseInput(), options);
+      input.addEventListener('change', () => this._handleInputChange(), options);
+      this._parseInput(true);
+      this._tryApplyFormatToInput();
+      this._validateDate();
     }
   }
 
-  /** Emits the change event. */
-  private _emitChange(date: Date): void {
-    this._setAriaLiveMessage(date);
+  private _emitInputUpdated(): void {
+    const { disabled, readOnly: readonly, min, max } = this._inputElement ?? {};
+    this._inputUpdated.emit({ disabled, readonly, min, max });
+  }
 
+  private _handleInputChange(): void {
+    if (this._tryApplyFormatToInput()) {
+      return;
+    }
+    this._validateDate();
+    this._setAriaLiveMessage();
     this._change.emit();
     this._didChange.emit();
+  }
 
-    if (this._inputElement) {
+  private _tryApplyFormatToInput(): boolean {
+    if (!this._inputElement) {
+      return false;
+    }
+
+    const formattedDate = this.valueAsDate ? this._format(this.valueAsDate!) : '';
+    if (formattedDate && this._inputElement.value !== formattedDate) {
+      this._inputElement.value = formattedDate;
       this._inputElement.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }));
-      this._inputElement.dispatchEvent(
-        new CustomEvent('change', { bubbles: true, composed: true }),
-      );
+      this._inputElement.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+      return true;
+    }
+
+    return false;
+  }
+
+  private _validateDate(): void {
+    if (!this._inputElement) {
+      return;
+    }
+
+    const isEmptyOrValid =
+      !this._inputElement.value ||
+      (!!this.valueAsDate &&
+        isDateAvailable(
+          this.valueAsDate,
+          this.dateFilter,
+          this._inputElement?.min,
+          this._inputElement?.max,
+        ));
+    const wasValid = !this._inputElement.hasAttribute('data-sbb-invalid');
+    this._inputElement.toggleAttribute('data-sbb-invalid', !isEmptyOrValid);
+    if (wasValid !== isEmptyOrValid) {
+      this._validationChange.emit({ valid: isEmptyOrValid });
     }
   }
 
-  private _getValidValue(value: string): string {
-    if (!value) {
-      return '';
-    }
-
-    const match: RegExpMatchArray | null = value.match(FORMAT_DATE);
-
-    if (match?.index === 0) {
-      return this._parseAndFormatValue(value);
-    } else if (Number.isInteger(+value)) {
-      return this._createAndComposeDate(+value);
-    } else if (this._dateAdapter.isValid(new Date(value))) {
-      return this._createAndComposeDate(value);
-    }
-
-    return value;
+  private _parseInput(deserializeAsFallback = false): void {
+    const value = this._inputElement?.value ?? '';
+    this._valueAsDate = this._dateAdapter.getValidDateOrNull(
+      this.dateParser
+        ? this.dateParser(value)
+        : this._dateAdapter.parse(value, this.now) ??
+            (deserializeAsFallback ? this._dateAdapter.deserialize(value) : null),
+    );
   }
 
-  private _parse(value: string): Date | undefined {
-    return this.dateParser ? this.dateParser(value) : this._dateAdapter.parse(value, this.now);
-  }
-
-  private _format(date: Date): string {
+  private _format(date: T): string {
     return this.format ? this.format(date) : this._dateAdapter.format(date);
   }
 
-  private _setAriaLiveMessage(date?: Date): void {
-    const ariaLiveFormatter = new Intl.DateTimeFormat(`${this._language.current}-CH`, {
-      weekday: 'long',
-    });
-
-    const dateFormatter = new Intl.DateTimeFormat('de-CH', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-    });
-
+  private _setAriaLiveMessage(): void {
     const containerElement: HTMLParagraphElement | null | undefined =
       this.shadowRoot?.querySelector?.<HTMLParagraphElement>('#status-container');
 
-    if (containerElement) {
-      containerElement.innerText = date
-        ? `${i18nDateChangedTo[this._language.current]} ${ariaLiveFormatter.format(
-            date,
-          )}, ${dateFormatter.format(date)}`
-        : '';
+    if (!containerElement) {
+      return;
+    } else if (!this.valueAsDate) {
+      containerElement.innerText = '';
+    } else {
+      const date = this._dateAdapter.format(this.valueAsDate, { weekdayStyle: 'long' });
+      containerElement.innerText = `${i18nDateChangedTo[this._language.current]} ${date}`;
     }
   }
 

--- a/src/elements/datepicker/datepicker/readme.md
+++ b/src/elements/datepicker/datepicker/readme.md
@@ -3,9 +3,9 @@ to display the typed value as a formatted date (default: `dd.MM.yyyy`).
 
 The component allows the insertion of up to 10 numbers, possibly with separators like `.`, `-`, ` `, `,` or `/`,
 then automatically formats the value as date and displays it.
-It also exposes methods to get / set the value formatted as Date.
+It also allows to get / set the value formatted as Date via the `valueAsDate` property.
 
-The component and the native `input` can be connected using the `input` property,
+The component and the native `<input>` can be connected using the `input` property,
 which accepts the id of the native input, or directly its reference.
 
 ```html
@@ -46,14 +46,15 @@ It's also possible to display a two-months view using the `wide` property.
 
 If the input's value changes, it is formatted then a `change` event is emitted with the new value.
 If it's an invalid date, the `data-sbb-invalid` attribute is added to the input.
-The component also listens for changes in its two properties, `wide` and `dateFilter`, and emits a `datePickerUpdated` event when changed.
+The component also listens for changes in its two properties, `wide` and `dateFilter`, and emits a
+`datePickerUpdated` event when changed.
 
-Consumers can listen to the native `change` and `input` events on the `sbb-datepicker` component to intercept date changes,
-the current value can be read from the async method `event.target.getValueAsDate()`.
-To set the value programmatically, it's recommended to use the `setValueAsDate()` method of the `sbb-datepicker`.
+Consumers can listen to the native `change` and `input` events on the `sbb-datepicker` component to
+intercept date changes. The `valueAsDate` property on the `sbb-datepicker` can be used to read the
+current value (e.g. from `event.target.valueAsDate`) or to set the value programmatically.
 
-Each time the user changes the date by using the calendar, or the next and previous day arrow, or by using the `setValueAsDate()` method,
-a `blur` event is fired on the input to ensure compatibility with any framework that relies on that event to update the current state.
+When the `valueAsDate` property is programmatically assigned, a `blur` event is fired on the input
+to ensure compatibility with any framework that relies on that event to update the current state.
 
 ## Custom date formats
 

--- a/src/elements/datepicker/datepicker/readme.md
+++ b/src/elements/datepicker/datepicker/readme.md
@@ -103,21 +103,22 @@ Whenever the validation state changes (e.g., a valid value becomes invalid or vi
 
 ## Properties
 
-| Name         | Attribute     | Privacy | Type                                                | Default | Description                                                                                                          |
-| ------------ | ------------- | ------- | --------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------- |
-| `dateFilter` | `date-filter` | public  | `(date: Date \| null) => boolean`                   |         | A function used to filter out dates.                                                                                 |
-| `dateParser` | `date-parser` | public  | `(value: string) => Date \| undefined \| undefined` |         | A function used to parse string value into dates.                                                                    |
-| `format`     | `format`      | public  | `(date: Date) => string \| undefined`               |         | A function used to format dates into the preferred string format.                                                    |
-| `input`      | `input`       | public  | `string \| HTMLElement \| undefined`                |         | Reference of the native input connected to the datepicker.                                                           |
-| `now`        | `now`         | public  | `Date`                                              | `null`  | A configured date which acts as the current date instead of the real current date. Recommended for testing purposes. |
-| `wide`       | `wide`        | public  | `boolean`                                           | `false` | If set to true, two months are displayed.                                                                            |
+| Name          | Attribute     | Privacy | Type                                             | Default | Description                                                                                                          |
+| ------------- | ------------- | ------- | ------------------------------------------------ | ------- | -------------------------------------------------------------------------------------------------------------------- |
+| `dateFilter`  | `date-filter` | public  | `(date: T \| null) => boolean`                   |         | A function used to filter out dates.                                                                                 |
+| `dateParser`  | `date-parser` | public  | `(value: string) => T \| undefined \| undefined` |         | A function used to parse string value into dates.                                                                    |
+| `format`      | `format`      | public  | `(date: T) => string \| undefined`               |         | A function used to format dates into the preferred string format.                                                    |
+| `input`       | `input`       | public  | `string \| HTMLElement \| undefined`             |         | Reference of the native input connected to the datepicker.                                                           |
+| `now`         | `now`         | public  | `T`                                              |         | A configured date which acts as the current date instead of the real current date. Recommended for testing purposes. |
+| `valueAsDate` | `valueAsDate` | public  | `T \| null`                                      |         | The currently selected date as a Date or custom date provider instance.                                              |
+| `wide`        | `wide`        | public  | `boolean`                                        | `false` | If set to true, two months are displayed.                                                                            |
 
 ## Methods
 
-| Name             | Privacy | Description                                           | Parameters          | Return              | Inherited From |
-| ---------------- | ------- | ----------------------------------------------------- | ------------------- | ------------------- | -------------- |
-| `getValueAsDate` | public  | Gets the input value with the correct date format.    |                     | `Date \| undefined` |                |
-| `setValueAsDate` | public  | Set the input value to the correctly formatted value. | `date: SbbDateLike` | `void`              |                |
+| Name             | Privacy | Description                                           | Parameters             | Return           | Inherited From |
+| ---------------- | ------- | ----------------------------------------------------- | ---------------------- | ---------------- | -------------- |
+| `getValueAsDate` | public  | Gets the input value with the correct date format.    |                        | `T \| undefined` |                |
+| `setValueAsDate` | public  | Set the input value to the correctly formatted value. | `date: SbbDateLike<T>` | `void`           |                |
 
 ## Events
 

--- a/src/elements/datepicker/datepicker/readme.md
+++ b/src/elements/datepicker/datepicker/readme.md
@@ -104,15 +104,15 @@ Whenever the validation state changes (e.g., a valid value becomes invalid or vi
 
 ## Properties
 
-| Name          | Attribute     | Privacy | Type                                             | Default | Description                                                                                                          |
-| ------------- | ------------- | ------- | ------------------------------------------------ | ------- | -------------------------------------------------------------------------------------------------------------------- |
-| `dateFilter`  | `date-filter` | public  | `(date: T \| null) => boolean`                   |         | A function used to filter out dates.                                                                                 |
-| `dateParser`  | `date-parser` | public  | `(value: string) => T \| undefined \| undefined` |         | A function used to parse string value into dates.                                                                    |
-| `format`      | `format`      | public  | `(date: T) => string \| undefined`               |         | A function used to format dates into the preferred string format.                                                    |
-| `input`       | `input`       | public  | `string \| HTMLElement \| undefined`             |         | Reference of the native input connected to the datepicker.                                                           |
-| `now`         | `now`         | public  | `T`                                              |         | A configured date which acts as the current date instead of the real current date. Recommended for testing purposes. |
-| `valueAsDate` | `valueAsDate` | public  | `T \| null`                                      |         | The currently selected date as a Date or custom date provider instance.                                              |
-| `wide`        | `wide`        | public  | `boolean`                                        | `false` | If set to true, two months are displayed.                                                                            |
+| Name          | Attribute | Privacy | Type                                             | Default | Description                                                                                                          |
+| ------------- | --------- | ------- | ------------------------------------------------ | ------- | -------------------------------------------------------------------------------------------------------------------- |
+| `dateFilter`  | -         | public  | `(date: T \| null) => boolean`                   |         | A function used to filter out dates.                                                                                 |
+| `dateParser`  | -         | public  | `(value: string) => T \| undefined \| undefined` |         | A function used to parse string value into dates.                                                                    |
+| `format`      | -         | public  | `(date: T) => string \| undefined`               |         | A function used to format dates into the preferred string format.                                                    |
+| `input`       | `input`   | public  | `string \| HTMLElement \| undefined`             |         | Reference of the native input connected to the datepicker.                                                           |
+| `now`         | `now`     | public  | `T`                                              |         | A configured date which acts as the current date instead of the real current date. Recommended for testing purposes. |
+| `valueAsDate` | -         | public  | `T \| null`                                      |         | The currently selected date as a Date or custom date provider instance.                                              |
+| `wide`        | `wide`    | public  | `boolean`                                        | `false` | If set to true, two months are displayed.                                                                            |
 
 ## Methods
 


### PR DESCRIPTION
This change adds support for the `DateAdapter` to all datepicker related components (`<sbb-datepicker>`, `<sbb-datepicker-toggle>`, `<sbb-datepicker-previous-day>` and `<sbb-datepicker-next-day>`).

Closes #2865, closes #1915

Partially supersedes #2244 (Thank you @DavideMininni-Fincons for the initial work!)