### PR TITLE
fix: display non bubbling events in storybook actions

### DIFF
--- a/src/elements/overlay/overlay-base-element.ts
+++ b/src/elements/overlay/overlay-base-element.ts
@@ -29,6 +29,7 @@ abstract class SbbOverlayBaseElement extends SbbNegativeMixin(SbbOpenCloseBaseEl
   protected override didClose: EventEmitter<SbbOverlayCloseEventDetails> = new EventEmitter(
     this,
     SbbOverlayBaseElement.events.didClose,
+    { cancelable: true },
   );
 
   // The last element which had focus before the component was opened.


### PR DESCRIPTION
Closes #3354 