### PR TITLE
fix(sbb-datepicker): remove deprecated methods and properties

### DIFF
--- a/src/elements/core/datetime/date-adapter.ts
+++ b/src/elements/core/datetime/date-adapter.ts
@@ -5,8 +5,6 @@ export const YEARS_PER_PAGE: number = 24;
 export const FORMAT_DATE =
   /(^0?[1-9]?|[12]?[0-9]?|3?[01]?)[.,\\/\-\s](0?[1-9]?|1?[0-2]?)?[.,\\/\-\s](\d{1,4}$)?/;
 
-// TODO(breaking-change): Change undefined return types to null.
-
 /**
  * Abstract date functionality.
  *
@@ -139,11 +137,12 @@ export abstract class DateAdapter<T = any> {
    * @param value The date in the format DD.MM.YYYY.
    * @param now The current date as Date.
    */
-  public abstract parse(value: string | null | undefined, now: T): T | undefined;
+  public abstract parse(value: string | null | undefined, now: T): T | null;
 
   /**
    * Format the given date as string.
    * @param date The date to format.
+   * @param options options object with weekdayStyle as property
    */
   public format(
     date: T | null | undefined,

--- a/src/elements/core/datetime/native-date-adapter.spec.ts
+++ b/src/elements/core/datetime/native-date-adapter.spec.ts
@@ -194,9 +194,9 @@ describe('NativeDateAdapter', () => {
 
   it('parseDate should return the correct value', function () {
     const now = new Date(2023, 8, 15, 0, 0, 0, 0);
-    expect(nativeDateAdapter.parse(null, now)).to.be.undefined;
-    expect(nativeDateAdapter.parse('Test', now)).to.be.undefined;
-    expect(nativeDateAdapter.parse('1.1', now)).to.be.undefined;
+    expect(nativeDateAdapter.parse(null, now)).to.be.null;
+    expect(nativeDateAdapter.parse('Test', now)).to.be.null;
+    expect(nativeDateAdapter.parse('1.1', now)).to.be.null;
     let formattedDate = nativeDateAdapter.parse('1/1/2000', now)!;
     expect(formattedDate.getFullYear()).to.be.equal(2000);
     expect(formattedDate.getMonth()).to.be.equal(0);

--- a/src/elements/core/datetime/native-date-adapter.ts
+++ b/src/elements/core/datetime/native-date-adapter.ts
@@ -173,9 +173,9 @@ export class NativeDateAdapter extends DateAdapter<Date> {
   }
 
   /** Returns the right format for the `valueAsDate` property. */
-  public parse(value: string | null | undefined, now: Date): Date | undefined {
+  public parse(value: string | null | undefined, now: Date): Date | null {
     if (!value) {
-      return undefined;
+      return null;
     }
 
     const strippedValue = value.replace(/\D/g, ' ').trim();
@@ -188,7 +188,7 @@ export class NativeDateAdapter extends DateAdapter<Date> {
       match.some((e) => e === undefined) ||
       !this.isValid(this.createDate(+match[3], +match[2], +match[1]))
     ) {
-      return undefined;
+      return null;
     }
 
     let year = +match[3];

--- a/src/elements/datepicker/datepicker-next-day/datepicker-next-day.ts
+++ b/src/elements/datepicker/datepicker-next-day/datepicker-next-day.ts
@@ -4,10 +4,10 @@ import { customElement } from 'lit/decorators.js';
 import { hostAttributes } from '../../core/decorators.js';
 import { i18nNextDay, i18nSelectNextDay } from '../../core/i18n.js';
 import { SbbDatepickerButton } from '../common.js';
-import { findNextAvailableDate, type SbbInputUpdateEvent } from '../datepicker.js';
+
+import style from './datepicker-next-day.scss?lit&inline';
 
 import '../../icon.js';
-import style from './datepicker-next-day.scss?lit&inline';
 
 /**
  * Combined with a `sbb-datepicker`, it can be used to move the date ahead.
@@ -23,13 +23,10 @@ class SbbDatepickerNextDayElement<T = Date> extends SbbDatepickerButton<T> {
   protected iconName: string = 'chevron-small-right-small';
   protected i18nOffBoundaryDay: Record<string, string> = i18nNextDay;
   protected i18nSelectOffBoundaryDay = i18nSelectNextDay;
-  protected findAvailableDate = findNextAvailableDate;
 
-  protected onInputUpdated(event: CustomEvent<SbbInputUpdateEvent>): void {
-    if (this.boundary !== event.detail.max) {
-      this.boundary = event.detail.max!;
-      this.setDisabledState(this.datePickerElement!);
-    }
+  protected findAvailableDate(date: T): T {
+    // When calling findAvailableDate, datepickerElement is always defined.
+    return this.datePickerElement!.findNextAvailableDate(date);
   }
 }
 

--- a/src/elements/datepicker/datepicker-previous-day/datepicker-previous-day.ts
+++ b/src/elements/datepicker/datepicker-previous-day/datepicker-previous-day.ts
@@ -4,10 +4,10 @@ import { customElement } from 'lit/decorators.js';
 import { hostAttributes } from '../../core/decorators.js';
 import { i18nPreviousDay, i18nSelectPreviousDay } from '../../core/i18n.js';
 import { SbbDatepickerButton } from '../common.js';
-import { findPreviousAvailableDate, type SbbInputUpdateEvent } from '../datepicker.js';
-import '../../icon.js';
 
 import style from './datepicker-previous-day.scss?lit&inline';
+
+import '../../icon.js';
 
 /**
  * Combined with a `sbb-datepicker`, it can be used to move the date back.
@@ -23,13 +23,10 @@ class SbbDatepickerPreviousDayElement<T = Date> extends SbbDatepickerButton<T> {
   protected iconName: string = 'chevron-small-left-small';
   protected i18nOffBoundaryDay: Record<string, string> = i18nPreviousDay;
   protected i18nSelectOffBoundaryDay = i18nSelectPreviousDay;
-  protected findAvailableDate = findPreviousAvailableDate;
 
-  protected onInputUpdated(event: CustomEvent<SbbInputUpdateEvent>): void {
-    if (this.boundary !== event.detail.min) {
-      this.boundary = event.detail.min!;
-      this.setDisabledState(this.datePickerElement!);
-    }
+  protected findAvailableDate(date: T): T {
+    // When calling findAvailableDate, datepickerElement is always defined.
+    return this.datePickerElement!.findPreviousAvailableDate(date);
   }
 }
 

--- a/src/elements/datepicker/datepicker/datepicker.spec.ts
+++ b/src/elements/datepicker/datepicker/datepicker.spec.ts
@@ -2,9 +2,7 @@ import { assert, expect } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import type { TemplateResult } from 'lit';
 import { html } from 'lit/static-html.js';
-import type { Context } from 'mocha';
 
-import { NativeDateAdapter } from '../../core/datetime.js';
 import { findInput } from '../../core/dom.js';
 import { i18nDateChangedTo } from '../../core/i18n.js';
 import { fixture, tabKey, typeInElement } from '../../core/testing/private.js';
@@ -13,14 +11,7 @@ import type { SbbFormFieldElement } from '../../form-field.js';
 import type { SbbDatepickerNextDayElement } from '../datepicker-next-day.js';
 import type { SbbDatepickerPreviousDayElement } from '../datepicker-previous-day.js';
 
-import {
-  findNextAvailableDate,
-  findPreviousAvailableDate,
-  getAvailableDate,
-  getDatePicker,
-  isDateAvailable,
-  SbbDatepickerElement,
-} from './datepicker.js';
+import { getDatePicker, SbbDatepickerElement } from './datepicker.js';
 
 import '../../form-field.js';
 import '../datepicker-previous-day.js';
@@ -89,7 +80,7 @@ describe(`sbb-datepicker`, () => {
         );
       });
 
-      it('renders and emit event on value change', async function (this: Context) {
+      it('renders and emit event on value change', async () => {
         const changeSpy = new EventSpy('change', element);
         typeInElement(input, '20/01/2023');
         button.focus();
@@ -98,7 +89,7 @@ describe(`sbb-datepicker`, () => {
         expect(changeSpy.count).to.be.equal(1);
       });
 
-      it('renders and interpret two digit year correctly in 2000s', async function (this: Context) {
+      it('renders and interpret two digit year correctly in 2000s', async () => {
         const changeSpy = new EventSpy('change', element);
         typeInElement(input, '20/01/12');
         button.focus();
@@ -107,7 +98,7 @@ describe(`sbb-datepicker`, () => {
         expect(changeSpy.count).to.be.equal(1);
       });
 
-      it('renders and interpret two digit year correctly in 1900s', async function (this: Context) {
+      it('renders and interpret two digit year correctly in 1900s', async () => {
         const changeSpy = new EventSpy('change', element);
         typeInElement(input, '20/01/99');
         button.focus();
@@ -171,33 +162,6 @@ describe(`sbb-datepicker`, () => {
         expect(datePickerUpdatedSpy.count).to.be.equal(2);
       });
 
-      it('renders and interprets date with custom parse and format functions', async () => {
-        const changeSpy = new EventSpy('change', element);
-
-        element.dateParser = (s) => {
-          s = s.replace(/\D/g, ' ').trim();
-          const date = s.split(' ');
-          const now = new Date(2023, 8, 15, 0, 0, 0, 0);
-          return new Date(now.getFullYear(), +date[1] - 1, +date[0]);
-        };
-        element.format = (d) => {
-          //Intl.DateTimeFormat API is not available in test environment.
-          const weekdays = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
-          const weekday = weekdays[d.getDay()];
-          const date = `${String(d.getDate()).padStart(2, '0')}.${String(d.getMonth() + 1).padStart(
-            2,
-            '0',
-          )}`;
-          return `${weekday}, ${date}`;
-        };
-        await waitForLitRender(element);
-        typeInElement(input, '7.8', { key: 'Enter', keyCode: 13 });
-        await changeSpy.calledOnce();
-        await waitForLitRender(element);
-        expect(input.value).to.be.equal('Mo, 07.08');
-        expect(changeSpy.count).to.be.equal(1);
-      });
-
       it('should emit validation change event', async () => {
         let validationChangeSpy = new EventSpy('validationChange', element);
 
@@ -231,7 +195,7 @@ describe(`sbb-datepicker`, () => {
         expect(input).not.to.have.attribute('data-sbb-invalid');
       });
 
-      it('should interpret valid values and set accessibility labels', async function (this: Context) {
+      it('should interpret valid values and set accessibility labels', async () => {
         const testCases = [
           {
             value: '5.5.0',
@@ -293,7 +257,7 @@ describe(`sbb-datepicker`, () => {
         }
       });
 
-      it('should not touch invalid values', async function (this: Context) {
+      it('should not touch invalid values', async () => {
         const testCases = [
           { value: '.12.2020', interpretedAs: '.12.2020' },
           { value: '24..1995', interpretedAs: '24..1995' },
@@ -338,6 +302,170 @@ describe(`sbb-datepicker`, () => {
           <button></button>
         </div>
       `);
+    });
+
+    describe('date validation', () => {
+      let formField: SbbFormFieldElement;
+      let datePicker: SbbDatepickerElement;
+      let input: HTMLInputElement;
+
+      beforeEach(async () => {
+        formField = await fixture(
+          html`<sbb-form-field>
+            <sbb-datepicker></sbb-datepicker>
+            <input id="datepicker-input" />
+          </sbb-form-field>`,
+        );
+
+        datePicker = formField.querySelector('sbb-datepicker')!;
+        input = formField.querySelector('input')!;
+      });
+
+      describe(`findPreviousAvailableDate`, () => {
+        it('get date without dateFilter and without min', async () => {
+          const availableDate: Date = datePicker.findPreviousAvailableDate(
+            new Date(2023, 1, 26, 0, 0, 0, 0),
+          );
+          expect(availableDate.getTime()).to.equal(new Date(2023, 1, 25, 0, 0, 0, 0).getTime());
+        });
+
+        it('get date without dateFilter and with current date equal to min date', async () => {
+          const date = new Date(2023, 1, 26, 0, 0, 0, 0);
+          input.min = String(date.valueOf() / 1000);
+          const availableDate: Date = datePicker.findPreviousAvailableDate(date);
+          expect(availableDate.getTime()).to.equal(date.getTime());
+        });
+
+        it('get date with dateFilter and min', async () => {
+          const minDate = new Date(2023, 1, 26, 0, 0, 0, 0);
+
+          datePicker.dateFilter = (d: Date | null) => d?.getDate() !== 27;
+          input.min = String(minDate.valueOf() / 1000);
+
+          const availableDate: Date = datePicker.findPreviousAvailableDate(
+            new Date(2023, 1, 28, 0, 0, 0, 0),
+          );
+          expect(availableDate.getTime()).to.equal(minDate.getTime());
+        });
+      });
+
+      describe(`findNextAvailableDate`, () => {
+        it('get date without max and without dateFilter', async () => {
+          const availableDate: Date = datePicker.findNextAvailableDate(
+            new Date(2023, 1, 26, 0, 0, 0, 0),
+          );
+          expect(availableDate.getTime()).to.equal(new Date(2023, 1, 27, 0, 0, 0, 0).getTime());
+        });
+
+        it('get date without dateFilter with current date equal to max date', async () => {
+          const date: Date = new Date(2023, 1, 26, 0, 0, 0, 0);
+          input.max = String(date.valueOf() / 1000);
+          const availableDate: Date = datePicker.findNextAvailableDate(date);
+          expect(availableDate.getTime()).to.equal(date.getTime());
+        });
+
+        it('get date with dateFilter and max', async () => {
+          const maxDate = new Date(2023, 1, 28, 0, 0, 0, 0);
+
+          datePicker.dateFilter = (d: Date | null) => d?.getDate() !== 27;
+          input.min = String(maxDate.valueOf() / 1000);
+
+          const availableDate: Date = datePicker.findNextAvailableDate(
+            new Date(2023, 1, 26, 0, 0, 0, 0),
+          );
+          expect(availableDate.getTime()).to.equal(maxDate.getTime());
+        });
+      });
+
+      describe(`validation`, () => {
+        describe('invalid', () => {
+          it('get invalid date with min', async () => {
+            input.min = new Date('2023-02-26').toISOString();
+            await waitForLitRender(formField);
+
+            typeInElement(input, '20.02.2023');
+            input.blur();
+            await waitForLitRender(formField);
+
+            expect(input.value).to.be.equal('Mo, 20.02.2023');
+            expect(input).to.have.attribute('data-sbb-invalid');
+          });
+
+          it('get invalid date with max', async () => {
+            input.max = new Date('2023-02-26').toISOString();
+            await waitForLitRender(formField);
+
+            typeInElement(input, '28.02.2023');
+            input.blur();
+            await waitForLitRender(formField);
+
+            expect(input.value).to.be.equal('Tu, 28.02.2023');
+            expect(input).to.have.attribute('data-sbb-invalid');
+          });
+
+          it('get invalid date with dateFilter', async () => {
+            datePicker.dateFilter = (d: Date | null) =>
+              d!.getTime() > new Date('2024-12-31').valueOf();
+            await waitForLitRender(formField);
+
+            typeInElement(input, '28.02.2023');
+            input.blur();
+            await waitForLitRender(formField);
+
+            expect(input.value).to.be.equal('Tu, 28.02.2023');
+            expect(input).to.have.attribute('data-sbb-invalid');
+          });
+        });
+
+        describe('valid', () => {
+          it('get valid date without dateFilter, min and max', async () => {
+            typeInElement(input, '25.02.2023');
+            input.blur();
+            await waitForLitRender(formField);
+
+            expect(input.value).to.be.equal('Sa, 25.02.2023');
+            expect(input).not.to.have.attribute('data-sbb-invalid');
+          });
+
+          it('get valid date with min', async () => {
+            input.min = new Date('2023-02-01').toISOString();
+            await waitForLitRender(formField);
+
+            typeInElement(input, '20.02.2023');
+            input.blur();
+            await waitForLitRender(formField);
+
+            expect(input.value).to.be.equal('Mo, 20.02.2023');
+            expect(input).not.to.have.attribute('data-sbb-invalid');
+          });
+
+          it('get valid date with max', async () => {
+            input.max = new Date('2023-03-31').toISOString();
+            await waitForLitRender(formField);
+
+            typeInElement(input, '28.02.2023');
+            input.blur();
+            await waitForLitRender(formField);
+
+            expect(input.value).to.be.equal('Tu, 28.02.2023');
+            expect(input).not.to.have.attribute('data-sbb-invalid');
+          });
+
+          it('get invalid date with dateFilter', async () => {
+            datePicker.dateFilter = (d: Date | null) =>
+              d!.getTime() > new Date('2022-01-01').valueOf();
+            await waitForLitRender(formField);
+
+            typeInElement(input, '28.02.2023');
+            input.blur();
+
+            await waitForLitRender(formField);
+
+            expect(input.value).to.be.equal('Tu, 28.02.2023');
+            expect(input).not.to.have.attribute('data-sbb-invalid');
+          });
+        });
+      });
     });
   });
 
@@ -398,172 +526,6 @@ describe(`sbb-datepicker`, () => {
         page.querySelector<SbbDatepickerElement>('sbb-datepicker')!;
       const input: HTMLInputElement = page.querySelector<HTMLInputElement>('input')!;
       expect(findInput(picker, 'input')).to.equal(input);
-    });
-  });
-
-  describe(`getAvailableDate`, () => {
-    it('with dateFilter', async () => {
-      const availableDate: Date = getAvailableDate(
-        new Date(2024, 0, 1, 0, 0, 0, 0),
-        1,
-        (d: Date) => d.getDay() === 1,
-        new NativeDateAdapter(),
-      );
-      expect(availableDate.getTime()).to.equal(new Date(2024, 0, 8, 0, 0, 0, 0).getTime());
-    });
-
-    it('without dateFilter', async () => {
-      const availableDate: Date = getAvailableDate(
-        new Date(2024, 0, 1, 0, 0, 0, 0),
-        1,
-        () => true,
-        new NativeDateAdapter(),
-      );
-      expect(availableDate.getTime()).to.equal(new Date(2024, 0, 2, 0, 0, 0, 0).getTime());
-    });
-  });
-
-  describe(`findPreviousAvailableDate`, () => {
-    it('get date without dateFilter and without min', async () => {
-      const availableDate: Date = findPreviousAvailableDate(
-        new Date(2023, 1, 26, 0, 0, 0, 0),
-        null,
-        new NativeDateAdapter(),
-        null,
-      );
-      expect(availableDate.getTime()).to.equal(new Date(2023, 1, 25, 0, 0, 0, 0).getTime());
-    });
-
-    it('get date without dateFilter and with current date equal to min date', async () => {
-      const date = new Date(2023, 1, 26, 0, 0, 0, 0);
-      const availableDate: Date = findPreviousAvailableDate(
-        date,
-        null,
-        new NativeDateAdapter(),
-        date.valueOf() / 1000,
-      );
-      expect(availableDate.getTime()).to.equal(date.getTime());
-    });
-
-    it('get date with dateFilter and min', async () => {
-      const minDate = new Date(2023, 1, 26, 0, 0, 0, 0);
-      const availableDate: Date = findPreviousAvailableDate(
-        new Date(2023, 1, 28, 0, 0, 0, 0),
-        (d: Date) => d.getDate() !== 27,
-        new NativeDateAdapter(),
-        minDate.valueOf() / 1000,
-      );
-      expect(availableDate.getTime()).to.equal(minDate.getTime());
-    });
-  });
-
-  describe(`findNextAvailableDate`, () => {
-    it('get date without max and without dateFilter', async () => {
-      const availableDate: Date = findNextAvailableDate(
-        new Date(2023, 1, 26, 0, 0, 0, 0),
-        null,
-        new NativeDateAdapter(),
-        null,
-      );
-      expect(availableDate.getTime()).to.equal(new Date(2023, 1, 27, 0, 0, 0, 0).getTime());
-    });
-
-    it('get date without dateFilter with current date equal to max date', async () => {
-      const date: Date = new Date(2023, 1, 26, 0, 0, 0, 0);
-      const availableDate: Date = findNextAvailableDate(
-        date,
-        null,
-        new NativeDateAdapter(),
-        date.valueOf() / 1000,
-      );
-      expect(availableDate.getTime()).to.equal(date.getTime());
-    });
-
-    it('get date with dateFilter and max', async () => {
-      const maxDate = new Date(2023, 1, 28, 0, 0, 0, 0);
-      const availableDate: Date = findNextAvailableDate(
-        new Date(2023, 1, 26, 0, 0, 0, 0),
-        (d: Date) => d.getDate() !== 27,
-        new NativeDateAdapter(),
-        maxDate.valueOf() / 1000,
-      );
-      expect(availableDate.getTime()).to.equal(maxDate.getTime());
-    });
-  });
-
-  describe(`isDateAvailable`, () => {
-    describe('invalid', () => {
-      it('get invalid date with min', async () => {
-        expect(
-          isDateAvailable(
-            new Date('2023-02-20'),
-            null,
-            new Date('2023-02-26').valueOf() / 1000,
-            null,
-          ),
-        ).to.be.false;
-      });
-
-      it('get invalid date with max', async () => {
-        expect(
-          isDateAvailable(
-            new Date('2023-02-28'),
-            null,
-            null,
-            new Date('2023-02-26').valueOf() / 1000,
-          ),
-        ).to.be.false;
-      });
-
-      it('get invalid date with dateFilter', async () => {
-        expect(
-          isDateAvailable(
-            new Date('2023-02-28'),
-            (d: Date) => d.getTime() > new Date('2024-12-31').valueOf(),
-            null,
-            null,
-          ),
-        ).to.be.false;
-      });
-    });
-
-    describe('valid', function () {
-      it('get valid date without dateFilter, min and max', async () => {
-        expect(isDateAvailable(new Date('2023-02-25'), null, null, null)).to.be.true;
-      });
-
-      it('get valid date with min', async () => {
-        expect(
-          isDateAvailable(
-            new Date('2023-02-20'),
-            null,
-            new Date('2023-02-01').valueOf() / 1000,
-            null,
-          ),
-        ).to.be.true;
-      });
-
-      it('get valid date with max', async () => {
-        expect(
-          isDateAvailable(
-            new Date('2023-02-28'),
-            null,
-            null,
-            new Date('2023-03-31').valueOf() / 1000,
-          ),
-        ).to.be.true;
-      });
-
-      it('get invalid date with dateFilter', async () => {
-        expect(
-          isDateAvailable(
-            new Date('2023-02-28'),
-            (d: Date) => d.getTime() > new Date('2022-01-01').valueOf(),
-            null,
-            null,
-          ),
-        ).to.be.true;
-      });
     });
   });
 });

--- a/src/elements/datepicker/datepicker/datepicker.stories.ts
+++ b/src/elements/datepicker/datepicker/datepicker.stories.ts
@@ -118,44 +118,6 @@ const dateFilter: InputType = {
   },
 };
 
-const handlingFunctions = [
-  { dateParser: undefined, format: undefined },
-  {
-    dateParser: (s: string) => new Date(s),
-    format: (d: Date) =>
-      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
-        d.getDate(),
-      ).padStart(2, '0')}`,
-  },
-  {
-    dateParser: (s: string) =>
-      new Date(+s.substring(4, s.length), +s.substring(2, 4) - 1, +s.substring(0, 2)),
-    format: (d: Date) =>
-      `${String(d.getDate()).padStart(2, '0')}${String(d.getMonth() + 1).padStart(
-        2,
-        '0',
-      )}${d.getFullYear()}`,
-  },
-];
-const dateHandling: InputType = {
-  name: 'Date Handling',
-  description:
-    'Change the default date handling option with a combination of `dateParser` and `format` properties.',
-  options: Object.keys(filterFunctions),
-  mapping: handlingFunctions,
-  control: {
-    type: 'select',
-    labels: {
-      0: 'Default',
-      1: 'ISO String (YYYY-MM-DD)',
-      2: 'Business (DDMMYY)',
-    },
-  },
-  table: {
-    category: 'Datepicker attribute',
-  },
-};
-
 const ariaLabel: InputType = {
   control: {
     type: 'text',
@@ -230,7 +192,6 @@ const basicArgTypes: ArgTypes = {
   max,
   wide,
   dateFilter,
-  dateHandling,
   now,
   'aria-label': ariaLabel,
 };
@@ -245,7 +206,6 @@ const basicArgs: Args = {
   max: undefined,
   wide: false,
   dateFilter: dateFilter.options![0],
-  dateHandling: dateHandling.options![0],
   now: undefined,
   'aria-label': undefined,
 };
@@ -318,7 +278,6 @@ const TemplateFormField = ({
   negative,
   wide,
   dateFilter,
-  dateHandling,
   now,
   ...args
 }: Args): TemplateResult => {
@@ -341,8 +300,6 @@ const TemplateFormField = ({
       />
       <sbb-datepicker
         .dateFilter=${dateFilter}
-        .dateParser=${dateHandling.dateParser}
-        .format=${dateHandling.format}
         ?wide=${wide}
         @change=${(event: Event) => changeEventHandler(event)}
         now=${convertMillisecondsToSeconds(now)}
@@ -413,12 +370,6 @@ export const InFormFieldWithDateFilter: StoryObj = {
   render: TemplateFormField,
   argTypes: { ...formFieldBasicArgsTypes },
   args: { ...formFieldBasicArgs, dateFilter: dateFilter.options![1] },
-};
-
-export const InFormFieldWithDateParser: StoryObj = {
-  render: TemplateFormField,
-  argTypes: { ...formFieldBasicArgsTypes },
-  args: { ...formFieldBasicArgs, value: '2023-02-12', dateHandling: dateHandling.options![1] },
 };
 
 export const InFormFieldSmall: StoryObj = {

--- a/src/elements/datepicker/datepicker/readme.md
+++ b/src/elements/datepicker/datepicker/readme.md
@@ -56,43 +56,11 @@ current value (e.g. from `event.target.valueAsDate`) or to set the value program
 When the `valueAsDate` property is programmatically assigned, a `blur` event is fired on the input
 to ensure compatibility with any framework that relies on that event to update the current state.
 
-## Custom date formats
+## Custom current date
 
 To simulate the current date, you can use the `now` property,
 which accepts a `Date` or a timestamp in seconds (as number or string).
 This is helpful if you need a specific state of the component.
-
-Using a combination of the `dateParser` and `format` properties, it's possible to configure the datepicker
-to accept date formats other than the default `EE, dd.mm.yyyy`.
-In the following example the datepicker is set to accept dates in the format `yyyy-mm-dd`.
-In particular, `dateParser` is the function that the component uses internally to decode strings and parse them into `Date` objects,
-while the `format` function is the one that the component uses internally to display a given `Date` object as a string.
-
-```ts
-// datePicker is a SbbDatepickerElement element
-datePicker.dateParser = (value: string) => {
-  // You should implement some kind of input validation
-  if (!value || !isValid(value)) {
-    return undefined;
-  }
-
-  return new Date(value);
-};
-
-datePicker.format = (value: Date) => {
-  if (!value) {
-    return '';
-  }
-
-  const offset = value.getTimezoneOffset();
-  value = new Date(yourDate.getTime() - offset * 60 * 1000);
-  return yourDate.toISOString().split('T')[0];
-};
-```
-
-Usually these functions need to be changed together, although in simple cases where the default `dateParser` might still work properly
-(e.g., in case we wanted to accept the format `dd.mm.yyyy`), it's possible to provide just the `format` function.
-For custom `format` functions is recommended to use the `Intl.DateTimeFormat` API, as it's done in the default implementation.
 
 <!-- TODO: add date adapter configuration documentation -->
 


### PR DESCRIPTION
BREAKING CHANGE: This refactoring introduces multiple breaking changes to the datepicker:
- DateAdapter: return value for invalid dates changed from undefined to null
- Datepicker: removed functions `getAvailableDate()` and `isDateAvailable()`
- Datepicker: moved functions `findPreviousAvailableDate()` and `findNextAvailableDate()` into `SbbDatepickerElement` and removed all params but `date`
- Datepicker: removed properties `dateParser` and `format`, as alternative use custom DateAdapter
- Datepicker: `now` property newly accepts `null` instead of `undefined`
- Datepicker: removed methods `getValueAsDate()` and  `setValueAsDate()`. Use getter/setter `valueAsDate` instead.