### PR TITLE
build: inline fonts during tests

### DIFF
--- a/tools/web-test-runner/index.ts
+++ b/tools/web-test-runner/index.ts
@@ -3,5 +3,6 @@ export * from './container-playwright-browser-plugin.js';
 export * from './minimal-reporter.js';
 export * from './patched-summary-reporter.js';
 export * from './preload-icons.js';
+export * from './preload-fonts.js';
 export * from './visual-regression-plugin-config.js';
 export * from './vite-plugin.js';

--- a/tools/web-test-runner/preload-fonts.ts
+++ b/tools/web-test-runner/preload-fonts.ts
@@ -18,7 +18,7 @@ export interface PreloadedFont {
 }
 
 async function downloadFont(fontUrl: string): Promise<ArrayBuffer> {
-  // Performing too many HTTP requestsin parallel or sequence causes fetch to fail.
+  // Performing too many HTTP requests in parallel or sequence causes fetch to fail.
   // We add a delay for each request to prevent the request failure.
   await new Promise((r) => setTimeout(r, 20));
   const r = await fetch(fontUrl);
@@ -46,7 +46,7 @@ export async function preloadFonts(): Promise<PreloadedFont[]> {
     }
     preloadedFonts.push({
       weight,
-      font: `url(data:application/font-woff2;charset=utf-8;base64,${readFileSync(fontCachePath).toString('base64')}) format('woff2')`,
+      font: `url(data:font-woff2;charset=utf-8;base64,${readFileSync(fontCachePath).toString('base64')}) format('woff2')`,
     });
   }
   console.log(`Finished preloading fonts`);

--- a/tools/web-test-runner/preload-fonts.ts
+++ b/tools/web-test-runner/preload-fonts.ts
@@ -1,0 +1,54 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const cacheLocation = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../node_modules/.cache/lyne-cdn-fonts',
+);
+const preloadFontList = [
+  [400, 'https://cdn.app.sbb.ch/fonts/v1_6_subset/SBBWeb-Roman.woff2'],
+  [700, 'https://cdn.app.sbb.ch/fonts/v1_6_subset/SBBWeb-Bold.woff2'],
+  [300, 'https://cdn.app.sbb.ch/fonts/v1_6_subset/SBBWeb-Light.woff2'],
+] as const;
+
+export interface PreloadedFont {
+  weight: number;
+  font: string;
+}
+
+async function downloadFont(fontUrl: string): Promise<ArrayBuffer> {
+  // Performing too many HTTP requestsin parallel or sequence causes fetch to fail.
+  // We add a delay for each request to prevent the request failure.
+  await new Promise((r) => setTimeout(r, 20));
+  const r = await fetch(fontUrl);
+  return await r.arrayBuffer();
+}
+
+export async function preloadFonts(): Promise<PreloadedFont[]> {
+  mkdirSync(cacheLocation, { recursive: true });
+
+  const preloadedFonts: PreloadedFont[] = [];
+  console.log(`Preloading fonts`);
+  for (const [weight, fontUrl] of preloadFontList) {
+    const fontFile = basename(fontUrl);
+    const fontCachePath = join(cacheLocation, fontFile);
+    if (!existsSync(fontCachePath)) {
+      let font: ArrayBuffer;
+      try {
+        font = await downloadFont(fontUrl);
+      } catch (e) {
+        console.log(`Failed to fetch ${fontUrl}`);
+        throw e;
+      }
+
+      writeFileSync(fontCachePath, Buffer.from(font), 'utf8');
+    }
+    preloadedFonts.push({
+      weight,
+      font: `url(data:application/font-woff2;charset=utf-8;base64,${readFileSync(fontCachePath).toString('base64')}) format('woff2')`,
+    });
+  }
+  console.log(`Finished preloading fonts`);
+  return preloadedFonts;
+}

--- a/tools/web-test-runner/preload-icons.ts
+++ b/tools/web-test-runner/preload-icons.ts
@@ -135,7 +135,7 @@ export interface PreloadedIcon {
 }
 
 async function downloadIcon(iconUrl: string): Promise<string> {
-  // Performing too many HTTP requestsin parallel or sequence causes fetch to fail.
+  // Performing too many HTTP requests in parallel or sequence causes fetch to fail.
   // We add a delay for each request to prevent the request failure.
   await new Promise((r) => setTimeout(r, 20));
   const r = await fetch(iconUrl);

--- a/web-test-runner.config.ts
+++ b/web-test-runner.config.ts
@@ -110,7 +110,22 @@ const testRunnerHtml = (
 ): string => `
 <!DOCTYPE html>
 <html lang='en'>
-  <head>
+  <head>${
+    // Although we provide the fonts as base64, we preload the original
+    // files which prevents a bug in Safari rendering special characters.
+    ['Roman', 'Bold', 'Light']
+      .map(
+        (type) => `
+    <link
+      rel="preload"
+      href="https://cdn.app.sbb.ch/fonts/v1_6_subset/SBBWeb-${type}.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin="anonymous"
+    />`,
+      )
+      .join('')
+  }
     <link rel="modulepreload" href="/src/elements/core/testing/test-setup.ts" />
     <style type="text/css">${renderStyles()}</style>
     <style type="text/css">

--- a/web-test-runner.config.ts
+++ b/web-test-runner.config.ts
@@ -26,6 +26,7 @@ import {
   visualRegressionConfig,
   vitePlugin,
   preloadIcons,
+  preloadFonts,
 } from './tools/web-test-runner/index.js';
 
 const { values: cliArgs } = parseArgs({
@@ -100,6 +101,7 @@ const browsers =
           : [playwrightLauncher({ product: 'chromium', ...launchOptions })];
 
 const preloadedIcons = await preloadIcons();
+const preloadedFonts = await preloadFonts();
 
 const testRunnerHtml = (
   testFramework: string,
@@ -108,20 +110,22 @@ const testRunnerHtml = (
 ): string => `
 <!DOCTYPE html>
 <html lang='en'>
-  <head>${['Roman', 'Bold', 'Light']
-    .map(
-      (type) => `
-    <link
-      rel="preload"
-      href="https://cdn.app.sbb.ch/fonts/v1_6_subset/SBBWeb-${type}.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin="anonymous"
-    />`,
-    )
-    .join('')}
+  <head>
     <link rel="modulepreload" href="/src/elements/core/testing/test-setup.ts" />
     <style type="text/css">${renderStyles()}</style>
+    <style type="text/css">
+      ${preloadedFonts
+        .map(
+          (f) => `
+      @font-face {
+        font-family: SBB;
+        src: ${f.font};
+        font-display: fallback;
+        font-weight: ${f.weight};
+      }`,
+        )
+        .join('')}
+    </style>
     <script type="module">
       globalThis.testEnv = '${cliArgs.debug ? 'debug' : ''}';
       globalThis.testGroup = '${cliArgs.ssr ? 'ssr' : (group?.name ?? 'default')}';


### PR DESCRIPTION
Similar to what we already do, this PR downloads the fonts before test runs and inlines them in the initial HTML. This avoids flakey font resolution in tests.