### PR TITLE
build: fix slim container image build

### DIFF
--- a/.github/workflows/continuous-integration-secure.yml
+++ b/.github/workflows/continuous-integration-secure.yml
@@ -73,7 +73,7 @@ jobs:
         uses: kitabisa/docker-slim-action@v1
         with:
           target: '${{ env.IMAGE_REPO_PREVIEW }}:pr${{ env.PR_NUMBER }}'
-          tag: '${{ env.IMAGE_REPO_PREVIEW }}:pr${{ env.PR_NUMBER }}-slim'
+          tag: 'pr${{ env.PR_NUMBER }}-slim'
         env:
           DSLIM_PRESERVE_PATH: /usr/share/nginx/html
       - name: Push slim image
@@ -196,7 +196,7 @@ jobs:
         uses: kitabisa/docker-slim-action@v1
         with:
           target: '${{ env.IMAGE_REPO_VISUAL_REGRESSION }}:pr${{ env.PR_NUMBER }}'
-          tag: '${{ env.IMAGE_REPO_VISUAL_REGRESSION }}:pr${{ env.PR_NUMBER }}-slim'
+          tag: 'pr${{ env.PR_NUMBER }}-slim'
         env:
           DSLIM_PRESERVE_PATH: /usr/share/nginx/html
       - name: Push slim image

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -163,7 +163,7 @@ jobs:
         uses: kitabisa/docker-slim-action@v1
         with:
           target: '${{ env.IMAGE_REPO_VISUAL_REGRESSION }}:baseline'
-          tag: '${{ env.IMAGE_REPO_VISUAL_REGRESSION }}:baseline-slim'
+          tag: baseline-slim
         env:
           DSLIM_PRESERVE_PATH: /usr/share/nginx/html
       - name: Push slim image

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -99,7 +99,7 @@ jobs:
         uses: kitabisa/docker-slim-action@v1
         with:
           target: '${{ env.IMAGE_REPO_STORYBOOK }}:${{ steps.release.outputs.version }}'
-          tag: '${{ env.IMAGE_REPO_STORYBOOK }}:${{ steps.release.outputs.version }}-slim'
+          tag: '${{ steps.release.outputs.version }}-slim'
         env:
           DSLIM_PRESERVE_PATH: /usr/share/nginx/html
       - name: Build slim image with latest
@@ -107,7 +107,7 @@ jobs:
         uses: kitabisa/docker-slim-action@v1
         with:
           target: '${{ env.IMAGE_REPO_STORYBOOK }}:latest'
-          tag: '${{ env.IMAGE_REPO_STORYBOOK }}:latest-slim'
+          tag: ':latest-slim'
         env:
           DSLIM_PRESERVE_PATH: /usr/share/nginx/html
       - name: Push slim image
@@ -128,7 +128,7 @@ jobs:
         uses: kitabisa/docker-slim-action@v1
         with:
           target: '${{ env.IMAGE_REPO_STORYBOOK }}:dev'
-          tag: '${{ env.IMAGE_REPO_STORYBOOK }}:dev-slim'
+          tag: dev-slim
         env:
           DSLIM_PRESERVE_PATH: /usr/share/nginx/html
       - name: Push slim image


### PR DESCRIPTION
Fixes usage of the tag parameter, which only expects the image tag and not the full path (contrary to Docker/Buildah).