### PR TITLE
style(sbb-dialog, sbb-link): removed `break-word` css rule

### DIFF
--- a/src/elements/dialog/dialog-title/dialog-title.scss
+++ b/src/elements/dialog/dialog-title/dialog-title.scss
@@ -14,6 +14,7 @@
   flex: 1;
   overflow: hidden;
   align-self: center;
+  hyphens: auto;
 
   // Overwrite sbb-title default margin
   margin: 0;

--- a/src/elements/dialog/dialog/dialog.scss
+++ b/src/elements/dialog/dialog/dialog.scss
@@ -158,7 +158,6 @@
   max-height: var(--sbb-dialog-max-height);
   outline: none;
   position: fixed;
-  word-break: break-word;
 
   @include sbb.mq($from: medium) {
     position: sticky;

--- a/src/elements/link/common/link.scss
+++ b/src/elements/link/common/link.scss
@@ -21,7 +21,6 @@ $disabled: '[disabled], :disabled, [disabled-interactive]';
   & {
     display: flex;
     align-items: center;
-    word-break: break-word;
     width: 100%;
     cursor: pointer;
     padding: var(--sbb-link-padding, 0);


### PR DESCRIPTION
This PR Closes #3158 

BREAKING CHANGE: Removed the `word-break: break-word;` CSS rule from lyne components. They will follow the default [break rules](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break).
Impacted components are: `sbb-dialog-content`, `sbb-link` and variants;