### PR TITLE
fix(various): re-enable scrolling when disconnecting the component before animationend

### DIFF
--- a/src/elements/core/testing.ts
+++ b/src/elements/core/testing.ts
@@ -2,5 +2,6 @@ export * from './testing/event-spy.js';
 export * from './testing/mocha-extensions.js';
 export * from './testing/scroll.js';
 export * from './testing/wait-for-condition.js';
+export * from './testing/wait-for-event.js';
 export * from './testing/wait-for-image-ready.js';
 export * from './testing/wait-for-render.js';

--- a/src/elements/core/testing/wait-for-event.ts
+++ b/src/elements/core/testing/wait-for-event.ts
@@ -1,0 +1,19 @@
+export function waitForEvent(
+  element: HTMLElement,
+  eventName: string,
+  timeout = 1000,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const signal = AbortSignal.timeout(timeout);
+    const timeoutReached = (): void => reject(`Timeout of ${timeout} reached`);
+    signal.addEventListener('abort', timeoutReached);
+    element.addEventListener(
+      eventName,
+      () => {
+        signal.removeEventListener('abort', timeoutReached);
+        resolve();
+      },
+      { passive: true, signal },
+    );
+  });
+}

--- a/src/elements/menu/menu/menu.ts
+++ b/src/elements/menu/menu/menu.ts
@@ -210,6 +210,7 @@ export class SbbMenuElement extends SbbNamedSlotListMixin<
     this._windowEventsController?.abort();
     this._focusHandler.disconnect();
     removeInertMechanism();
+    this._scrollHandler.enableScroll();
   }
 
   private _checkListCase(event: Event): void {

--- a/src/elements/navigation/navigation/navigation.spec.ts
+++ b/src/elements/navigation/navigation/navigation.spec.ts
@@ -3,9 +3,10 @@ import { sendKeys } from '@web/test-runner-commands';
 import { html } from 'lit/static-html.js';
 
 import type { SbbButtonElement } from '../../button.js';
+import { pageScrollDisabled } from '../../core/dom.js';
 import { tabKey } from '../../core/testing/private/keys.js';
 import { fixture } from '../../core/testing/private.js';
-import { waitForCondition, waitForLitRender, EventSpy } from '../../core/testing.js';
+import { waitForCondition, waitForLitRender, EventSpy, waitForEvent } from '../../core/testing.js';
 import type { SbbNavigationButtonElement } from '../navigation-button.js';
 import type { SbbNavigationSectionElement } from '../navigation-section.js';
 
@@ -521,5 +522,15 @@ describe(`sbb-navigation`, () => {
     await waitForLitRender(element);
 
     expect(element).to.have.attribute('data-state', 'opened');
+  });
+
+  it('should re-enable scrolling when removed from the DOM', async () => {
+    element.open();
+    await waitForEvent(element, SbbNavigationElement.events.didOpen);
+
+    expect(pageScrollDisabled()).to.be.true;
+
+    element.remove();
+    expect(pageScrollDisabled()).to.be.false;
   });
 });

--- a/src/elements/navigation/navigation/navigation.ts
+++ b/src/elements/navigation/navigation/navigation.ts
@@ -340,6 +340,7 @@ export class SbbNavigationElement extends SbbUpdateSchedulerMixin(SbbOpenCloseBa
     this._navigationObserver.disconnect();
     this._navigationResizeObserver.disconnect();
     removeInertMechanism();
+    this._scrollHandler.enableScroll();
   }
 
   protected override render(): TemplateResult {

--- a/src/elements/overlay/overlay-base-element.ts
+++ b/src/elements/overlay/overlay-base-element.ts
@@ -85,6 +85,7 @@ export abstract class SbbOverlayBaseElement extends SbbNegativeMixin(SbbOpenClos
     this.focusHandler.disconnect();
     this.removeInstanceFromGlobalCollection();
     removeInertMechanism();
+    this.scrollHandler.enableScroll();
   }
 
   protected attachOpenOverlayEvents(): void {


### PR DESCRIPTION
Currently if an overlay element is removed from the DOM before its `animationend` event is called, the page is stuck with disabled scrolling. To prevent this, we re-enable the scrolling additionally in the `disconnectedCallback`.

Closes #2967