### PR TITLE
test(sbb-navigation): fix popover visual spec

### DIFF
--- a/src/elements/navigation/navigation-section/navigation-section.visual.spec.ts
+++ b/src/elements/navigation/navigation-section/navigation-section.visual.spec.ts
@@ -44,9 +44,12 @@ describe(`sbb-navigation-section`, () => {
           `,
           { padding: '0' },
         );
-        setup.withPostSetupAction(() =>
-          setup.snapshotElement.querySelector<SbbNavigationElement>('sbb-navigation')!.open(),
+
+        setup.withSnapshotElement(
+          setup.snapshotElement.querySelector<SbbNavigationElement>('sbb-navigation')!,
         );
+
+        setup.withPostSetupAction(() => (setup.snapshotElement as SbbNavigationElement).open());
       }),
     );
   });

--- a/src/elements/navigation/navigation/navigation.visual.spec.ts
+++ b/src/elements/navigation/navigation/navigation.visual.spec.ts
@@ -29,9 +29,12 @@ describe(`sbb-navigation`, () => {
           `,
           { padding: '0' },
         );
-        setup.withPostSetupAction(() =>
-          setup.snapshotElement.querySelector<SbbNavigationElement>('sbb-navigation')!.open(),
+
+        setup.withSnapshotElement(
+          setup.snapshotElement.querySelector<SbbNavigationElement>('sbb-navigation')!,
         );
+
+        setup.withPostSetupAction(() => (setup.snapshotElement as SbbNavigationElement).open());
       }),
     );
   });


### PR DESCRIPTION
I do not have a proper explanation of for the problem we're having.

In general, it seems that the `visuaDiff` tool is not able to take a screenshot of an element market as `popover` (It says that it is not attached to the DOM)

For the `sbb-navigation` the case is the exact opposite. If I take a snapshot of the default element (which is the parent of the template) I get the "not attached to DOM" error. 
On the contrary, if I set the snapshotElement as the `sbb-navigation` it does not complain

Test made locally on `navigation.visual.spec` and `dialog.visual.spec`