### PR TITLE
fix(sbb-form-field): remove deprecated `getInputElement()` method

### DIFF
--- a/src/elements/datepicker/common/datepicker-button.ts
+++ b/src/elements/datepicker/common/datepicker-button.ts
@@ -111,8 +111,6 @@ export abstract class SbbDatepickerButton<T = Date> extends SbbNegativeMixin(Sbb
     if (formField) {
       this.negative = formField.hasAttribute('negative');
 
-      // We can't use getInputElement of SbbFormFieldElement as async awaiting is not supported in connectedCallback.
-      // We here only have to look for input.
       const inputElement = formField.querySelector('input');
 
       if (inputElement) {

--- a/src/elements/form-field/form-field/form-field.ts
+++ b/src/elements/form-field/form-field/form-field.ts
@@ -427,14 +427,6 @@ class SbbFormFieldElement extends SbbNegativeMixin(SbbHydrationMixin(LitElement)
     this._checkAndUpdateInputEmpty();
   }
 
-  /**
-   * Returns the input element.
-   * @deprecated Use the 'inputElement' property instead
-   */
-  public getInputElement(): HTMLInputElement | HTMLSelectElement | HTMLElement | undefined {
-    return this._input;
-  }
-
   private _syncNegative(): void {
     this.querySelectorAll?.(
       'sbb-form-error,sbb-mini-button,sbb-popover-trigger,sbb-form-field-clear,sbb-datepicker-next-day,sbb-datepicker-previous-day,sbb-datepicker-toggle,sbb-select,sbb-autocomplete,sbb-autocomplete-grid',

--- a/src/elements/form-field/form-field/readme.md
+++ b/src/elements/form-field/form-field/readme.md
@@ -162,11 +162,10 @@ technology will announce errors when they appear.
 
 ## Methods
 
-| Name              | Privacy | Description                                                                           | Parameters | Return                                                              | Inherited From |
-| ----------------- | ------- | ------------------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------- | -------------- |
-| `clear`           | public  | Manually clears the input value. It only works for inputs, selects are not supported. |            | `void`                                                              |                |
-| `getInputElement` | public  | Returns the input element.                                                            |            | `HTMLInputElement \| HTMLSelectElement \| HTMLElement \| undefined` |                |
-| `reset`           | public  | Manually reset the form field. Currently, this only resets the floating label.        |            | `void`                                                              |                |
+| Name    | Privacy | Description                                                                           | Parameters | Return | Inherited From |
+| ------- | ------- | ------------------------------------------------------------------------------------- | ---------- | ------ | -------------- |
+| `clear` | public  | Manually clears the input value. It only works for inputs, selects are not supported. |            | `void` |                |
+| `reset` | public  | Manually reset the form field. Currently, this only resets the floating label.        |            | `void` |                |
 
 ## Slots
 


### PR DESCRIPTION
BREAKING CHANGE: The `getInputElement()` method of the `sbb-form-field` has been removed. Use `inputElement` property as alternative.