### PR TITLE
refactor(sbb-title, sbb-dialog-title): remove obsolete h1-h6 tags

### DIFF
--- a/src/elements/dialog/dialog-title/__snapshots__/dialog-title.snapshot.spec.snap.js
+++ b/src/elements/dialog/dialog-title/__snapshots__/dialog-title.snapshot.spec.snap.js
@@ -15,13 +15,10 @@ snapshots["sbb-dialog-title renders Light DOM"] =
 
 snapshots["sbb-dialog-title renders Shadow DOM"] = 
 `<div class="sbb-dialog__header">
-  <h2
-    class="sbb-title"
-    role="presentation"
-  >
+  <div class="sbb-title">
     <slot>
     </slot>
-  </h2>
+  </div>
   <sbb-secondary-button
     aria-label="Close secondary window"
     class="sbb-dialog__close"

--- a/src/elements/title/__snapshots__/title.snapshot.spec.snap.js
+++ b/src/elements/title/__snapshots__/title.snapshot.spec.snap.js
@@ -14,13 +14,10 @@ snapshots["sbb-title renders DOM"] =
 /* end snapshot sbb-title renders DOM */
 
 snapshots["sbb-title renders Shadow DOM"] = 
-`<h1
-  class="sbb-title"
-  role="presentation"
->
+`<div class="sbb-title">
   <slot>
   </slot>
-</h1>
+</div>
 `;
 /* end snapshot sbb-title renders Shadow DOM */
 

--- a/src/elements/title/title-base.ts
+++ b/src/elements/title/title-base.ts
@@ -1,7 +1,7 @@
 import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
-import { html, unsafeStatic } from 'lit/static-html.js';
+import { html } from 'lit/static-html.js';
 
 import { forceType, hostAttributes } from '../core/decorators.js';
 import { SbbNegativeMixin } from '../core/mixins.js';
@@ -47,14 +47,10 @@ abstract class SbbTitleBase extends SbbNegativeMixin(LitElement) {
   }
 
   protected override render(): TemplateResult {
-    const TAGNAME = `h${this.level}`;
-
-    /* eslint-disable lit/binding-positions */
     return html`
-      <${unsafeStatic(TAGNAME)} class="sbb-title" role="presentation">
+      <div class="sbb-title">
         <slot></slot>
-      </${unsafeStatic(TAGNAME)}>
+      </div>
     `;
-    /* eslint-enable lit/binding-positions */
   }
 }


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role#description

> Writing `<h2 role="presentation">Democracy Dies in Darkness</h2>` removes the heading semantics of the [h2](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) element, making it the equivalent of `<div>Democracy Dies in Darkness</div>`. The heading role semantics are removed, but the content itself is still available.
