### PR TITLE
refactor(sbb-date-input): feature detect plaintext-only support

### DIFF
--- a/src/elements/core/mixins/form-associated-input-mixin.ts
+++ b/src/elements/core/mixins/form-associated-input-mixin.ts
@@ -3,7 +3,7 @@ import { eventOptions, property } from 'lit/decorators.js';
 
 import { sbbInputModalityDetector } from '../a11y.js';
 import { SbbLanguageController } from '../controllers.js';
-import { isFirefox, isWebkit } from '../dom.js';
+import { isWebkit } from '../dom.js';
 import { i18nInputRequired } from '../i18n.js';
 
 import type { Constructor } from './constructor.js';
@@ -38,6 +38,20 @@ export declare abstract class SbbFormAssociatedInputMixinType
   protected updateFormValue(): void;
   protected language: SbbLanguageController;
 }
+
+const checkPlaintextOnlySupport = (): boolean => {
+  if (isServer) {
+    return false;
+  }
+
+  const div = document.createElement('div');
+  div.setAttribute('contenteditable', 'PLAINTEXT-ONLY');
+
+  // If plaintext-only is supported, the attribute value is
+  // returned as lower-case from the property access.
+  return div.contentEditable === 'plaintext-only';
+};
+const plaintextOnlySupported = checkPlaintextOnlySupport();
 
 /**
  * The SbbFormAssociatedInputMixin enables native form support for text input controls.
@@ -371,10 +385,14 @@ export const SbbFormAssociatedInputMixin = <T extends Constructor<LitElement>>(
 
     private _updateContenteditable(): void {
       if (!isServer && this.isConnected) {
-        // Firefox does not yet support plaintext-only. Once this is available
-        // for our supported browser range, we can switch to it fully.
+        // TODO(2026): Firefox supports plaintext-only since version 136 (March 2025).
+        // Until this is part of our baseline, we should feature check to enable it.
         const value =
-          this.disabled || this.readOnly ? 'false' : isFirefox ? 'true' : 'plaintext-only';
+          this.disabled || this.readOnly
+            ? 'false'
+            : plaintextOnlySupported
+              ? 'plaintext-only'
+              : 'true';
         this.setAttribute('contenteditable', value);
         // In the readonly case, we disable contenteditable, but it still
         // needs to be focusable. We achieve this by setting tabindex in that case.


### PR DESCRIPTION
Currently we do not use `contenteditable="plaintext-only"` on Firefox, as it was not supported. Now that support has landed, we are switching to feature detection.