### PR TITLE
fix: provide `accessibility-current` property for link elements

### DIFF
--- a/src/elements/breadcrumb/breadcrumb-group/__snapshots__/breadcrumb-group.snapshot.spec.snap.js
+++ b/src/elements/breadcrumb/breadcrumb-group/__snapshots__/breadcrumb-group.snapshot.spec.snap.js
@@ -23,7 +23,7 @@ snapshots["sbb-breadcrumb-group renders DOM"] =
     One
   </sbb-breadcrumb>
   <sbb-breadcrumb
-    aria-current="page"
+    accessibility-current="page"
     data-action=""
     data-link=""
     href="https://example.com/one"

--- a/src/elements/breadcrumb/breadcrumb-group/breadcrumb-group.ts
+++ b/src/elements/breadcrumb/breadcrumb-group/breadcrumb-group.ts
@@ -115,9 +115,9 @@ class SbbBreadcrumbGroupElement extends SbbNamedSlotListMixin<
   private _syncBreadcrumbs(): void {
     this.listChildren
       .slice(0, -1)
-      .filter((c) => c.hasAttribute('aria-current'))
-      .forEach((c) => c.removeAttribute('aria-current'));
-    this.listChildren[this.listChildren.length - 1]?.setAttribute('aria-current', 'page');
+      .filter((c) => c.hasAttribute('accessibility-current'))
+      .forEach((c) => c.removeAttribute('accessibility-current'));
+    this.listChildren[this.listChildren.length - 1]?.setAttribute('accessibility-current', 'page');
 
     // If it is not expandable, reset state
     if (this.listChildren.length < MIN_BREADCRUMBS_TO_COLLAPSE) {

--- a/src/elements/breadcrumb/breadcrumb-group/readme.md
+++ b/src/elements/breadcrumb/breadcrumb-group/readme.md
@@ -21,7 +21,7 @@ Clicking on this `sbb-breadcrumb` will make the ellipsis disappear and will rest
 It is strongly recommended to place an `aria-label` attribute on the `sbb-breadcrumb-group`, as in the example above,
 to describe what context the breadcrumbs have.
 Whenever the `sbb-breadcrumb` list within the component is loaded or updated,
-the last element of the list receives the attribute `aria-current="page"`.
+the last element of the list receives the attribute `accessibility-current="page"`.
 
 <!-- Auto Generated Below -->
 

--- a/src/elements/breadcrumb/breadcrumb/readme.md
+++ b/src/elements/breadcrumb/breadcrumb/readme.md
@@ -30,23 +30,24 @@ It's possible to set all the link related properties (`download`, `href`, `rel` 
 
 ## Accessibility
 
-The `aria-current` property should be used to make the breadcrumb read correctly by screen-readers when the component
+The `accessibility-current` property should be used to make the breadcrumb read correctly by screen-readers when the component
 is used in the `sbb-breadcrumb-group`.
 
-By default, the `sbb-breadcrumb-group` component sets `aria-current="page"` on the last slotted `sbb-breadcrumb`.
+By default, the `sbb-breadcrumb-group` component sets `accessibility-current="page"` on the last slotted `sbb-breadcrumb`.
 
 <!-- Auto Generated Below -->
 
 ## Properties
 
-| Name                 | Attribute             | Privacy | Type                       | Default | Description                                                                                                                      |
-| -------------------- | --------------------- | ------- | -------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityLabel` | `accessibility-label` | public  | `string`                   | `''`    | This will be forwarded as aria-label to the inner anchor element.                                                                |
-| `download`           | `download`            | public  | `boolean`                  | `false` | Whether the browser will show the download dialog on click.                                                                      |
-| `href`               | `href`                | public  | `string`                   | `''`    | The href value you want to link to.                                                                                              |
-| `iconName`           | `icon-name`           | public  | `string`                   | `''`    | The icon name we want to use, choose from the small icon variants from the ui-icons category from here https://icons.app.sbb.ch. |
-| `rel`                | `rel`                 | public  | `string`                   | `''`    | The relationship of the linked URL as space-separated link types.                                                                |
-| `target`             | `target`              | public  | `LinkTargetType \| string` | `''`    | Where to display the linked URL.                                                                                                 |
+| Name                   | Attribute               | Privacy | Type                       | Default | Description                                                                                                                      |
+| ---------------------- | ----------------------- | ------- | -------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityCurrent` | `accessibility-current` | public  | `string`                   | `''`    | This will be forwarded as aria-current to the inner anchor element.                                                              |
+| `accessibilityLabel`   | `accessibility-label`   | public  | `string`                   | `''`    | This will be forwarded as aria-label to the inner anchor element.                                                                |
+| `download`             | `download`              | public  | `boolean`                  | `false` | Whether the browser will show the download dialog on click.                                                                      |
+| `href`                 | `href`                  | public  | `string`                   | `''`    | The href value you want to link to.                                                                                              |
+| `iconName`             | `icon-name`             | public  | `string`                   | `''`    | The icon name we want to use, choose from the small icon variants from the ui-icons category from here https://icons.app.sbb.ch. |
+| `rel`                  | `rel`                   | public  | `string`                   | `''`    | The relationship of the linked URL as space-separated link types.                                                                |
+| `target`               | `target`                | public  | `LinkTargetType \| string` | `''`    | Where to display the linked URL.                                                                                                 |
 
 ## Slots
 

--- a/src/elements/button/accent-button-link/readme.md
+++ b/src/elements/button/accent-button-link/readme.md
@@ -77,18 +77,19 @@ Use the accessibility properties in case of an icon-only button to describe the 
 
 ## Properties
 
-| Name                  | Attribute              | Privacy | Type                       | Default            | Description                                                                                                                      |
-| --------------------- | ---------------------- | ------- | -------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityLabel`  | `accessibility-label`  | public  | `string`                   | `''`               | This will be forwarded as aria-label to the inner anchor element.                                                                |
-| `disabled`            | `disabled`             | public  | `boolean`                  | `false`            | Whether the component is disabled.                                                                                               |
-| `disabledInteractive` | `disabled-interactive` | public  | `boolean`                  | `false`            | Whether the button should be aria-disabled but stay interactive.                                                                 |
-| `download`            | `download`             | public  | `boolean`                  | `false`            | Whether the browser will show the download dialog on click.                                                                      |
-| `href`                | `href`                 | public  | `string`                   | `''`               | The href value you want to link to.                                                                                              |
-| `iconName`            | `icon-name`            | public  | `string`                   | `''`               | The icon name we want to use, choose from the small icon variants from the ui-icons category from here https://icons.app.sbb.ch. |
-| `negative`            | `negative`             | public  | `boolean`                  | `false`            | Negative coloring variant flag.                                                                                                  |
-| `rel`                 | `rel`                  | public  | `string`                   | `''`               | The relationship of the linked URL as space-separated link types.                                                                |
-| `size`                | `size`                 | public  | `SbbButtonSize`            | `'l' / 's' (lean)` | Size variant, either l, m or s.                                                                                                  |
-| `target`              | `target`               | public  | `LinkTargetType \| string` | `''`               | Where to display the linked URL.                                                                                                 |
+| Name                   | Attribute               | Privacy | Type                       | Default            | Description                                                                                                                      |
+| ---------------------- | ----------------------- | ------- | -------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityCurrent` | `accessibility-current` | public  | `string`                   | `''`               | This will be forwarded as aria-current to the inner anchor element.                                                              |
+| `accessibilityLabel`   | `accessibility-label`   | public  | `string`                   | `''`               | This will be forwarded as aria-label to the inner anchor element.                                                                |
+| `disabled`             | `disabled`              | public  | `boolean`                  | `false`            | Whether the component is disabled.                                                                                               |
+| `disabledInteractive`  | `disabled-interactive`  | public  | `boolean`                  | `false`            | Whether the button should be aria-disabled but stay interactive.                                                                 |
+| `download`             | `download`              | public  | `boolean`                  | `false`            | Whether the browser will show the download dialog on click.                                                                      |
+| `href`                 | `href`                  | public  | `string`                   | `''`               | The href value you want to link to.                                                                                              |
+| `iconName`             | `icon-name`             | public  | `string`                   | `''`               | The icon name we want to use, choose from the small icon variants from the ui-icons category from here https://icons.app.sbb.ch. |
+| `negative`             | `negative`              | public  | `boolean`                  | `false`            | Negative coloring variant flag.                                                                                                  |
+| `rel`                  | `rel`                   | public  | `string`                   | `''`               | The relationship of the linked URL as space-separated link types.                                                                |
+| `size`                 | `size`                  | public  | `SbbButtonSize`            | `'l' / 's' (lean)` | Size variant, either l, m or s.                                                                                                  |
+| `target`               | `target`                | public  | `LinkTargetType \| string` | `''`               | Where to display the linked URL.                                                                                                 |
 
 ## Slots
 

--- a/src/elements/button/button-link/readme.md
+++ b/src/elements/button/button-link/readme.md
@@ -72,18 +72,19 @@ Use the accessibility properties in case of an icon-only button to describe the 
 
 ## Properties
 
-| Name                  | Attribute              | Privacy | Type                       | Default            | Description                                                                                                                      |
-| --------------------- | ---------------------- | ------- | -------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityLabel`  | `accessibility-label`  | public  | `string`                   | `''`               | This will be forwarded as aria-label to the inner anchor element.                                                                |
-| `disabled`            | `disabled`             | public  | `boolean`                  | `false`            | Whether the component is disabled.                                                                                               |
-| `disabledInteractive` | `disabled-interactive` | public  | `boolean`                  | `false`            | Whether the button should be aria-disabled but stay interactive.                                                                 |
-| `download`            | `download`             | public  | `boolean`                  | `false`            | Whether the browser will show the download dialog on click.                                                                      |
-| `href`                | `href`                 | public  | `string`                   | `''`               | The href value you want to link to.                                                                                              |
-| `iconName`            | `icon-name`            | public  | `string`                   | `''`               | The icon name we want to use, choose from the small icon variants from the ui-icons category from here https://icons.app.sbb.ch. |
-| `negative`            | `negative`             | public  | `boolean`                  | `false`            | Negative coloring variant flag.                                                                                                  |
-| `rel`                 | `rel`                  | public  | `string`                   | `''`               | The relationship of the linked URL as space-separated link types.                                                                |
-| `size`                | `size`                 | public  | `SbbButtonSize`            | `'l' / 's' (lean)` | Size variant, either l, m or s.                                                                                                  |
-| `target`              | `target`               | public  | `LinkTargetType \| string` | `''`               | Where to display the linked URL.                                                                                                 |
+| Name                   | Attribute               | Privacy | Type                       | Default            | Description                                                                                                                      |
+| ---------------------- | ----------------------- | ------- | -------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityCurrent` | `accessibility-current` | public  | `string`                   | `''`               | This will be forwarded as aria-current to the inner anchor element.                                                              |
+| `accessibilityLabel`   | `accessibility-label`   | public  | `string`                   | `''`               | This will be forwarded as aria-label to the inner anchor element.                                                                |
+| `disabled`             | `disabled`              | public  | `boolean`                  | `false`            | Whether the component is disabled.                                                                                               |
+| `disabledInteractive`  | `disabled-interactive`  | public  | `boolean`                  | `false`            | Whether the button should be aria-disabled but stay interactive.                                                                 |
+| `download`             | `download`              | public  | `boolean`                  | `false`            | Whether the browser will show the download dialog on click.                                                                      |
+| `href`                 | `href`                  | public  | `string`                   | `''`               | The href value you want to link to.                                                                                              |
+| `iconName`             | `icon-name`             | public  | `string`                   | `''`               | The icon name we want to use, choose from the small icon variants from the ui-icons category from here https://icons.app.sbb.ch. |
+| `negative`             | `negative`              | public  | `boolean`                  | `false`            | Negative coloring variant flag.                                                                                                  |
+| `rel`                  | `rel`                   | public  | `string`                   | `''`               | The relationship of the linked URL as space-separated link types.                                                                |
+| `size`                 | `size`                  | public  | `SbbButtonSize`            | `'l' / 's' (lean)` | Size variant, either l, m or s.                                                                                                  |
+| `target`               | `target`                | public  | `LinkTargetType \| string` | `''`               | Where to display the linked URL.                                                                                                 |
 
 ## Slots
 

--- a/src/elements/button/secondary-button-link/readme.md
+++ b/src/elements/button/secondary-button-link/readme.md
@@ -77,18 +77,19 @@ Use the accessibility properties in case of an icon-only button to describe the 
 
 ## Properties
 
-| Name                  | Attribute              | Privacy | Type                       | Default            | Description                                                                                                                      |
-| --------------------- | ---------------------- | ------- | -------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityLabel`  | `accessibility-label`  | public  | `string`                   | `''`               | This will be forwarded as aria-label to the inner anchor element.                                                                |
-| `disabled`            | `disabled`             | public  | `boolean`                  | `false`            | Whether the component is disabled.                                                                                               |
-| `disabledInteractive` | `disabled-interactive` | public  | `boolean`                  | `false`            | Whether the button should be aria-disabled but stay interactive.                                                                 |
-| `download`            | `download`             | public  | `boolean`                  | `false`            | Whether the browser will show the download dialog on click.                                                                      |
-| `href`                | `href`                 | public  | `string`                   | `''`               | The href value you want to link to.                                                                                              |
-| `iconName`            | `icon-name`            | public  | `string`                   | `''`               | The icon name we want to use, choose from the small icon variants from the ui-icons category from here https://icons.app.sbb.ch. |
-| `negative`            | `negative`             | public  | `boolean`                  | `false`            | Negative coloring variant flag.                                                                                                  |
-| `rel`                 | `rel`                  | public  | `string`                   | `''`               | The relationship of the linked URL as space-separated link types.                                                                |
-| `size`                | `size`                 | public  | `SbbButtonSize`            | `'l' / 's' (lean)` | Size variant, either l, m or s.                                                                                                  |
-| `target`              | `target`               | public  | `LinkTargetType \| string` | `''`               | Where to display the linked URL.                                                                                                 |
+| Name                   | Attribute               | Privacy | Type                       | Default            | Description                                                                                                                      |
+| ---------------------- | ----------------------- | ------- | -------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityCurrent` | `accessibility-current` | public  | `string`                   | `''`               | This will be forwarded as aria-current to the inner anchor element.                                                              |
+| `accessibilityLabel`   | `accessibility-label`   | public  | `string`                   | `''`               | This will be forwarded as aria-label to the inner anchor element.                                                                |
+| `disabled`             | `disabled`              | public  | `boolean`                  | `false`            | Whether the component is disabled.                                                                                               |
+| `disabledInteractive`  | `disabled-interactive`  | public  | `boolean`                  | `false`            | Whether the button should be aria-disabled but stay interactive.                                                                 |
+| `download`             | `download`              | public  | `boolean`                  | `false`            | Whether the browser will show the download dialog on click.                                                                      |
+| `href`                 | `href`                  | public  | `string`                   | `''`               | The href value you want to link to.                                                                                              |
+| `iconName`             | `icon-name`             | public  | `string`                   | `''`               | The icon name we want to use, choose from the small icon variants from the ui-icons category from here https://icons.app.sbb.ch. |
+| `negative`             | `negative`              | public  | `boolean`                  | `false`            | Negative coloring variant flag.                                                                                                  |
+| `rel`                  | `rel`                   | public  | `string`                   | `''`               | The relationship of the linked URL as space-separated link types.                                                                |
+| `size`                 | `size`                  | public  | `SbbButtonSize`            | `'l' / 's' (lean)` | Size variant, either l, m or s.                                                                                                  |
+| `target`               | `target`                | public  | `LinkTargetType \| string` | `''`               | Where to display the linked URL.                                                                                                 |
 
 ## Slots
 

--- a/src/elements/button/transparent-button-link/readme.md
+++ b/src/elements/button/transparent-button-link/readme.md
@@ -77,18 +77,19 @@ Use the accessibility properties in case of an icon-only button to describe the 
 
 ## Properties
 
-| Name                  | Attribute              | Privacy | Type                       | Default            | Description                                                                                                                      |
-| --------------------- | ---------------------- | ------- | -------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityLabel`  | `accessibility-label`  | public  | `string`                   | `''`               | This will be forwarded as aria-label to the inner anchor element.                                                                |
-| `disabled`            | `disabled`             | public  | `boolean`                  | `false`            | Whether the component is disabled.                                                                                               |
-| `disabledInteractive` | `disabled-interactive` | public  | `boolean`                  | `false`            | Whether the button should be aria-disabled but stay interactive.                                                                 |
-| `download`            | `download`             | public  | `boolean`                  | `false`            | Whether the browser will show the download dialog on click.                                                                      |
-| `href`                | `href`                 | public  | `string`                   | `''`               | The href value you want to link to.                                                                                              |
-| `iconName`            | `icon-name`            | public  | `string`                   | `''`               | The icon name we want to use, choose from the small icon variants from the ui-icons category from here https://icons.app.sbb.ch. |
-| `negative`            | `negative`             | public  | `boolean`                  | `false`            | Negative coloring variant flag.                                                                                                  |
-| `rel`                 | `rel`                  | public  | `string`                   | `''`               | The relationship of the linked URL as space-separated link types.                                                                |
-| `size`                | `size`                 | public  | `SbbButtonSize`            | `'l' / 's' (lean)` | Size variant, either l, m or s.                                                                                                  |
-| `target`              | `target`               | public  | `LinkTargetType \| string` | `''`               | Where to display the linked URL.                                                                                                 |
+| Name                   | Attribute               | Privacy | Type                       | Default            | Description                                                                                                                      |
+| ---------------------- | ----------------------- | ------- | -------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityCurrent` | `accessibility-current` | public  | `string`                   | `''`               | This will be forwarded as aria-current to the inner anchor element.                                                              |
+| `accessibilityLabel`   | `accessibility-label`   | public  | `string`                   | `''`               | This will be forwarded as aria-label to the inner anchor element.                                                                |
+| `disabled`             | `disabled`              | public  | `boolean`                  | `false`            | Whether the component is disabled.                                                                                               |
+| `disabledInteractive`  | `disabled-interactive`  | public  | `boolean`                  | `false`            | Whether the button should be aria-disabled but stay interactive.                                                                 |
+| `download`             | `download`              | public  | `boolean`                  | `false`            | Whether the browser will show the download dialog on click.                                                                      |
+| `href`                 | `href`                  | public  | `string`                   | `''`               | The href value you want to link to.                                                                                              |
+| `iconName`             | `icon-name`             | public  | `string`                   | `''`               | The icon name we want to use, choose from the small icon variants from the ui-icons category from here https://icons.app.sbb.ch. |
+| `negative`             | `negative`              | public  | `boolean`                  | `false`            | Negative coloring variant flag.                                                                                                  |
+| `rel`                  | `rel`                   | public  | `string`                   | `''`               | The relationship of the linked URL as space-separated link types.                                                                |
+| `size`                 | `size`                  | public  | `SbbButtonSize`            | `'l' / 's' (lean)` | Size variant, either l, m or s.                                                                                                  |
+| `target`               | `target`                | public  | `LinkTargetType \| string` | `''`               | Where to display the linked URL.                                                                                                 |
 
 ## Slots
 

--- a/src/elements/card/card-link/readme.md
+++ b/src/elements/card/card-link/readme.md
@@ -22,14 +22,15 @@ as it is used for search engines and screen-reader users.
 
 ## Properties
 
-| Name                 | Attribute             | Privacy | Type                       | Default | Description                                                       |
-| -------------------- | --------------------- | ------- | -------------------------- | ------- | ----------------------------------------------------------------- |
-| `accessibilityLabel` | `accessibility-label` | public  | `string`                   | `''`    | This will be forwarded as aria-label to the inner anchor element. |
-| `active`             | `active`              | public  | `boolean`                  | `false` | Whether the card is active.                                       |
-| `download`           | `download`            | public  | `boolean`                  | `false` | Whether the browser will show the download dialog on click.       |
-| `href`               | `href`                | public  | `string`                   | `''`    | The href value you want to link to.                               |
-| `rel`                | `rel`                 | public  | `string`                   | `''`    | The relationship of the linked URL as space-separated link types. |
-| `target`             | `target`              | public  | `LinkTargetType \| string` | `''`    | Where to display the linked URL.                                  |
+| Name                   | Attribute               | Privacy | Type                       | Default | Description                                                         |
+| ---------------------- | ----------------------- | ------- | -------------------------- | ------- | ------------------------------------------------------------------- |
+| `accessibilityCurrent` | `accessibility-current` | public  | `string`                   | `''`    | This will be forwarded as aria-current to the inner anchor element. |
+| `accessibilityLabel`   | `accessibility-label`   | public  | `string`                   | `''`    | This will be forwarded as aria-label to the inner anchor element.   |
+| `active`               | `active`                | public  | `boolean`                  | `false` | Whether the card is active.                                         |
+| `download`             | `download`              | public  | `boolean`                  | `false` | Whether the browser will show the download dialog on click.         |
+| `href`                 | `href`                  | public  | `string`                   | `''`    | The href value you want to link to.                                 |
+| `rel`                  | `rel`                   | public  | `string`                   | `''`    | The relationship of the linked URL as space-separated link types.   |
+| `target`               | `target`                | public  | `LinkTargetType \| string` | `''`    | Where to display the linked URL.                                    |
 
 ## Slots
 

--- a/src/elements/core/base-elements/link-base-element.spec.ts
+++ b/src/elements/core/base-elements/link-base-element.spec.ts
@@ -36,8 +36,23 @@ describe(`SbbLinkBaseElement`, () => {
     });
 
     it('check host attributes and content', () => {
-      expect(element.shadowRoot!.firstElementChild!.classList.contains('generic-link')).to.be.true;
+      const a = element.shadowRoot!.firstElementChild!;
+
+      expect(a.classList.contains('generic-link')).to.be.true;
+      expect(a.ariaLabel).to.be.null;
+      expect(a.ariaCurrent).to.be.null;
       expect(element.shadowRoot!.textContent!.trim()).to.be.equal('Link');
+    });
+
+    it('should forward accessibility labels', async () => {
+      const a = element.shadowRoot!.firstElementChild!;
+
+      element.accessibilityLabel = 'label';
+      element.accessibilityCurrent = 'page';
+      await waitForLitRender(element);
+
+      expect(a.ariaLabel).to.be.equal('label');
+      expect(a.ariaCurrent).to.be.equal('page');
     });
   });
 

