### PR TITLE
docs: added warning about necessary import in type-script file

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -76,6 +76,8 @@ Select your technology to get started.
 
 4. In order to use web components with Angular, you have to import `CUSTOM_ELEMENTS_SCHEMA` from the `@angular/core` package.
 
+5. In each component, import the lyne components, which you want to use, in the typescript file: e.g. `import '@sbb-esta/lyne-elements/button.js';`
+
 ### Example app
 
 ```ts


### PR DESCRIPTION
It is - in my opinion - not obvious that I need to make a JavaScript import in the TypeScript file of my component to use a lyne-component in its template.

(also, that was not necessary in the "older" lyne-components dependency)
