### PR TITLE
chore: remove puppeteer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "@web/test-runner": "0.19.0",
     "@web/test-runner-commands": "0.9.0",
     "@web/test-runner-playwright": "0.11.0",
-    "@web/test-runner-puppeteer": "0.17.0",
     "@web/test-runner-visual-regression": "0.9.0",
     "custom-elements-manifest": "2.1.0",
     "date-fns": "4.1.0",

--- a/src/elements/core/testing/private/a11y-tree-snapshot.ts
+++ b/src/elements/core/testing/private/a11y-tree-snapshot.ts
@@ -25,8 +25,6 @@ async function a11yTreeEqualSnapshot(): Promise<void> {
 /**
  * The function creates and tests the accessibility tree snapshot on each browser.
  * If a template is passed, it will be instantiated before the snapshot is taken.
- * Note:
- * We skip a11yTreeSnapshots in debug environment because they're not consistent on Puppeteer
  * @param title The title of the section
  * @param template The optional html template
  */

--- a/web-test-runner.config.ts
+++ b/web-test-runner.config.ts
@@ -14,7 +14,6 @@ import {
   playwrightLauncher,
   type PlaywrightLauncher,
 } from '@web/test-runner-playwright';
-import { puppeteerLauncher } from '@web/test-runner-puppeteer';
 import { visualRegressionPlugin } from '@web/test-runner-visual-regression/plugin';
 import { initCompiler } from 'sass';
 
@@ -91,14 +90,7 @@ const browsers =
       ? [playwrightLauncher({ product: 'firefox', ...launchOptions })]
       : cliArgs.webkit
         ? [playwrightLauncher({ product: 'webkit', ...launchOptions })]
-        : cliArgs.debug
-          ? [
-              puppeteerLauncher({
-                launchOptions: { headless: false, devtools: true },
-                ...concurrency,
-              }),
-            ]
-          : [playwrightLauncher({ product: 'chromium', ...launchOptions })];
+        : [playwrightLauncher({ product: 'chromium', ...launchOptions })];
 
 const preloadedIcons = await preloadIcons();
 const preloadedFonts = await preloadFonts();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2536,15 +2536,6 @@
     "@web/test-runner-coverage-v8" "^0.8.0"
     playwright "^1.22.2"
 
-"@web/test-runner-puppeteer@0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@web/test-runner-puppeteer/-/test-runner-puppeteer-0.17.0.tgz#a194df3f57a53d66b1bc9ef993358d4f3b2d0469"
-  integrity sha512-uGk0G28RfQFDRoBBGOwq4i+PGcVS2dTqu/wFJzT4A7o1DIwKk32dT68q+m7idtH/6X+jIKVg4nnDBVEVgujtpg==
-  dependencies:
-    "@web/test-runner-chrome" "^0.17.0"
-    "@web/test-runner-core" "^0.13.0"
-    puppeteer "^23.2.0"
-
 "@web/test-runner-visual-regression@0.9.0":
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/@web/test-runner-visual-regression/-/test-runner-visual-regression-0.9.0.tgz#9875a4871a24f8bf520c97b80ce548e81bce51e6"
@@ -7504,7 +7495,7 @@ punycode@^2.1.0, punycode@^2.3.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-puppeteer-core@23.11.1, puppeteer-core@^23.2.0:
+puppeteer-core@^23.2.0:
   version "23.11.1"
   resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-23.11.1.tgz#3e064de11b3cb3a2df1a8060ff2d05b41be583db"
   integrity sha512-3HZ2/7hdDKZvZQ7dhhITOUg4/wOrDRjyK2ZBllRB0ZCOi9u0cwq1ACHDjBB+nX+7+kltHjQvBRdeY7+W0T+7Gg==
@@ -7515,18 +7506,6 @@ puppeteer-core@23.11.1, puppeteer-core@^23.2.0:
     devtools-protocol "0.0.1367902"
     typed-query-selector "^2.12.0"
     ws "^8.18.0"
-
-puppeteer@^23.2.0:
-  version "23.11.1"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-23.11.1.tgz#98fd9040786b1219b1a4f639c270377586e8899c"
-  integrity sha512-53uIX3KR5en8l7Vd8n5DUv90Ae9QDQsyIthaUFVzwV6yU750RjqRznEtNMBT20VthqAdemnJN+hxVdmMHKt7Zw==
-  dependencies:
-    "@puppeteer/browsers" "2.6.1"
-    chromium-bidi "0.11.0"
-    cosmiconfig "^9.0.0"
-    devtools-protocol "0.0.1367902"
-    puppeteer-core "23.11.1"
-    typed-query-selector "^2.12.0"
 
 qs@^6.5.2:
   version "6.14.0"


### PR DESCRIPTION
We kept the puppeteer configuration just for the possibility of debugging tests.

Since we found a way to do it with Playwright, it does not add any value anymore. 
Plus, tests do not run consistently on it (I was probably the only one using it)

