### PR TITLE
fix(sbb-clock): fix internal await to actually finish

### DIFF
--- a/src/elements/clock/clock.ts
+++ b/src/elements/clock/clock.ts
@@ -139,11 +139,12 @@ export class SbbClockElement extends LitElement {
       ADD_EVENT_LISTENER_OPTIONS,
     );
 
-    await new Promise(() =>
+    await new Promise<void>((resolve) =>
       setTimeout(() => {
         this._setHandsStartingPosition();
 
         this.style?.setProperty('--sbb-clock-animation-play-state', 'running');
+        resolve();
       }, INITIAL_TIMEOUT_DURATION),
     );
   }


### PR DESCRIPTION
Previously `_startClock` would not finish, as the awaited Promise would not resolve. This prevented other internal methods from completing.