### PR TITLE
fix: fix mixin due to wrong manifest generation

### DIFF
--- a/src/elements/core/mixins/form-associated-mixin.ts
+++ b/src/elements/core/mixins/form-associated-mixin.ts
@@ -3,7 +3,7 @@ import { property, state } from 'lit/decorators.js';
 
 import type { AbstractConstructor } from './constructor.js';
 
-export declare abstract class SbbFormAssociatedMixinType<V = string> extends LitElement {
+export declare abstract class SbbFormAssociatedMixinType<V = string> {
   public get form(): HTMLFormElement | null;
   public get name(): string;
   public set name(value: string);

--- a/src/elements/radio-button/common/radio-button-common.spec.ts
+++ b/src/elements/radio-button/common/radio-button-common.spec.ts
@@ -604,7 +604,9 @@ describe(`radio-button common behaviors`, () => {
             });
 
             it('should be sorted in DOM order', async () => {
-              const group1Set = radioButtonRegistry.get(form)!.get('sbb-group-1')!;
+              const group1Set = radioButtonRegistry
+                .get(form)!
+                .get('sbb-group-1')! as unknown as Set<Element>;
               let group1Radios = Array.from(form.querySelectorAll(selector));
 
               // Assert the order is the correct

--- a/src/elements/radio-button/radio-button-panel/radio-button-panel.ts
+++ b/src/elements/radio-button/radio-button-panel/radio-button-panel.ts
@@ -12,7 +12,6 @@ import { getOverride, slotState } from '../../core/decorators.js';
 import { isLean } from '../../core/dom.js';
 import {
   panelCommonStyle,
-  type SbbFormAssociatedRadioButtonMixinType,
   SbbPanelMixin,
   type SbbPanelSize,
   SbbUpdateSchedulerMixin,
@@ -87,9 +86,7 @@ class SbbRadioButtonPanelElement extends SbbPanelMixin(
   /**
    * As an exception, radio-panels with an expansion-panel attached are not checked automatically when navigating by keyboard
    */
-  protected override async navigateByKeyboard(
-    next: SbbFormAssociatedRadioButtonMixinType,
-  ): Promise<void> {
+  protected override async navigateByKeyboard(next: SbbRadioButtonPanelElement): Promise<void> {
     if (!this._hasSelectionExpansionPanelElement) {
       await super.navigateByKeyboard(next);
     } else {


### PR DESCRIPTION
During the generation of the Angular classes in the new repo, the SbbFormAssociatedMixinType is marked with `customElement: true`, which breaks some logic.