--- a/src/elements/core/base-elements/link-base-element.ts
+++ b/src/elements/core/base-elements/link-base-element.ts
@@ -43,6 +43,11 @@ abstract class SbbLinkBaseElement extends SbbActionBaseElement {
   @property({ attribute: 'accessibility-label' })
   public accessor accessibilityLabel: string = '';
 
+  /** This will be forwarded as aria-current to the inner anchor element. */
+  @forceType()
+  @property({ attribute: 'accessibility-current' })
+  public accessor accessibilityCurrent: string = '';
+
   protected language = new SbbLanguageController(this);
 
   public constructor() {
@@ -85,6 +90,7 @@ abstract class SbbLinkBaseElement extends SbbActionBaseElement {
         target=${this.target || nothing}
         rel=${this._evaluateRelAttribute()}
         aria-label=${this.accessibilityLabel || nothing}
+        aria-current=${this.accessibilityCurrent || nothing}
         tabindex=${this.maybeDisabled && !this.maybeDisabledInteractive ? '-1' : nothing}
         aria-disabled=${this.maybeDisabled ? 'true' : nothing}
       >

--- a/src/elements/header/header-link/readme.md
+++ b/src/elements/header/header-link/readme.md
@@ -22,10 +22,15 @@ from which the label is displayed; below that, only the icon is visible.
 
 To indicate an active state, the CSS class `sbb-active` should be set.
 
-From accessibility perspective `aria-current="page"` should be set whenever the CSS class `sbb-active` is set.
+From accessibility perspective `accessibility-current="page"` should be set whenever the CSS class `sbb-active` is set.
 
 ```html
-<sbb-header-link icon-name="magnifying-glass-small" href="#" class="sbb-active" aria-current="page">
+<sbb-header-link
+  icon-name="magnifying-glass-small"
+  href="#"
+  class="sbb-active"
+  accessibility-current="page"
+>
   Overview
 </sbb-header-link>
 ```
@@ -43,15 +48,16 @@ accepting its associated properties (`href`, `target`, `rel` and `download`).
 
 ## Properties
 
-| Name                 | Attribute             | Privacy | Type                       | Default    | Description                                                                                                                                                                              |
-| -------------------- | --------------------- | ------- | -------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityLabel` | `accessibility-label` | public  | `string`                   | `''`       | This will be forwarded as aria-label to the inner anchor element.                                                                                                                        |
-| `download`           | `download`            | public  | `boolean`                  | `false`    | Whether the browser will show the download dialog on click.                                                                                                                              |
-| `expandFrom`         | `expand-from`         | public  | `SbbHorizontalFrom`        | `'medium'` | Used to set the minimum breakpoint from which the text is displayed. E.g. if set to 'large', the text will be visible for breakpoints large, wide, ultra, and hidden for all the others. |
-| `href`               | `href`                | public  | `string`                   | `''`       | The href value you want to link to.                                                                                                                                                      |
-| `iconName`           | `icon-name`           | public  | `string`                   | `''`       | The icon name we want to use, choose from the small icon variants from the ui-icons category from here https://icons.app.sbb.ch.                                                         |
-| `rel`                | `rel`                 | public  | `string`                   | `''`       | The relationship of the linked URL as space-separated link types.                                                                                                                        |
-| `target`             | `target`              | public  | `LinkTargetType \| string` | `''`       | Where to display the linked URL.                                                                                                                                                         |
+| Name                   | Attribute               | Privacy | Type                       | Default    | Description                                                                                                                                                                              |
+| ---------------------- | ----------------------- | ------- | -------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityCurrent` | `accessibility-current` | public  | `string`                   | `''`       | This will be forwarded as aria-current to the inner anchor element.                                                                                                                      |
+| `accessibilityLabel`   | `accessibility-label`   | public  | `string`                   | `''`       | This will be forwarded as aria-label to the inner anchor element.                                                                                                                        |
+| `download`             | `download`              | public  | `boolean`                  | `false`    | Whether the browser will show the download dialog on click.                                                                                                                              |
+| `expandFrom`           | `expand-from`           | public  | `SbbHorizontalFrom`        | `'medium'` | Used to set the minimum breakpoint from which the text is displayed. E.g. if set to 'large', the text will be visible for breakpoints large, wide, ultra, and hidden for all the others. |
+| `href`                 | `href`                  | public  | `string`                   | `''`       | The href value you want to link to.                                                                                                                                                      |
+| `iconName`             | `icon-name`             | public  | `string`                   | `''`       | The icon name we want to use, choose from the small icon variants from the ui-icons category from here https://icons.app.sbb.ch.                                                         |
+| `rel`                  | `rel`                   | public  | `string`                   | `''`       | The relationship of the linked URL as space-separated link types.                                                                                                                        |
+| `target`               | `target`                | public  | `LinkTargetType \| string` | `''`       | Where to display the linked URL.                                                                                                                                                         |
 
 ## Slots
 

--- a/src/elements/header/header/header.stories.ts
+++ b/src/elements/header/header/header.stories.ts
@@ -1,8 +1,7 @@
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { InputType } from '@storybook/types';
 import type { Args, ArgTypes, Decorator, Meta, StoryObj } from '@storybook/web-components';
-import { nothing, type TemplateResult } from 'lit';
-import { html } from 'lit';
+import { html, nothing, type TemplateResult } from 'lit';
 
 import { sbbSpread } from '../../../storybook/helpers/spread.js';
 
@@ -52,7 +51,7 @@ const HeaderBasicTemplate = (
       target="_blank"
       icon-name="magnifying-glass-small"
       class="sbb-active"
-      aria-current="page"
+      accessibility-current="page"
     >
       Search
     </sbb-header-link>

--- a/src/elements/header/header/readme.md
+++ b/src/elements/header/header/readme.md
@@ -52,7 +52,8 @@ For the latter, the usage of the `sbb-signet` with `protective-room='panel'` is 
 To indicate an active state of the `sbb-header-link` or `sbb-header-button`,
 the CSS class `sbb-active` should be set on the corresponding element.
 
-From accessibility perspective `aria-current="page"` should be set whenever the CSS class `sbb-active` is set.
+From accessibility perspective `accessibility-current="page"` (or `aria-current="page"` for buttons)
+should be set whenever the CSS class `sbb-active` is set.
 
 ```html
 <sbb-header size="s">
@@ -60,7 +61,7 @@ From accessibility perspective `aria-current="page"` should be set whenever the 
     icon-name="magnifying-glass-small"
     href="https://sbb.ch/somewhere"
     class="sbb-active"
-    aria-current="page"
+    accessibility-current="page"
   >
     Overview
   </sbb-header-link>

--- a/src/elements/link/block-link/readme.md
+++ b/src/elements/link/block-link/readme.md
@@ -51,17 +51,18 @@ The component has three sizes (`xs`, `s`, which is the default, and `m`).
 
 ## Properties
 
-| Name                 | Attribute             | Privacy | Type                       | Default             | Description                                                                                                                      |
-| -------------------- | --------------------- | ------- | -------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityLabel` | `accessibility-label` | public  | `string`                   | `''`                | This will be forwarded as aria-label to the inner anchor element.                                                                |
-| `disabled`           | `disabled`            | public  | `boolean`                  | `false`             | Whether the component is disabled.                                                                                               |
-| `download`           | `download`            | public  | `boolean`                  | `false`             | Whether the browser will show the download dialog on click.                                                                      |
-| `href`               | `href`                | public  | `string`                   | `''`                | The href value you want to link to.                                                                                              |
-| `iconName`           | `icon-name`           | public  | `string`                   | `''`                | The icon name we want to use, choose from the small icon variants from the ui-icons category from here https://icons.app.sbb.ch. |
-| `iconPlacement`      | `icon-placement`      | public  | `SbbIconPlacement`         | `'start'`           | Moves the icon to the end of the component if set to true.                                                                       |
-| `rel`                | `rel`                 | public  | `string`                   | `''`                | The relationship of the linked URL as space-separated link types.                                                                |
-| `size`               | `size`                | public  | `SbbLinkSize`              | `'s' / 'xs' (lean)` | Text size, the link should get in the non-button variation. With inline variant, the text size adapts to where it is used.       |
-| `target`             | `target`              | public  | `LinkTargetType \| string` | `''`                | Where to display the linked URL.                                                                                                 |
+| Name                   | Attribute               | Privacy | Type                       | Default             | Description                                                                                                                      |
+| ---------------------- | ----------------------- | ------- | -------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityCurrent` | `accessibility-current` | public  | `string`                   | `''`                | This will be forwarded as aria-current to the inner anchor element.                                                              |
+| `accessibilityLabel`   | `accessibility-label`   | public  | `string`                   | `''`                | This will be forwarded as aria-label to the inner anchor element.                                                                |
+| `disabled`             | `disabled`              | public  | `boolean`                  | `false`             | Whether the component is disabled.                                                                                               |
+| `download`             | `download`              | public  | `boolean`                  | `false`             | Whether the browser will show the download dialog on click.                                                                      |
+| `href`                 | `href`                  | public  | `string`                   | `''`                | The href value you want to link to.                                                                                              |
+| `iconName`             | `icon-name`             | public  | `string`                   | `''`                | The icon name we want to use, choose from the small icon variants from the ui-icons category from here https://icons.app.sbb.ch. |
+| `iconPlacement`        | `icon-placement`        | public  | `SbbIconPlacement`         | `'start'`           | Moves the icon to the end of the component if set to true.                                                                       |
+| `rel`                  | `rel`                   | public  | `string`                   | `''`                | The relationship of the linked URL as space-separated link types.                                                                |
+| `size`                 | `size`                  | public  | `SbbLinkSize`              | `'s' / 'xs' (lean)` | Text size, the link should get in the non-button variation. With inline variant, the text size adapts to where it is used.       |
+| `target`               | `target`                | public  | `LinkTargetType \| string` | `''`                | Where to display the linked URL.                                                                                                 |
 
 ## Slots
 

--- a/src/elements/link/link/readme.md
+++ b/src/elements/link/link/readme.md
@@ -31,16 +31,17 @@ accepting its associated properties (`href`, `target`, `rel` and `download`).
 
 ## Properties
 
-| Name                 | Attribute             | Privacy | Type                       | Default             | Description                                                                                                                |
-| -------------------- | --------------------- | ------- | -------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityLabel` | `accessibility-label` | public  | `string`                   | `''`                | This will be forwarded as aria-label to the inner anchor element.                                                          |
-| `disabled`           | `disabled`            | public  | `boolean`                  | `false`             | Whether the component is disabled.                                                                                         |
-| `download`           | `download`            | public  | `boolean`                  | `false`             | Whether the browser will show the download dialog on click.                                                                |
-| `href`               | `href`                | public  | `string`                   | `''`                | The href value you want to link to.                                                                                        |
-| `negative`           | `negative`            | public  | `boolean`                  | `false`             | Negative coloring variant flag.                                                                                            |
-| `rel`                | `rel`                 | public  | `string`                   | `''`                | The relationship of the linked URL as space-separated link types.                                                          |
-| `size`               | `size`                | public  | `SbbLinkSize`              | `'s' / 'xs' (lean)` | Text size, the link should get in the non-button variation. With inline variant, the text size adapts to where it is used. |
-| `target`             | `target`              | public  | `LinkTargetType \| string` | `''`                | Where to display the linked URL.                                                                                           |
+| Name                   | Attribute               | Privacy | Type                       | Default             | Description                                                                                                                |
+| ---------------------- | ----------------------- | ------- | -------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityCurrent` | `accessibility-current` | public  | `string`                   | `''`                | This will be forwarded as aria-current to the inner anchor element.                                                        |
+| `accessibilityLabel`   | `accessibility-label`   | public  | `string`                   | `''`                | This will be forwarded as aria-label to the inner anchor element.                                                          |
+| `disabled`             | `disabled`              | public  | `boolean`                  | `false`             | Whether the component is disabled.                                                                                         |
+| `download`             | `download`              | public  | `boolean`                  | `false`             | Whether the browser will show the download dialog on click.                                                                |
+| `href`                 | `href`                  | public  | `string`                   | `''`                | The href value you want to link to.                                                                                        |
+| `negative`             | `negative`              | public  | `boolean`                  | `false`             | Negative coloring variant flag.                                                                                            |
+| `rel`                  | `rel`                   | public  | `string`                   | `''`                | The relationship of the linked URL as space-separated link types.                                                          |
+| `size`                 | `size`                  | public  | `SbbLinkSize`              | `'s' / 'xs' (lean)` | Text size, the link should get in the non-button variation. With inline variant, the text size adapts to where it is used. |
+| `target`               | `target`                | public  | `LinkTargetType \| string` | `''`                | Where to display the linked URL.                                                                                           |
 
 ## Slots
 

--- a/src/elements/menu/menu-link/readme.md
+++ b/src/elements/menu/menu-link/readme.md
@@ -30,17 +30,18 @@ accepting its associated properties (`href`, `target`, `rel` and `download`).
 
 ## Properties
 
-| Name                  | Attribute              | Privacy | Type                       | Default | Description                                                                                                                      |
-| --------------------- | ---------------------- | ------- | -------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityLabel`  | `accessibility-label`  | public  | `string`                   | `''`    | This will be forwarded as aria-label to the inner anchor element.                                                                |
-| `amount`              | `amount`               | public  | `string`                   | `''`    | Value shown as badge at component end.                                                                                           |
-| `disabled`            | `disabled`             | public  | `boolean`                  | `false` | Whether the component is disabled.                                                                                               |
-| `disabledInteractive` | `disabled-interactive` | public  | `boolean`                  | `false` | Whether the button should be aria-disabled but stay interactive.                                                                 |
-| `download`            | `download`             | public  | `boolean`                  | `false` | Whether the browser will show the download dialog on click.                                                                      |
-| `href`                | `href`                 | public  | `string`                   | `''`    | The href value you want to link to.                                                                                              |
-| `iconName`            | `icon-name`            | public  | `string`                   | `''`    | The icon name we want to use, choose from the small icon variants from the ui-icons category from here https://icons.app.sbb.ch. |
-| `rel`                 | `rel`                  | public  | `string`                   | `''`    | The relationship of the linked URL as space-separated link types.                                                                |
-| `target`              | `target`               | public  | `LinkTargetType \| string` | `''`    | Where to display the linked URL.                                                                                                 |
+| Name                   | Attribute               | Privacy | Type                       | Default | Description                                                                                                                      |
+| ---------------------- | ----------------------- | ------- | -------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityCurrent` | `accessibility-current` | public  | `string`                   | `''`    | This will be forwarded as aria-current to the inner anchor element.                                                              |
+| `accessibilityLabel`   | `accessibility-label`   | public  | `string`                   | `''`    | This will be forwarded as aria-label to the inner anchor element.                                                                |
+| `amount`               | `amount`                | public  | `string`                   | `''`    | Value shown as badge at component end.                                                                                           |
+| `disabled`             | `disabled`              | public  | `boolean`                  | `false` | Whether the component is disabled.                                                                                               |
+| `disabledInteractive`  | `disabled-interactive`  | public  | `boolean`                  | `false` | Whether the button should be aria-disabled but stay interactive.                                                                 |
+| `download`             | `download`              | public  | `boolean`                  | `false` | Whether the browser will show the download dialog on click.                                                                      |
+| `href`                 | `href`                  | public  | `string`                   | `''`    | The href value you want to link to.                                                                                              |
+| `iconName`             | `icon-name`             | public  | `string`                   | `''`    | The icon name we want to use, choose from the small icon variants from the ui-icons category from here https://icons.app.sbb.ch. |
+| `rel`                  | `rel`                   | public  | `string`                   | `''`    | The relationship of the linked URL as space-separated link types.                                                                |
+| `target`               | `target`                | public  | `LinkTargetType \| string` | `''`    | Where to display the linked URL.                                                                                                 |
 
 ## CSS Properties
 

--- a/src/elements/navigation/navigation-link/readme.md
+++ b/src/elements/navigation/navigation-link/readme.md
@@ -31,17 +31,18 @@ The component has three different sizes, which can be changed using the `size` p
 
 ## Properties
 
-| Name                 | Attribute             | Privacy | Type                                       | Default            | Description                                                       |
-| -------------------- | --------------------- | ------- | ------------------------------------------ | ------------------ | ----------------------------------------------------------------- |
-| `accessibilityLabel` | `accessibility-label` | public  | `string`                                   | `''`               | This will be forwarded as aria-label to the inner anchor element. |
-| `connectedSection`   | -                     | public  | `SbbNavigationSectionElement \| undefined` |                    | The section that is beign controlled by the action, if any.       |
-| `download`           | `download`            | public  | `boolean`                                  | `false`            | Whether the browser will show the download dialog on click.       |
-| `href`               | `href`                | public  | `string`                                   | `''`               | The href value you want to link to.                               |
-| `marker`             | -                     | public  | `SbbNavigationMarkerElement \| null`       |                    | The navigation marker in which the action is nested.              |
-| `rel`                | `rel`                 | public  | `string`                                   | `''`               | The relationship of the linked URL as space-separated link types. |
-| `section`            | -                     | public  | `SbbNavigationSectionElement \| null`      |                    | The section in which the action is nested.                        |
-| `size`               | `size`                | public  | `SbbNavigationActionSize`                  | `'l' / 's' (lean)` | Action size variant, either s, m or l.                            |
-| `target`             | `target`              | public  | `LinkTargetType \| string`                 | `''`               | Where to display the linked URL.                                  |
+| Name                   | Attribute               | Privacy | Type                                       | Default            | Description                                                         |
+| ---------------------- | ----------------------- | ------- | ------------------------------------------ | ------------------ | ------------------------------------------------------------------- |
+| `accessibilityCurrent` | `accessibility-current` | public  | `string`                                   | `''`               | This will be forwarded as aria-current to the inner anchor element. |
+| `accessibilityLabel`   | `accessibility-label`   | public  | `string`                                   | `''`               | This will be forwarded as aria-label to the inner anchor element.   |
+| `connectedSection`     | -                       | public  | `SbbNavigationSectionElement \| undefined` |                    | The section that is beign controlled by the action, if any.         |
+| `download`             | `download`              | public  | `boolean`                                  | `false`            | Whether the browser will show the download dialog on click.         |
+| `href`                 | `href`                  | public  | `string`                                   | `''`               | The href value you want to link to.                                 |
+| `marker`               | -                       | public  | `SbbNavigationMarkerElement \| null`       |                    | The navigation marker in which the action is nested.                |
+| `rel`                  | `rel`                   | public  | `string`                                   | `''`               | The relationship of the linked URL as space-separated link types.   |
+| `section`              | -                       | public  | `SbbNavigationSectionElement \| null`      |                    | The section in which the action is nested.                          |
+| `size`                 | `size`                  | public  | `SbbNavigationActionSize`                  | `'l' / 's' (lean)` | Action size variant, either s, m or l.                              |
+| `target`               | `target`                | public  | `LinkTargetType \| string`                 | `''`               | Where to display the linked URL.                                    |
 
 ## Slots
 

--- a/src/elements/navigation/navigation-section/readme.md
+++ b/src/elements/navigation/navigation-section/readme.md
@@ -9,7 +9,7 @@ Optionally a label can be provided via slot or via the `titleContent` property.
 ```html
 <sbb-navigation-section trigger="nav1" titleContent="Title 1">
   <sbb-navigation-list label="Label 1.1">
-    <sbb-navigation-link aria-current="page" href="...">Label 1.1.1</sbb-navigation-link>
+    <sbb-navigation-link accessibility-current="page" href="...">Label 1.1.1</sbb-navigation-link>
     <sbb-navigation-link href="...">Label 1.1.2</sbb-navigation-link>
     ...
   </sbb-navigation-list>
@@ -19,8 +19,11 @@ Optionally a label can be provided via slot or via the `titleContent` property.
 
 ## Accessibility
 
-When a navigation action is marked to indicate the user is currently on that page, `aria-current="page"` should be set on that action.
-Similarly, if a navigation action is marked to indicate a selected option (e.g., the selected language) `aria-pressed` should be set on that action.
+When a navigation action is marked to indicate the user is currently on that page,
+`accessibility-current="page"` (for `sbb-navigation-link`s) or `aria-current="page"` (for `sbb-navigation-button`s)
+should be set on that action.
+Similarly, if a navigation action is marked to indicate a selected option (e.g. the selected language),
+`aria-pressed` should be set on that action.
 
 <!-- Auto Generated Below -->
 

--- a/src/elements/navigation/navigation/readme.md
+++ b/src/elements/navigation/navigation/readme.md
@@ -50,9 +50,15 @@ or call the `open()` method on the `sbb-navigation` component.
 
 ## Accessibility
 
-On opening, the focus will be automatically set on the first focusable element or the first action with the `.sbb-active` class and, if the action with this class has a connected section, the section will be opened and the focus will be set on the first focusable element or the first action with the `.sbb-active` class in the section.
-When a navigation action is marked to indicate the user is currently on that page, `aria-current="page"` should be set on that action.
-Similarly, if a navigation action is marked to indicate a selected option (e.g., the selected language) `aria-pressed` should be set on that action.
+On opening, the focus will be automatically set on the first focusable element or the first action with
+the `.sbb-active` class and, if the action with this class has a connected section,
+the section will be opened and the focus will be set on the first focusable element or the first action
+with the `.sbb-active` class in the section.
+When a navigation action is marked to indicate the user is currently on that page,
+`accessibility-current="page"` (for `sbb-navigation-link`s) or `aria-current="page"` (for `sbb-navigation-button`s)
+should be set on that action.
+Similarly, if a navigation action is marked to indicate a selected option (e.g. the selected language),
+`aria-pressed` should be set on that action.
 
 <!-- Auto Generated Below -->
 

--- a/src/elements/teaser-hero/readme.md
+++ b/src/elements/teaser-hero/readme.md
@@ -43,14 +43,15 @@ Avoid slotting block elements (e.g. `div`) as this violates semantic rules and c
 
 ## Properties
 
-| Name                 | Attribute             | Privacy | Type                       | Default | Description                                                       |
-| -------------------- | --------------------- | ------- | -------------------------- | ------- | ----------------------------------------------------------------- |
-| `accessibilityLabel` | `accessibility-label` | public  | `string`                   | `''`    | This will be forwarded as aria-label to the inner anchor element. |
-| `download`           | `download`            | public  | `boolean`                  | `false` | Whether the browser will show the download dialog on click.       |
-| `href`               | `href`                | public  | `string`                   | `''`    | The href value you want to link to.                               |
-| `linkContent`        | `link-content`        | public  | `string`                   | `''`    | Panel link text.                                                  |
-| `rel`                | `rel`                 | public  | `string`                   | `''`    | The relationship of the linked URL as space-separated link types. |
-| `target`             | `target`              | public  | `LinkTargetType \| string` | `''`    | Where to display the linked URL.                                  |
+| Name                   | Attribute               | Privacy | Type                       | Default | Description                                                         |
+| ---------------------- | ----------------------- | ------- | -------------------------- | ------- | ------------------------------------------------------------------- |
+| `accessibilityCurrent` | `accessibility-current` | public  | `string`                   | `''`    | This will be forwarded as aria-current to the inner anchor element. |
+| `accessibilityLabel`   | `accessibility-label`   | public  | `string`                   | `''`    | This will be forwarded as aria-label to the inner anchor element.   |
+| `download`             | `download`              | public  | `boolean`                  | `false` | Whether the browser will show the download dialog on click.         |
+| `href`                 | `href`                  | public  | `string`                   | `''`    | The href value you want to link to.                                 |
+| `linkContent`          | `link-content`          | public  | `string`                   | `''`    | Panel link text.                                                    |
+| `rel`                  | `rel`                   | public  | `string`                   | `''`    | The relationship of the linked URL as space-separated link types.   |
+| `target`               | `target`                | public  | `LinkTargetType \| string` | `''`    | Where to display the linked URL.                                    |
 
 ## Slots
 

--- a/src/elements/teaser-product/teaser-product/readme.md
+++ b/src/elements/teaser-product/teaser-product/readme.md
@@ -74,15 +74,16 @@ It's important to set the `accessibilityLabel` on the `<sbb-teaser-product>`, wh
 
 ## Properties
 
-| Name                 | Attribute             | Privacy | Type                       | Default   | Description                                                                                                                           |
-| -------------------- | --------------------- | ------- | -------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityLabel` | `accessibility-label` | public  | `string`                   | `''`      | This will be forwarded as aria-label to the inner anchor element.                                                                     |
-| `download`           | `download`            | public  | `boolean`                  | `false`   | Whether the browser will show the download dialog on click.                                                                           |
-| `href`               | `href`                | public  | `string`                   | `''`      | The href value you want to link to.                                                                                                   |
-| `imageAlignment`     | `image-alignment`     | public  | `'after' \| 'before'`      | `'after'` | Whether the fully visible part of the image is aligned 'before' or 'after' the content. Only relevant starting from large breakpoint. |
-| `negative`           | `negative`            | public  | `boolean`                  | `false`   | Negative coloring variant flag.                                                                                                       |
-| `rel`                | `rel`                 | public  | `string`                   | `''`      | The relationship of the linked URL as space-separated link types.                                                                     |
-| `target`             | `target`              | public  | `LinkTargetType \| string` | `''`      | Where to display the linked URL.                                                                                                      |
+| Name                   | Attribute               | Privacy | Type                       | Default   | Description                                                                                                                           |
+| ---------------------- | ----------------------- | ------- | -------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityCurrent` | `accessibility-current` | public  | `string`                   | `''`      | This will be forwarded as aria-current to the inner anchor element.                                                                   |
+| `accessibilityLabel`   | `accessibility-label`   | public  | `string`                   | `''`      | This will be forwarded as aria-label to the inner anchor element.                                                                     |
+| `download`             | `download`              | public  | `boolean`                  | `false`   | Whether the browser will show the download dialog on click.                                                                           |
+| `href`                 | `href`                  | public  | `string`                   | `''`      | The href value you want to link to.                                                                                                   |
+| `imageAlignment`       | `image-alignment`       | public  | `'after' \| 'before'`      | `'after'` | Whether the fully visible part of the image is aligned 'before' or 'after' the content. Only relevant starting from large breakpoint. |
+| `negative`             | `negative`              | public  | `boolean`                  | `false`   | Negative coloring variant flag.                                                                                                       |
+| `rel`                  | `rel`                   | public  | `string`                   | `''`      | The relationship of the linked URL as space-separated link types.                                                                     |
+| `target`               | `target`                | public  | `LinkTargetType \| string` | `''`      | Where to display the linked URL.                                                                                                      |
 
 ## CSS Properties
 

--- a/src/elements/teaser/readme.md
+++ b/src/elements/teaser/readme.md
@@ -75,17 +75,18 @@ The description text is wrapped into an `<p>` element to guarantee the semantic 
 
 ## Properties
 
-| Name                 | Attribute             | Privacy | Type                                     | Default            | Description                                                               |
-| -------------------- | --------------------- | ------- | ---------------------------------------- | ------------------ | ------------------------------------------------------------------------- |
-| `accessibilityLabel` | `accessibility-label` | public  | `string`                                 | `''`               | This will be forwarded as aria-label to the inner anchor element.         |
-| `alignment`          | `alignment`           | public  | `'after-centered' \| 'after' \| 'below'` | `'after-centered'` | Teaser variant - define the position and the alignment of the text block. |
-| `chipContent`        | `chip-content`        | public  | `string`                                 | `''`               | Content of chip label.                                                    |
-| `download`           | `download`            | public  | `boolean`                                | `false`            | Whether the browser will show the download dialog on click.               |
-| `href`               | `href`                | public  | `string`                                 | `''`               | The href value you want to link to.                                       |
-| `rel`                | `rel`                 | public  | `string`                                 | `''`               | The relationship of the linked URL as space-separated link types.         |
-| `target`             | `target`              | public  | `LinkTargetType \| string`               | `''`               | Where to display the linked URL.                                          |
-| `titleContent`       | `title-content`       | public  | `string`                                 | `''`               | Content of title.                                                         |
-| `titleLevel`         | `title-level`         | public  | `SbbTitleLevel`                          | `'5'`              | Heading level of the sbb-title element (e.g. h1-h6).                      |
+| Name                   | Attribute               | Privacy | Type                                     | Default            | Description                                                               |
+| ---------------------- | ----------------------- | ------- | ---------------------------------------- | ------------------ | ------------------------------------------------------------------------- |
+| `accessibilityCurrent` | `accessibility-current` | public  | `string`                                 | `''`               | This will be forwarded as aria-current to the inner anchor element.       |
+| `accessibilityLabel`   | `accessibility-label`   | public  | `string`                                 | `''`               | This will be forwarded as aria-label to the inner anchor element.         |
+| `alignment`            | `alignment`             | public  | `'after-centered' \| 'after' \| 'below'` | `'after-centered'` | Teaser variant - define the position and the alignment of the text block. |
+| `chipContent`          | `chip-content`          | public  | `string`                                 | `''`               | Content of chip label.                                                    |
+| `download`             | `download`              | public  | `boolean`                                | `false`            | Whether the browser will show the download dialog on click.               |
+| `href`                 | `href`                  | public  | `string`                                 | `''`               | The href value you want to link to.                                       |
+| `rel`                  | `rel`                   | public  | `string`                                 | `''`               | The relationship of the linked URL as space-separated link types.         |
+| `target`               | `target`                | public  | `LinkTargetType \| string`               | `''`               | Where to display the linked URL.                                          |
+| `titleContent`         | `title-content`         | public  | `string`                                 | `''`               | Content of title.                                                         |
+| `titleLevel`           | `title-level`           | public  | `SbbTitleLevel`                          | `'5'`              | Heading level of the sbb-title element (e.g. h1-h6).                      |
 
 ## Slots
 


### PR DESCRIPTION
With the previous implementation, the `aria-current` was set on the host (e.g. in breadcrumb or navigation). However, this was not forwarded to the inner anchor tag which resulted in partially broken screen reader support. This PR introduces the `accessibility-current` property on link elements which forwards the value to the inner anchor element as `aria-current`.