### PR TITLE
fix(sbb-radio-button-group): prevent didChange emit from nested group

### DIFF
--- a/src/elements/radio-button/radio-button-group/radio-button-group.spec.ts
+++ b/src/elements/radio-button/radio-button-group/radio-button-group.spec.ts
@@ -267,5 +267,36 @@ import '../radio-button-panel.js';
         expect(element.value).to.equal('42');
       });
     });
+
+    describe('nested groups', () => {
+      let radios: (SbbRadioButtonElement | SbbRadioButtonPanelElement)[];
+
+      beforeEach(async () => {
+        /* eslint-disable lit/binding-positions */
+        element = await fixture(html`
+          <sbb-radio-button-group>
+            <sbb-radio-button-group>
+              <${tagSingle} id="sbb-radio-1" value="Value one">Value one</${tagSingle}>
+              <${tagSingle} id="sbb-radio-2" value="Value two">Value two</${tagSingle}>
+              <${tagSingle} id="sbb-radio-3" value="Value three" disabled>Value three</${tagSingle}>
+            </sbb-radio-button-group>
+          </sbb-radio-button-group>
+        `);
+        radios = Array.from(element.querySelectorAll(selector));
+
+        await waitForLitRender(element);
+      });
+
+      it('user interaction should have priority over group value', async () => {
+        const changeSpy = new EventSpy('change', element);
+        const didChangeSpy = new EventSpy('didChange', element);
+        radios[0].click();
+
+        await waitForLitRender(element);
+
+        await changeSpy.calledOnce();
+        await didChangeSpy.calledOnce();
+      });
+    });
   });
 });

--- a/src/elements/radio-button/radio-button-group/radio-button-group.ts
+++ b/src/elements/radio-button/radio-button-group/radio-button-group.ts
@@ -163,7 +163,10 @@ class SbbRadioButtonGroupElement extends SbbDisabledMixin(LitElement) {
     const target = event.target! as SbbRadioButtonElement | SbbRadioButtonPanelElement;
 
     // Only filter radio-buttons event
-    if (target.localName !== 'sbb-radio-button' && target.localName !== 'sbb-radio-button-panel') {
+    if (
+      (target.localName !== 'sbb-radio-button' && target.localName !== 'sbb-radio-button-panel') ||
+      target.group !== this
+    ) {
       return;
     }
 


### PR DESCRIPTION
Currently if there is a `change` from a radio button inside a radio button group that is nested in another radio button group, the outer radio button group also emits a `didChange` event. This fix checks whether the target of an event is actually directly contained in a group.