### PR TITLE
chore: minor fixes on stories

### DIFF
--- a/src/elements-experimental/journey-summary/journey-summary.stories.ts
+++ b/src/elements-experimental/journey-summary/journey-summary.stories.ts
@@ -2,7 +2,6 @@ import type { InputType } from '@storybook/types';
 import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/web-components';
 import { nothing, type TemplateResult } from 'lit';
 import { html } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import { sbbSpread } from '../../storybook/helpers/spread.js';
 import {
@@ -97,14 +96,7 @@ const Template = ({ trip, tripBack, now, ...args }: Args): TemplateResult => htm
     now=${now ? now / 1000 : nothing}
     ${sbbSpread(args)}
   >
-    <div
-      style=${styleMap({
-        display: 'flex',
-        paddingTop: '24px',
-        justifyContent: 'space-between',
-      })}
-      slot="content"
-    >
+    <div style="display: flex; padding-top: 24px; justify-content: space-between;" slot="content">
       <sbb-secondary-button icon-name="context-menu-small"></sbb-secondary-button>
       <sbb-button>Button label</sbb-button>
     </div>

--- a/src/elements/autocomplete-grid/autocomplete-grid/autocomplete-grid.stories.ts
+++ b/src/elements/autocomplete-grid/autocomplete-grid/autocomplete-grid.stories.ts
@@ -56,27 +56,14 @@ const textBlock = (): TemplateResult => html`
 
 const aboveDecorator: Decorator = (story) => html`
   <div
-    style=${styleMap({
-      'inset-block-end': '2rem',
-      'inset-inline-start': '2rem',
-      position: 'absolute',
-      'max-width': 'calc(100% - 4rem)',
-    })}
+    style="inset-block-end: 2rem; inset-inline-start: 2rem; position: absolute; max-width: calc(100% - 4rem);"
   >
     ${story()}
   </div>
 `;
 
 const scrollDecorator: Decorator = (story) => html`
-  <div
-    style=${styleMap({
-      height: '175vh',
-      display: 'flex',
-      'align-items': 'center',
-    })}
-  >
-    ${story()}
-  </div>
+  <div style="height: 175vh; display: flex; align-items: center;">${story()}</div>
 `;
 
 const negative: InputType = {

--- a/src/elements/autocomplete/autocomplete.stories.ts
+++ b/src/elements/autocomplete/autocomplete.stories.ts
@@ -162,27 +162,14 @@ const withGroupsDefaultArgs: Args = {
 
 const aboveDecorator: Decorator = (story) => html`
   <div
-    style=${styleMap({
-      'inset-block-end': '2rem',
-      'inset-inline-start': '2rem',
-      position: 'absolute',
-      'max-width': 'calc(100% - 4rem)',
-    })}
+    style="inset-block-end: 2rem; inset-inline-start: 2rem; position: absolute; max-width: calc(100% - 4rem)"
   >
     ${story()}
   </div>
 `;
 
 const scrollDecorator: Decorator = (story) => html`
-  <div
-    style=${styleMap({
-      height: '175vh',
-      display: 'flex',
-      'align-items': 'center',
-    })}
-  >
-    ${story()}
-  </div>
+  <div style="height: 175vh; display: flex; align-items: center;">${story()}</div>
 `;
 
 const createOptionGroup1 = (iconName: string, disableOption: boolean): TemplateResult => {
@@ -284,7 +271,7 @@ const MixedTemplate = (args: Args): TemplateResult => html`
           <sbb-icon
             slot="icon"
             name=${args.iconName}
-            style=${styleMap({ color: 'var(--sbb-color-sky)' })}
+            style="color: var(--sbb-color-sky)"
           ></sbb-icon>
           Option Value
         </sbb-option>

--- a/src/elements/card/card/card.stories.ts
+++ b/src/elements/card/card/card.stories.ts
@@ -10,7 +10,6 @@ import type {
 } from '@storybook/web-components';
 import type { TemplateResult } from 'lit';
 import { html } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import { sbbSpread } from '../../../storybook/helpers/spread.js';
 
@@ -79,7 +78,7 @@ const TemplateCardActionWithBadge = ({ size, color, label, ...args }: Args): Tem
 `;
 
 const TemplateCardActionMultipleCards = (args: Args): TemplateResult => html`
-  <div style=${styleMap({ display: 'flex', gap: '1rem' })}>
+  <div style="display: flex; gap: 1rem;">
     ${TemplateCardActionWithBadge(args)} ${TemplateCardActionWithBadge({ ...args, active: true })}
     ${TemplateCardActionWithBadge(args)} ${TemplateCardActionWithBadge(args)}
   </div>

--- a/src/elements/checkbox/checkbox-group/checkbox-group.stories.ts
+++ b/src/elements/checkbox/checkbox-group/checkbox-group.stories.ts
@@ -150,7 +150,7 @@ const IndeterminateGroupTemplate = ({
   label,
   ...args
 }: Args): TemplateResult => html`
-  <div style=${styleMap({ 'margin-block-end': '1rem' })}>
+  <div style="margin-block-end: 1rem;">
     <div>Check/uncheck all the children checkboxes and the parent will be checked/unchecked.</div>
     <div>Check a single child and the parent will be indeterminate.</div>
   </div>
@@ -174,7 +174,7 @@ const IndeterminateGroupTemplate = ({
       icon-name=${iconName || nothing}
       icon-placement=${iconPlacement}
       ?disabled=${disabledSingle}
-      style=${styleMap({ 'margin-inline-start': '2rem' })}
+      style="margin-inline-start: 2rem;"
     >
       ${label} option 1
     </sbb-checkbox>
@@ -185,7 +185,7 @@ const IndeterminateGroupTemplate = ({
       @change=${(event: Event) => childCheck(event)}
       icon-name=${iconName || nothing}
       icon-placement=${iconPlacement}
-      style=${styleMap({ 'margin-inline-start': '2rem' })}
+      style="margin-inline-start: 2rem;"
     >
       ${label} option 2
     </sbb-checkbox>

--- a/src/elements/chip-label/chip-label.stories.ts
+++ b/src/elements/chip-label/chip-label.stories.ts
@@ -2,7 +2,6 @@ import type { InputType } from '@storybook/types';
 import type { Meta, StoryObj, ArgTypes, Args, StoryContext } from '@storybook/web-components';
 import type { TemplateResult } from 'lit';
 import { html } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import { sbbSpread } from '../../storybook/helpers/spread.js';
 
@@ -47,9 +46,7 @@ const Template = ({ label, ...args }: Args): TemplateResult => html`
 `;
 
 const TemplateFixedWidth = ({ label, ...args }: Args): TemplateResult => html`
-  <sbb-chip-label ${sbbSpread(args)} style=${styleMap({ width: '10rem' })}>
-    ${label}
-  </sbb-chip-label>
+  <sbb-chip-label ${sbbSpread(args)} style="width: 10rem;"> ${label} </sbb-chip-label>
 `;
 
 export const MilkXXS: StoryObj = {

--- a/src/elements/clock/clock.stories.ts
+++ b/src/elements/clock/clock.stories.ts
@@ -1,7 +1,6 @@
 import type { InputType } from '@storybook/types';
 import type { Args, ArgTypes, Meta, StoryObj } from '@storybook/web-components';
 import { html, nothing, type TemplateResult } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import { sbbSpread } from '../../storybook/helpers/spread.js';
 import type { SbbTime } from '../core/interfaces/types.js';
@@ -49,7 +48,7 @@ export const Paused: StoryObj = {
 };
 
 const meta: Meta = {
-  decorators: [(story) => html`<div style=${styleMap({ 'max-width': '600px' })}>${story()}</div>`],
+  decorators: [(story) => html`<div style="max-width: 600px;">${story()}</div>`],
   parameters: {
     docs: {
       extractComponentDescription: () => readme,

--- a/src/elements/container/sticky-bar/sticky-bar.stories.ts
+++ b/src/elements/container/sticky-bar/sticky-bar.stories.ts
@@ -2,7 +2,6 @@ import { withActions } from '@storybook/addon-actions/decorator';
 import type { InputType } from '@storybook/types';
 import type { Args, ArgTypes, Meta, StoryObj } from '@storybook/web-components';
 import { html, nothing, type TemplateResult } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import readme from './readme.md?raw';
 import { SbbStickyBarElement } from './sticky-bar.js';
@@ -280,15 +279,15 @@ export const ControlStickyState: StoryObj = {
   decorators: [
     (story) =>
       html`<div
-          style=${styleMap({
-            position: 'fixed',
-            'inset-block-start': 0,
-            'background-color': 'var(--sbb-color-white)',
-            padding: 'var(--sbb-spacing-responsive-xs)',
-            'z-index': 1,
-            'border-block-end': 'var(--sbb-border-width-1x) solid var(--sbb-color-black)',
-            'border-inline-end': 'var(--sbb-border-width-1x) solid var(--sbb-color-black)',
-          })}
+          style="
+            position: fixed;
+            inset-block-start: 0;
+            background-color: var(--sbb-color-white);
+            padding: var(--sbb-spacing-responsive-xs);
+            z-index: 1;
+            border-block-end: var(--sbb-border-width-1x) solid var(--sbb-color-black);
+            border-inline-end: var(--sbb-border-width-1x) solid var(--sbb-color-black);
+          "
         >
           Control whether the sticky bar has \`position: sticky\`.
           <sbb-secondary-button

--- a/src/elements/datepicker/datepicker-next-day/datepicker-next-day.stories.ts
+++ b/src/elements/datepicker/datepicker-next-day/datepicker-next-day.stories.ts
@@ -10,7 +10,6 @@ import type {
 } from '@storybook/web-components';
 import type { TemplateResult } from 'lit';
 import { html } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import { sbbSpread } from '../../../storybook/helpers/spread.js';
 
@@ -40,7 +39,7 @@ const BaseTemplate = (args: Args, picker: string | undefined = undefined): Templ
 const StandaloneTemplate = (args: Args): TemplateResult => html` ${BaseTemplate(args)} `;
 
 const PickerAndButtonTemplate = (args: Args): TemplateResult => html`
-  <div style=${styleMap({ display: 'flex', gap: '1em' })}>
+  <div style="display: flex; gap: 1em;">
     <sbb-datepicker
       id="datepicker"
       input="datepicker-input"

--- a/src/elements/datepicker/datepicker-previous-day/datepicker-previous-day.stories.ts
+++ b/src/elements/datepicker/datepicker-previous-day/datepicker-previous-day.stories.ts
@@ -10,7 +10,6 @@ import type {
 } from '@storybook/web-components';
 import type { TemplateResult } from 'lit';
 import { html } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import { sbbSpread } from '../../../storybook/helpers/spread.js';
 
@@ -43,7 +42,7 @@ const BaseTemplate = (args: Args, picker: string | undefined = undefined): Templ
 const StandaloneTemplate = (args: Args): TemplateResult => html` ${BaseTemplate(args)} `;
 
 const PickerAndButtonTemplate = (args: Args): TemplateResult => html`
-  <div style=${styleMap({ display: 'flex', gap: '1em' })}>
+  <div style="display: flex; gap: 1em;">
     ${BaseTemplate(args, 'datepicker')}
     <input value="15.02.2023" id="datepicker-input" />
     <sbb-datepicker

--- a/src/elements/datepicker/datepicker-toggle/datepicker-toggle.stories.ts
+++ b/src/elements/datepicker/datepicker-toggle/datepicker-toggle.stories.ts
@@ -10,7 +10,6 @@ import type {
 } from '@storybook/web-components';
 import type { TemplateResult } from 'lit';
 import { html, nothing } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import { sbbSpread } from '../../../storybook/helpers/spread.js';
 
@@ -51,7 +50,7 @@ const StandaloneTemplate = (args: Args, picker?: string): TemplateResult => html
 `;
 
 const PickerAndButtonTemplate = (args: Args): TemplateResult => html`
-  <div style=${styleMap({ display: 'flex', gap: '1em' })}>
+  <div style="display: flex; gap: 1em;">
     ${StandaloneTemplate(args, 'datepicker')}
     <sbb-datepicker id="datepicker" input="datepicker-input"></sbb-datepicker>
     <input id="datepicker-input" />

--- a/src/elements/datepicker/datepicker/datepicker.stories.ts
+++ b/src/elements/datepicker/datepicker/datepicker.stories.ts
@@ -9,7 +9,6 @@ import type {
   StoryObj,
 } from '@storybook/web-components';
 import { html, nothing, type TemplateResult } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import { sbbSpread } from '../../../storybook/helpers/spread.js';
 
@@ -240,7 +239,7 @@ const changeEventHandler = async (event: Event): Promise<void> => {
 
 const Template = ({ min, max, wide, dateFilter, now, ...args }: Args): TemplateResult => {
   return html`
-    <div style=${styleMap({ display: 'flex', gap: '0.25rem' })}>
+    <div style="display: flex; gap: 0.25rem;">
       <sbb-datepicker-previous-day date-picker="datepicker"></sbb-datepicker-previous-day>
       <sbb-datepicker-toggle date-picker="datepicker"></sbb-datepicker-toggle>
       <input
@@ -259,10 +258,7 @@ const Template = ({ min, max, wide, dateFilter, now, ...args }: Args): TemplateR
       ></sbb-datepicker>
       <sbb-datepicker-next-day date-picker="datepicker"></sbb-datepicker-next-day>
     </div>
-    <div
-      id="container-value"
-      style=${styleMap({ 'margin-block-start': '1rem', color: 'var(--sbb-color-smoke)' })}
-    >
+    <div id="container-value" style="margin-block-start: 1rem; color: var(--sbb-color-smoke);">
       Change date to get the latest value:
     </div>
   `;
@@ -305,10 +301,7 @@ const TemplateFormField = ({
         now=${convertMillisecondsToSeconds(now)}
       ></sbb-datepicker>
     </sbb-form-field>
-    <div
-      id="container-value"
-      style=${styleMap({ 'margin-block-start': '1rem', color: 'var(--sbb-color-smoke)' })}
-    >
+    <div id="container-value" style="margin-block-start: 1rem; color: var(--sbb-color-smoke);">
       Change date to get the latest value:
     </div>
   `;

--- a/src/elements/dialog/dialog-actions/dialog-actions.stories.ts
+++ b/src/elements/dialog/dialog-actions/dialog-actions.stories.ts
@@ -8,7 +8,7 @@ import readme from './readme.md?raw';
 
 import '../../button/button.js';
 import '../../button/secondary-button.js';
-import '../../link.js';
+import '../../link/block-link/block-link.js';
 
 const Template = (): TemplateResult =>
   html`<sbb-dialog-actions align-group="stretch" orientation="vertical" horizontal-from="medium">

--- a/src/elements/dialog/dialog-actions/dialog-actions.stories.ts
+++ b/src/elements/dialog/dialog-actions/dialog-actions.stories.ts
@@ -8,7 +8,7 @@ import readme from './readme.md?raw';
 
 import '../../button/button.js';
 import '../../button/secondary-button.js';
-import '../../link/block-link/block-link.js';
+import '../../link/block-link.js';
 
 const Template = (): TemplateResult =>
   html`<sbb-dialog-actions align-group="stretch" orientation="vertical" horizontal-from="medium">

--- a/src/elements/dialog/dialog/dialog.stories.ts
+++ b/src/elements/dialog/dialog/dialog.stories.ts
@@ -224,12 +224,7 @@ const DefaultTemplate = ({
     <sbb-dialog-content>
       <p
         id="dialog-content-1"
-        style=${styleMap({
-          display: 'flex',
-          alignItems: 'center',
-          gap: 'var(--sbb-spacing-fixed-1x)',
-          margin: '0',
-        })}
+        style="display: flex; align-items: center; gap: var(--sbb-spacing-fixed-1x); margin: 0;"
       >
         Dialog content
         <sbb-popover-trigger id="popover-trigger"></sbb-popover-trigger>
@@ -261,7 +256,7 @@ const LongContentTemplate = ({
       to Frodo that Arwen turned towards him, and the light of her eyes fell on him from afar and
       pierced his heart.
       <sbb-image
-        style=${styleMap({ 'margin-block': '1rem' })}
+        style="margin-block: 1rem;"
         image-src=${sampleImages[1]}
         alt="Natural landscape"
       ></sbb-image>
@@ -303,7 +298,7 @@ const FormTemplate = ({
   >
     ${dialogTitle(level, backButton, hideOnScroll, accessibilityCloseLabel, accessibilityBackLabel)}
     <sbb-dialog-content>
-      <div style=${styleMap({ 'margin-block-end': 'var(--sbb-spacing-fixed-4x)' })}>
+      <div style="margin-block-end: var(--sbb-spacing-fixed-4x);">
         Submit the form below to close the dialog box using the
         <code style=${styleMap(codeStyle)}>close(result?: any, target?: HTMLElement)</code>
         method and returning the form values to update the details.
@@ -340,7 +335,7 @@ const NoFooterTemplate = ({
   <sbb-dialog id="my-dialog-4" ${sbbSpread(args)}>
     ${dialogTitle(level, backButton, hideOnScroll, accessibilityCloseLabel, accessibilityBackLabel)}
     <sbb-dialog-content>
-      <p id="dialog-content-5" style=${styleMap({ margin: '0' })}>
+      <p id="dialog-content-5" style="margin: 0;">
         “What really knocks me out is a book that, when you're all done reading it, you wish the
         author that wrote it was a terrific friend of yours and you could call him up on the phone
         whenever you felt like it. That doesn't happen much, though.” ― J.D. Salinger, The Catcher

--- a/src/elements/divider/divider.stories.ts
+++ b/src/elements/divider/divider.stories.ts
@@ -2,7 +2,6 @@ import type { InputType } from '@storybook/types';
 import type { Meta, StoryObj, ArgTypes, Args, StoryContext } from '@storybook/web-components';
 import type { TemplateResult } from 'lit';
 import { html } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import { sbbSpread } from '../../storybook/helpers/spread.js';
 
@@ -10,7 +9,7 @@ import readme from './readme.md?raw';
 import './divider.js';
 
 const Template = (args: Args): TemplateResult => html`
-  <div style=${styleMap({ height: '340px', padding: '20px' })}>
+  <div style="height: 340px; padding: 20px;">
     <sbb-divider ${sbbSpread(args)}></sbb-divider>
   </div>
 `;

--- a/src/elements/flip-card/flip-card-summary/flip-card-summary.stories.ts
+++ b/src/elements/flip-card/flip-card-summary/flip-card-summary.stories.ts
@@ -10,7 +10,6 @@ import type {
 } from '@storybook/web-components';
 import type { TemplateResult } from 'lit';
 import { html } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import sampleImages from '../../core/images.js';
 
@@ -40,14 +39,14 @@ const defaultArgs: Args = {
 
 const Template = (args: Args): TemplateResult => html`
   <div
-    style=${styleMap({
-      position: 'relative',
-      display: 'flex',
-      'flex-flow': 'column wrap',
-      gap: 'var(--sbb-spacing-responsive-xs)',
-      'min-height': '17.5rem',
-      'background-color': 'var(--sbb-color-cloud-alpha-80)',
-    })}
+    style="
+      position: relative;
+      display: flex;
+      flex-flow: column wrap;
+      gap: var(--sbb-spacing-responsive-xs);
+      min-height: 17.5rem;
+      background-color: var(--sbb-color-cloud-alpha-80);
+    "
   >
     <sbb-flip-card-summary image-alignment=${args.imageAlignment}>
       <sbb-title level="4">Summary</sbb-title>

--- a/src/elements/flip-card/flip-card/flip-card.stories.ts
+++ b/src/elements/flip-card/flip-card/flip-card.stories.ts
@@ -3,7 +3,6 @@ import type { InputType } from '@storybook/types';
 import type { Args, ArgTypes, Meta, StoryObj, Decorator } from '@storybook/web-components';
 import type { TemplateResult } from 'lit';
 import { html, nothing } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import sampleImages from '../../core/images.js';
 
@@ -126,13 +125,13 @@ const LongContentTemplate = (args: Args): TemplateResult =>
 
 const GridTemplate = (args: Args): TemplateResult =>
   html`<div
-    style=${styleMap({
-      display: 'grid',
-      gridTemplateRows: 'minmax(20rem, 1fr)',
-      gridTemplateColumns: 'repeat(2, 1fr)',
-      gridColumnGap: '1rem',
-      gridRowGap: '1rem',
-    })}
+    style="
+    display: grid;
+    grid-template-rows: minmax(20rem, 1fr);
+    grid-template-columns: repeat(2, 1fr);
+    grid-column-gap: 1rem;
+    grid-row-gap: 1rem;
+  "
   >
     <sbb-flip-card accessibility-label=${args['accessibility-label']}>
       ${cardSummary(args.label, args.imageAlignment, true)} ${cardDetails()}

--- a/src/elements/footer/footer.stories.ts
+++ b/src/elements/footer/footer.stories.ts
@@ -1,7 +1,6 @@
 import type { InputType } from '@storybook/types';
 import type { Args, ArgTypes, Meta, StoryObj } from '@storybook/web-components';
 import { html, type TemplateResult } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import { sbbSpread } from '../../storybook/helpers/spread.js';
 
@@ -171,11 +170,11 @@ const TemplateClockColumns = ({ ...args }): TemplateResult => html`
           level="2"
           visual-level="5"
           ?negative=${args.negative}
-          style=${styleMap({ margin: '0 0 var(--sbb-spacing-fixed-3x)' })}
+          style="margin: 0 0 var(--sbb-spacing-fixed-3x);"
         >
           Newsletter.
         </sbb-title>
-        <p style=${styleMap({ margin: '0' })}>
+        <p style="margin: 0;">
           Our newsletter regularly informs you of attractive offers from SBB via e-mail.
         </p>
       </span>

--- a/src/elements/form-error/form-error.stories.ts
+++ b/src/elements/form-error/form-error.stories.ts
@@ -32,6 +32,7 @@ const iconNameArg: InputType = {
     type: 'text',
   },
 };
+
 const errorTextArg: InputType = {
   control: {
     type: 'text',

--- a/src/elements/form-field/form-field/form-field.stories.ts
+++ b/src/elements/form-field/form-field/form-field.stories.ts
@@ -2,7 +2,6 @@ import type { InputType } from '@storybook/types';
 import type { Meta, StoryObj, ArgTypes, Args, StoryContext } from '@storybook/web-components';
 import type { TemplateResult } from 'lit';
 import { html, nothing } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import type { SbbFormErrorElement } from '../../form-error.js';
 
@@ -205,7 +204,7 @@ const TemplateSelectWithErrorSpace = (args: Args): TemplateResult => {
         )}
       </div>
       <div>
-        <div style=${styleMap({ color: 'var(--sbb-color-smoke)' })}>
+        <div style="color: var(--sbb-color-smoke);">
           Some text, right below the form-field, inside a div.
         </div>
       </div>
@@ -258,7 +257,7 @@ const TemplateTextareaWithErrorSpace = (args: Args): TemplateResult => {
         )}
       </div>
       <div>
-        <div style=${styleMap({ color: 'var(--sbb-color-smoke)' })}>
+        <div style="color: var(--sbb-color-smoke);">
           Some text, right below the form-field, inside a div.
         </div>
       </div>

--- a/src/elements/logo/logo.stories.ts
+++ b/src/elements/logo/logo.stories.ts
@@ -2,7 +2,6 @@ import type { InputType } from '@storybook/types';
 import type { Meta, StoryObj, ArgTypes, Args, StoryContext } from '@storybook/web-components';
 import type { TemplateResult } from 'lit';
 import { html } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import { sbbSpread } from '../../storybook/helpers/spread.js';
 
@@ -71,7 +70,7 @@ export const Negative: StoryObj = {
 };
 
 const meta: Meta = {
-  decorators: [(story) => html`<div style=${styleMap({ 'max-width': '300px' })}>${story()}</div>`],
+  decorators: [(story) => html`<div style="max-width: 300px;">${story()}</div>`],
   parameters: {
     backgroundColor: (context: StoryContext) =>
       context.args.negative ? 'var(--sbb-color-charcoal)' : 'var(--sbb-color-white)',

--- a/src/elements/map-container/map-container.stories.ts
+++ b/src/elements/map-container/map-container.stories.ts
@@ -2,7 +2,6 @@ import type { InputType } from '@storybook/types';
 import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/web-components';
 import type { TemplateResult } from 'lit';
 import { html } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import { sbbSpread } from '../../storybook/helpers/spread.js';
 
@@ -30,8 +29,8 @@ const defaultArgs: Args = {
 
 const Template = (args: Args): TemplateResult => html`
   <sbb-map-container ${sbbSpread(args)}>
-    <div style=${styleMap({ padding: 'var(--sbb-spacing-fixed-4x)' })}>
-      <sbb-form-field style=${styleMap({ width: '100%' })}>
+    <div style="padding: var(--sbb-spacing-fixed-4x);">
+      <sbb-form-field style="width: 100%;">
         <sbb-icon slot="prefix" name="magnifying-glass-small"></sbb-icon>
         <input minlength=${2} name="keyword" autocomplete="off" placeholder="Search" />
         <sbb-form-field-clear></sbb-form-field-clear>
@@ -40,15 +39,15 @@ const Template = (args: Args): TemplateResult => html`
       ${[...Array(10).keys()].map(
         (value) => html`
           <div
-            style=${styleMap({
-              'background-color': 'var(--sbb-color-milk)',
-              height: '116px',
-              display: 'flex',
-              'align-items': 'center',
-              'justify-content': 'center',
-              'border-radius': 'var(--sbb-border-radius-4x)',
-              'margin-block-end': 'var(--sbb-spacing-fixed-4x)',
-            })}
+            style="
+              background-color: var(--sbb-color-milk);
+              height: 116px;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              border-radius: var(--sbb-border-radius-4x);
+              margin-block-end: var(--sbb-spacing-fixed-4x);
+            "
           >
             <p>Situation ${value}</p>
           </div>
@@ -56,15 +55,9 @@ const Template = (args: Args): TemplateResult => html`
       )}
     </div>
 
-    <div slot="map" style=${styleMap({ height: '100%' })}>
+    <div slot="map" style="height: 100%;">
       <div
-        style=${styleMap({
-          'background-color': 'grey',
-          height: '100%',
-          display: 'flex',
-          'align-items': 'center',
-          'justify-content': 'center',
-        })}
+        style="background-color: grey; height: 100%; display: flex; align-items: center; justify-content: center;"
       >
         map
       </div>

--- a/src/elements/menu/menu-button/menu-button.stories.ts
+++ b/src/elements/menu/menu-button/menu-button.stories.ts
@@ -2,7 +2,6 @@ import { withActions } from '@storybook/addon-actions/decorator';
 import type { InputType } from '@storybook/types';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/web-components';
 import { html, nothing, type TemplateResult } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import { sbbSpread } from '../../../storybook/helpers/spread.js';
 
@@ -175,7 +174,7 @@ export const menuActionButtonEllipsis: StoryObj = {
 
 const meta: Meta = {
   decorators: [
-    (story) => html`<div style=${styleMap({ width: '256px' })}>${story()}</div>`,
+    (story) => html`<div style="width: 256px;">${story()}</div>`,
     withActions as Decorator,
   ],
   parameters: {

--- a/src/elements/menu/menu-link/menu-link.stories.ts
+++ b/src/elements/menu/menu-link/menu-link.stories.ts
@@ -3,7 +3,6 @@ import type { InputType } from '@storybook/types';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/web-components';
 import type { TemplateResult } from 'lit';
 import { html, nothing } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import { sbbSpread } from '../../../storybook/helpers/spread.js';
 
@@ -188,7 +187,7 @@ export const menuLinkButtonEllipsis: StoryObj = {
 
 const meta: Meta = {
   decorators: [
-    (story) => html`<div style=${styleMap({ width: '256px' })}>${story()}</div>`,
+    (story) => html`<div style="width: 256px;">${story()}</div>`,
     withActions as Decorator,
   ],
   parameters: {

--- a/src/elements/message/message.stories.ts
+++ b/src/elements/message/message.stories.ts
@@ -3,7 +3,6 @@ import type { InputType } from '@storybook/types';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/web-components';
 import type { TemplateResult } from 'lit';
 import { html } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import { sbbSpread } from '../../storybook/helpers/spread.js';
 import images from '../core/images.js';
@@ -124,9 +123,7 @@ export const SlottedTitle: StoryObj = {
 
 const meta: Meta = {
   decorators: [
-    (story) => html`
-      <div style=${styleMap({ 'max-width': '45rem', margin: 'auto' })}>${story()}</div>
-    `,
+    (story) => html` <div style="max-width: 45rem; margin: auto;">${story()}</div> `,
     withActions as Decorator,
   ],
   parameters: {

--- a/src/elements/option/optgroup/optgroup.stories.ts
+++ b/src/elements/option/optgroup/optgroup.stories.ts
@@ -112,21 +112,25 @@ const borderDecorator: Decorator = (story) => html`
   </div>
 `;
 
-const createOptions = (args: Args): TemplateResult[] =>
+const createOptions = (args: Args, groupId: string): TemplateResult[] =>
   new Array(args.numberOfOptions).fill(null).map((_, i) => {
     return html`
       <sbb-option
-        value=${`${args.value} ${i + 1}`}
+        value="${args.value} ${groupId} - ${i + 1}"
         ?disabled=${args.disabledSingle && i === 0}
         icon-name=${args['icon-name'] || nothing}
-        >${`${args.value} ${i + 1}`}</sbb-option
+        >${args.value} ${groupId} - ${i + 1}</sbb-option
       >
     `;
   });
 
 const Template = ({ label, disabled, ...args }: Args): TemplateResult => html`
-  <sbb-optgroup label=${label + ' 1'} ?disabled=${disabled}> ${createOptions(args)} </sbb-optgroup>
-  <sbb-optgroup label=${label + ' 2'} ?disabled=${disabled}> ${createOptions(args)} </sbb-optgroup>
+  <sbb-optgroup label=${label + ' 1'} ?disabled=${disabled}>
+    ${createOptions(args, '1')}
+  </sbb-optgroup>
+  <sbb-optgroup label=${label + ' 2'} ?disabled=${disabled}>
+    ${createOptions(args, '2')}
+  </sbb-optgroup>
 `;
 
 const TemplateAutocomplete = (args: Args): TemplateResult => {

--- a/src/elements/select/select.stories.ts
+++ b/src/elements/select/select.stories.ts
@@ -208,12 +208,7 @@ const codeStyle: Readonly<StyleInfo> = {
 
 const aboveDecorator: Decorator = (story) => html`
   <div
-    style=${styleMap({
-      'inset-block-end': '2rem',
-      'inset-inline-start': '2rem',
-      position: 'absolute',
-      'max-width': 'calc(100% - 4rem)',
-    })}
+    style="inset-block-end: 2rem; inset-inline-start: 2rem; position: absolute; max-width: calc(100% - 4rem);"
   >
     ${story()}
   </div>


### PR DESCRIPTION
Some minor fixes on stories
- Removal of useless `styleMap` in points where there's no need for interpolation
- Fixed a bug in optgroup.stories.ts: options need a unique value, otherwise the keyboard navigation will mark two options as selected