### PR TITLE
test: use inlined font-face for testing

### DIFF
--- a/web-test-runner.config.ts
+++ b/web-test-runner.config.ts
@@ -106,24 +106,8 @@ const testRunnerHtml = (
 ): string => `
 <!DOCTYPE html>
 <html lang='en'>
-  <head>${
-    // Although we provide the fonts as base64, we preload the original
-    // files which prevents a bug in Safari rendering special characters.
-    ['Roman', 'Bold', 'Light']
-      .map(
-        (type) => `
-    <link
-      rel="preload"
-      href="https://cdn.app.sbb.ch/fonts/v1_8_1_subset/SBBWeb-${type}.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin="anonymous"
-    />`,
-      )
-      .join('')
-  }
+  <head>
     <link rel="modulepreload" href="/src/elements/core/testing/test-setup.ts" />
-    <style type="text/css">${renderStyles()}</style>
     <style type="text/css">
       ${preloadedFonts
         .map(
@@ -131,11 +115,12 @@ const testRunnerHtml = (
       @font-face {
         font-family: SBB;
         src: ${f.font};
-        font-display: fallback;
+        font-display: block;
         font-weight: ${f.weight};
       }`,
         )
         .join('')}
+      ${renderStyles().replace(/@font-face([^}]|\n)+\}/g, '')}
     </style>
     <script type="module">
       globalThis.testEnv = '${cliArgs.debug ? 'debug' : ''}';


### PR DESCRIPTION
This PR adapts the web test runner config to only use the inlined font-face for testing.