### PR TITLE
fix: avoid throwing on parsing invalid date

### DIFF
--- a/src/elements/core/datetime/native-date-adapter.spec.ts
+++ b/src/elements/core/datetime/native-date-adapter.spec.ts
@@ -192,11 +192,12 @@ describe('NativeDateAdapter', () => {
     expect(+fakeDate).to.be.NaN;
   });
 
-  it('parseDate should return the correct value', function () {
+  it('parse should return the correct value', function () {
     const now = new Date(2023, 8, 15, 0, 0, 0, 0);
     expect(nativeDateAdapter.parse(null, now)).to.be.null;
     expect(nativeDateAdapter.parse('Test', now)).to.be.null;
     expect(nativeDateAdapter.parse('1.1', now)).to.be.null;
+    expect(nativeDateAdapter.parse('2000.0.1', now)).to.be.null;
     for (const dateString of ['1/1/2000', '1.1.2000', '2000-01-01']) {
       const date = nativeDateAdapter.parse(dateString, now)!;
       expect(date.getFullYear()).to.be.equal(2000);

--- a/src/elements/core/datetime/native-date-adapter.ts
+++ b/src/elements/core/datetime/native-date-adapter.ts
@@ -178,8 +178,13 @@ export class NativeDateAdapter extends DateAdapter<Date> {
       return null;
     }
 
+    let date: Date | null = null;
     const isoMatch = value.match(ISO8601_FORMAT_DATE);
-    const date = isoMatch ? this.createDate(+isoMatch[1], +isoMatch[2], +isoMatch[3]) : null;
+    try {
+      date = isoMatch ? this.createDate(+isoMatch[1], +isoMatch[2], +isoMatch[3]) : null;
+    } catch {
+      /* empty */
+    }
     if (this.isValid(date)) {
       return date;
     }


### PR DESCRIPTION
Currently we use `createDate` inside `parse`, which throws on invalid date. However, `parse` should never throw, just return `null` for an invalid date, which this PR addresses.