### PR TITLE
style(sbb-table): add support to header filters

### DIFF
--- a/src/elements/core/styles/mixins/table.scss
+++ b/src/elements/core/styles/mixins/table.scss
@@ -28,8 +28,12 @@
   }
 
   thead {
-    & > tr > th {
-      @include table-header-cell;
+    & > tr {
+      @include table-header-row;
+
+      & > th {
+        @include table-header-cell;
+      }
     }
   }
 
@@ -45,6 +49,13 @@
 
   caption {
     @include table-caption;
+  }
+}
+
+@mixin table-header-row {
+  // If there are more header rows, only the last one has the bottom border
+  &:not(:last-of-type) > th {
+    border-bottom: none;
   }
 }
 
@@ -91,6 +102,10 @@
   color: var(--sbb-table-caption-color, var(--sbb-color-granite));
   margin-block-start: var(--sbb-table-caption-margin-block-start, var(--sbb-spacing-fixed-4x));
   text-align: left;
+}
+
+@mixin table-filter {
+  padding-block-start: 0 !important;
 }
 
 @mixin table--striped {

--- a/src/elements/core/styles/mixins/table.scss
+++ b/src/elements/core/styles/mixins/table.scss
@@ -18,9 +18,6 @@
     --sbb-table-caption-color: var(--sbb-color-granite);
     --sbb-table-caption-margin-block-start: var(--sbb-spacing-fixed-4x);
 
-    background-color: var(--sbb-table-background-color);
-    border: var(--sbb-table-border);
-    border-radius: var(--sbb-table-border-radius);
     border-spacing: 0;
     caption-side: bottom;
     color: var(--sbb-table-color);
@@ -31,8 +28,28 @@
     & > tr {
       @include table-header-row;
 
+      &:first-of-type {
+        & > th {
+          border-block-start: var(--sbb-table-border);
+        }
+
+        // Border radius on top-left corner
+        & > th:first-of-type {
+          border-start-start-radius: var(--sbb-table-border-radius);
+        }
+
+        // Border radius on top-right corner
+        & > th:last-of-type {
+          border-start-end-radius: var(--sbb-table-border-radius);
+        }
+      }
+
       & > th {
         @include table-header-cell;
+
+        &:first-of-type {
+          border-inline-start: var(--sbb-table-border);
+        }
       }
     }
   }
@@ -43,6 +60,22 @@
 
       & > td {
         @include table-data-cell;
+
+        &:first-of-type {
+          border-inline-start: var(--sbb-table-border);
+        }
+      }
+
+      &:last-of-type {
+        // Border radius on bottom-left corner
+        & > td:first-of-type {
+          border-end-start-radius: var(--sbb-table-border-radius);
+        }
+
+        // Border radius on bottom-right corner
+        & > td:last-of-type {
+          border-end-end-radius: var(--sbb-table-border-radius);
+        }
       }
     }
   }
@@ -53,46 +86,35 @@
 }
 
 @mixin table-header-row {
-  // If there is more than one header row, remove the bottom border except for the last one
-  &:not(:last-of-type) > th {
-    border-bottom: none;
+  // If there is more than one header row, only the last one has the bottom border
+  &:last-of-type > th {
+    border-bottom: var(--sbb-table-border);
   }
 }
 
 @mixin table-header-cell {
   @include typo.text-xs--bold;
 
-  border-block-end: var(--sbb-table-border);
+  background-color: var(--sbb-table-background-color);
   border-inline-end: var(--sbb-table-border);
   padding-block: var(--sbb-table-header-padding-block);
   padding-inline: var(--sbb-table-header-padding-inline);
   text-align: left;
-
-  // To avoid double border
-  &:last-of-type {
-    border-inline-end: none;
-  }
 }
 
+// @deprecated No longer used internally.
 @mixin table-data-row {
-  // To avoid double borders
-  &:first-of-type td {
-    border-block-start: none;
-  }
+  // empty
 }
 
 @mixin table-data-cell {
   @include typo.text-s--regular;
 
-  border-block-start: var(--sbb-table-border);
+  background-color: var(--sbb-table-background-color);
+  border-block-end: var(--sbb-table-border);
   border-inline-end: var(--sbb-table-border);
   padding-block: var(--sbb-table-cell-padding-block);
   padding-inline: var(--sbb-table-cell-padding-inline);
-
-  // To avoid double border
-  &:last-of-type {
-    border-inline-end: none;
-  }
 }
 
 @mixin table-caption {
@@ -109,14 +131,14 @@
 }
 
 @mixin table--striped {
-  tbody tr:nth-child(odd) {
+  tbody tr:nth-child(odd) :is(th, td) {
     @include table-row--striped;
   }
 }
 
 @mixin table--unstriped {
-  tbody tr:nth-child(odd) {
-    background-color: unset;
+  tbody tr:nth-child(odd) :is(th, td) {
+    background-color: var(--sbb-table-background-color);
   }
 }
 

--- a/src/elements/core/styles/mixins/table.scss
+++ b/src/elements/core/styles/mixins/table.scss
@@ -53,7 +53,7 @@
 }
 
 @mixin table-header-row {
-  // If there are more header rows, only the last one has the bottom border
+  // If there is more than one header row, only the last one has the bottom border
   &:not(:last-of-type) > th {
     border-bottom: none;
   }

--- a/src/elements/core/styles/mixins/table.scss
+++ b/src/elements/core/styles/mixins/table.scss
@@ -53,7 +53,7 @@
 }
 
 @mixin table-header-row {
-  // If there is more than one header row, only the last one has the bottom border
+  // If there is more than one header row, remove the bottom border except for the last one
   &:not(:last-of-type) > th {
     border-bottom: none;
   }
@@ -62,36 +62,36 @@
 @mixin table-header-cell {
   @include typo.text-xs--bold;
 
-  border-bottom: var(--sbb-table-border);
-  border-right: var(--sbb-table-border);
+  border-block-end: var(--sbb-table-border);
+  border-inline-end: var(--sbb-table-border);
   padding-block: var(--sbb-table-header-padding-block);
   padding-inline: var(--sbb-table-header-padding-inline);
   text-align: left;
 
   // To avoid double border
   &:last-of-type {
-    border-right: none;
+    border-inline-end: none;
   }
 }
 
 @mixin table-data-row {
   // To avoid double borders
   &:first-of-type td {
-    border-top: none;
+    border-block-start: none;
   }
 }
 
 @mixin table-data-cell {
   @include typo.text-s--regular;
 
-  border-top: var(--sbb-table-border);
-  border-right: var(--sbb-table-border);
+  border-block-start: var(--sbb-table-border);
+  border-inline-end: var(--sbb-table-border);
   padding-block: var(--sbb-table-cell-padding-block);
   padding-inline: var(--sbb-table-cell-padding-inline);
 
   // To avoid double border
   &:last-of-type {
-    border-right: none;
+    border-inline-end: none;
   }
 }
 

--- a/src/elements/core/styles/table.scss
+++ b/src/elements/core/styles/table.scss
@@ -68,7 +68,7 @@ sbb-table-wrapper[negative] .sbb-table,
   @include table.table-filter;
 }
 
-// TODO In future, move to the 'sbb-lean' theme
+// TODO: In future, move to the 'sbb-lean' theme
 html.sbb-lean .sbb-table:not(.sbb-table-xs, .sbb-table-m) {
   @include table.table--s;
 }

--- a/src/elements/core/styles/table.scss
+++ b/src/elements/core/styles/table.scss
@@ -68,6 +68,13 @@ sbb-table-wrapper[negative] .sbb-table,
   @include table.table-filter;
 }
 
+.sbb-table-sticky {
+  // Note that the table can either set this class or an inline style to make something sticky.
+  // We set the style as `!important` so that we get an identical specificity in both cases
+  // and to avoid cases where user styles have a higher specificity.
+  position: sticky !important;
+}
+
 // TODO: In future, move to the 'sbb-lean' theme
 html.sbb-lean .sbb-table:not(.sbb-table-xs, .sbb-table-m) {
   @include table.table--s;

--- a/src/elements/core/styles/table.scss
+++ b/src/elements/core/styles/table.scss
@@ -40,6 +40,10 @@ sbb-table-wrapper[negative] .sbb-table,
   }
 }
 
+.sbb-table-header-row {
+  @include table.table-header-row;
+}
+
 .sbb-table-header-cell {
   @include table.table-header-cell;
 }
@@ -60,6 +64,11 @@ sbb-table-wrapper[negative] .sbb-table,
   @include table.table-caption;
 }
 
+.sbb-table-filter {
+  @include table.table-filter;
+}
+
+// TODO In future, move to the 'sbb-lean' theme
 html.sbb-lean .sbb-table:not(.sbb-table-xs, .sbb-table-m) {
   @include table.table--s;
 }

--- a/src/elements/table/table-wrapper/table-wrapper.scss
+++ b/src/elements/table/table-wrapper/table-wrapper.scss
@@ -6,7 +6,7 @@
 :host {
   --sbb-table-wrapper-border-radius: var(--sbb-border-radius-4x);
 
-  display: block;
+  display: contents;
 }
 
 ::slotted(.sbb-table) {
@@ -14,6 +14,7 @@
 }
 
 .sbb-table-wrapper {
+  height: 100%;
   overflow: auto;
   @include sbb.scrollbar($size: thick, $track-visible: true);
 

--- a/src/elements/table/table-wrapper/table-wrapper.scss
+++ b/src/elements/table/table-wrapper/table-wrapper.scss
@@ -6,7 +6,7 @@
 :host {
   --sbb-table-wrapper-border-radius: var(--sbb-border-radius-4x);
 
-  display: contents;
+  display: block;
 }
 
 ::slotted(.sbb-table) {

--- a/src/elements/table/table-wrapper/table-wrapper.stories.ts
+++ b/src/elements/table/table-wrapper/table-wrapper.stories.ts
@@ -86,20 +86,18 @@ const body: () => TemplateResult = () => html`
 `;
 
 const Template = (args: Args): TemplateResult => html`
-  <div style="height: 400px">
-    <sbb-table-wrapper ?negative=${args.negative}>
-      <table
-        aria-label="Train lines 2024"
-        class=${classMap({
-          'sbb-table': true,
-          'sbb-table--negative': args.negative,
-        })}
-      >
-        ${header()} ${body()}
-      </table>
-    </sbb-table-wrapper>
-    <p class="sbb-table-caption">Train lines 2024</p>
-  </div>
+  <sbb-table-wrapper ?negative=${args.negative} style="height: 400px">
+    <table
+      aria-label="Train lines 2024"
+      class=${classMap({
+        'sbb-table': true,
+        'sbb-table--negative': args.negative,
+      })}
+    >
+      ${header()} ${body()}
+    </table>
+  </sbb-table-wrapper>
+  <p class="sbb-table-caption">Train lines 2024</p>
 `;
 
 export const Default: StoryObj = {

--- a/src/elements/table/table-wrapper/table-wrapper.stories.ts
+++ b/src/elements/table/table-wrapper/table-wrapper.stories.ts
@@ -86,18 +86,20 @@ const body: () => TemplateResult = () => html`
 `;
 
 const Template = (args: Args): TemplateResult => html`
-  <sbb-table-wrapper ?negative=${args.negative}>
-    <table
-      aria-label="Train lines 2024"
-      class=${classMap({
-        'sbb-table': true,
-        'sbb-table--negative': args.negative,
-      })}
-    >
-      ${header()} ${body()}
-    </table>
-  </sbb-table-wrapper>
-  <p class="sbb-table-caption">Train lines 2024</p>
+  <div style="height: 400px">
+    <sbb-table-wrapper ?negative=${args.negative}>
+      <table
+        aria-label="Train lines 2024"
+        class=${classMap({
+          'sbb-table': true,
+          'sbb-table--negative': args.negative,
+        })}
+      >
+        ${header()} ${body()}
+      </table>
+    </sbb-table-wrapper>
+    <p class="sbb-table-caption">Train lines 2024</p>
+  </div>
 `;
 
 export const Default: StoryObj = {

--- a/src/storybook/styles/table/readme.md
+++ b/src/storybook/styles/table/readme.md
@@ -82,17 +82,19 @@ This scheme changes the text color of the cells to `sbb-color-iron`.
 In advanced scenarios, predefined classes might not suffice.
 Therefore, we provide mixins you can build on top of:
 
-| Sass Mixin           | CSS class                | Description                               |
-| -------------------- | ------------------------ | ----------------------------------------- |
-| `table`              | `sbb-table`              | The table style (equivalent to `table-m`) |
-| `table--m`           | `sbb-table-m`            | Medium size table style                   |
-| `table--s`           | `sbb-table-s`            | Small size table style                    |
-| `table--xs`          | `sbb-table-xs`           | Smallest size table style                 |
-| `table--negative`    | `sbb-table--negative`    | Negative variant style                    |
-| `table--striped`     | `sbb-table--striped`     | Striped table style                       |
-| `table--unstriped`   | `sbb-table--unstriped`   | Non-striped table style                   |
-| `table-row--striped` | `sbb-table-row--striped` | Force the striped state on a `tr`         |
-| `table-header-cell`  | `sbb-table-header-cell`  | `th` element style                        |
-| `table-data-row`     | `sbb-table-data-row`     | `tr` element style                        |
-| `table-data-cell`    | `sbb-table-data-cell`    | `td` element style                        |
-| `table-caption`      | `sbb-table-caption`      | `caption` element style                   |
+| Sass Mixin           | CSS class                | Description                                 |
+| -------------------- | ------------------------ | ------------------------------------------- |
+| `table`              | `sbb-table`              | The table style (equivalent to `table-m`)   |
+| `table--m`           | `sbb-table-m`            | Medium size table style                     |
+| `table--s`           | `sbb-table-s`            | Small size table style                      |
+| `table--xs`          | `sbb-table-xs`           | Smallest size table style                   |
+| `table--negative`    | `sbb-table--negative`    | Negative variant style                      |
+| `table--striped`     | `sbb-table--striped`     | Striped table style                         |
+| `table--unstriped`   | `sbb-table--unstriped`   | Non-striped table style                     |
+| `table-row--striped` | `sbb-table-row--striped` | Force the striped state on a `tr`           |
+| `table-header-row`   | `sbb-table-header-row`   | Header `tr` element style                   |
+| `table-header-cell`  | `sbb-table-header-cell`  | `th` element style                          |
+| `table-data-row`     | `sbb-table-data-row`     | Body `tr` element style                     |
+| `table-data-cell`    | `sbb-table-data-cell`    | `td` element style                          |
+| `table-caption`      | `sbb-table-caption`      | `caption` element style                     |
+| `table-filter`       | `sbb-table-filter`       | `th` element that contains an inline filter |

--- a/src/storybook/styles/table/readme.md
+++ b/src/storybook/styles/table/readme.md
@@ -94,7 +94,6 @@ Therefore, we provide mixins you can build on top of:
 | `table-row--striped` | `sbb-table-row--striped` | Force the striped state on a `tr`           |
 | `table-header-row`   | `sbb-table-header-row`   | Header `tr` element style                   |
 | `table-header-cell`  | `sbb-table-header-cell`  | `th` element style                          |
-| `table-data-row`     | `sbb-table-data-row`     | Body `tr` element style                     |
 | `table-data-cell`    | `sbb-table-data-cell`    | `td` element style                          |
 | `table-caption`      | `sbb-table-caption`      | `caption` element style                     |
 | `table-filter`       | `sbb-table-filter`       | `th` element that contains an inline filter |

--- a/src/storybook/styles/table/table.stories.ts
+++ b/src/storybook/styles/table/table.stories.ts
@@ -40,7 +40,7 @@ const defaultArgTypes: ArgTypes = {
 };
 
 const defaultArgs: Args = {
-  size: size.options![1],
+  size: 'm',
   negative: false,
   striped: true,
   'color-theme': colorTheme.options![0],

--- a/src/storybook/styles/table/table.stories.ts
+++ b/src/storybook/styles/table/table.stories.ts
@@ -25,6 +25,12 @@ const striped: InputType = {
   },
 };
 
+const inlineFilters: InputType = {
+  control: {
+    type: 'boolean',
+  },
+};
+
 const colorTheme: InputType = {
   options: ['none', 'iron'],
   control: {
@@ -36,6 +42,7 @@ const defaultArgTypes: ArgTypes = {
   size,
   negative,
   striped,
+  inlineFilters,
   'color-theme': colorTheme,
 };
 
@@ -43,6 +50,7 @@ const defaultArgs: Args = {
   size: 'm',
   negative: false,
   striped: true,
+  'inline-filters': false,
   'color-theme': colorTheme.options![0],
 };
 
@@ -58,6 +66,21 @@ const header: () => TemplateResult = () => html`
       <th>Person</th>
       <th>Most interest in</th>
       <th>Age</th>
+    </tr>
+  </thead>
+`;
+
+const headerWithFilters: () => TemplateResult = () => html`
+  <thead>
+    <tr>
+      <th>Person</th>
+      <th>Most interest in</th>
+      <th>Age</th>
+    </tr>
+    <tr>
+      <th class="sbb-table-filter"><input /></th>
+      <th class="sbb-table-filter"><input /></th>
+      <th class="sbb-table-filter"><input /></th>
     </tr>
   </thead>
 `;
@@ -98,7 +121,7 @@ const Template = (args: Args): TemplateResult => html`
       'sbb-table--theme-iron': args['color-theme'] === 'iron',
     })}
   >
-    ${caption()} ${header()} ${body()}
+    ${caption()} ${args['inline-filters'] ? headerWithFilters() : header()} ${body()}
   </table>
 `;
 
@@ -130,6 +153,12 @@ export const IronTheme: StoryObj = {
   render: Template,
   argTypes: defaultArgTypes,
   args: { ...defaultArgs, 'color-theme': 'iron' },
+};
+
+export const WithFilters: StoryObj = {
+  render: Template,
+  argTypes: defaultArgTypes,
+  args: { ...defaultArgs, 'inline-filters': true, size: 's' },
 };
 
 const meta: Meta = {

--- a/src/storybook/styles/table/table.stories.ts
+++ b/src/storybook/styles/table/table.stories.ts
@@ -4,7 +4,7 @@ import type { TemplateResult } from 'lit';
 import { html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 
-import '@sbb-esta/lyne-elements/form-field.js';
+import '../../../elements/form-field.js';
 
 import readme from './readme.md?raw';
 

--- a/src/storybook/styles/table/table.stories.ts
+++ b/src/storybook/styles/table/table.stories.ts
@@ -4,6 +4,8 @@ import type { TemplateResult } from 'lit';
 import { html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 
+import '@sbb-esta/lyne-elements/form-field.js';
+
 import readme from './readme.md?raw';
 
 const size: InputType = {
@@ -78,9 +80,15 @@ const headerWithFilters: () => TemplateResult = () => html`
       <th>Age</th>
     </tr>
     <tr>
-      <th class="sbb-table-filter"><input /></th>
-      <th class="sbb-table-filter"><input /></th>
-      <th class="sbb-table-filter"><input /></th>
+      <th class="sbb-table-filter">
+        <sbb-form-field size="s"><input placeholder="Placeholder" /></sbb-form-field>
+      </th>
+      <th class="sbb-table-filter">
+        <sbb-form-field size="s"><input placeholder="Placeholder" /></sbb-form-field>
+      </th>
+      <th class="sbb-table-filter">
+        <sbb-form-field size="s"><input placeholder="Placeholder" /></sbb-form-field>
+      </th>
     </tr>
   </thead>
 `;

--- a/src/storybook/styles/table/table.visual.spec.ts
+++ b/src/storybook/styles/table/table.visual.spec.ts
@@ -79,7 +79,7 @@ describe(`table`, () => {
     </table>
   `;
 
-  describeViewports({ viewports: ['zero', 'medium'] }, () => {
+  describeViewports({ viewports: ['medium'] }, () => {
     describeEach(cases, ({ negative, striped }) => {
       beforeEach(async function () {
         root = await visualRegressionFixture(

--- a/src/storybook/styles/table/table.visual.spec.ts
+++ b/src/storybook/styles/table/table.visual.spec.ts
@@ -62,13 +62,9 @@ describe(`table`, () => {
   `;
 
   const caption = (): TemplateResult => html`
-    <thead>
-      <tr>
-        <th>Person</th>
-        <th>Most interest in</th>
-        <th>Age</th>
-      </tr>
-    </thead>
+    <caption>
+      Table caption
+    </caption>
   `;
 
   const tableTemplate = (classInfo: ClassInfo): TemplateResult => html`

--- a/src/storybook/styles/table/table.visual.spec.ts
+++ b/src/storybook/styles/table/table.visual.spec.ts
@@ -21,30 +21,65 @@ describe(`table`, () => {
     size: ['m', 's', 'xs'],
   };
 
+  const header = (): TemplateResult => html`
+    <thead>
+      <tr>
+        <th>Person</th>
+        <th>Most interest in</th>
+        <th>Age</th>
+      </tr>
+    </thead>
+  `;
+
+  const headerWithFilters = (): TemplateResult => html`
+    <thead>
+      <tr>
+        <th>Person</th>
+        <th>Most interest in</th>
+        <th>Age</th>
+      </tr>
+      <tr>
+        <th class="sbb-table-filter"><input /></th>
+        <th class="sbb-table-filter"><input /></th>
+        <th class="sbb-table-filter"><input /></th>
+      </tr>
+    </thead>
+  `;
+
+  const body = (): TemplateResult => html`
+    <tbody>
+      <tr>
+        <td>Chris</td>
+        <td>HTML tables</td>
+        <td>22</td>
+      </tr>
+      <tr>
+        <td>Dennis</td>
+        <td>Web accessibility</td>
+        <td>45</td>
+      </tr>
+    </tbody>
+  `;
+
+  const caption = (): TemplateResult => html`
+    <thead>
+      <tr>
+        <th>Person</th>
+        <th>Most interest in</th>
+        <th>Age</th>
+      </tr>
+    </thead>
+  `;
+
   const tableTemplate = (classInfo: ClassInfo): TemplateResult => html`
     <table class=${classMap(classInfo)}>
-      <thead>
-        <tr>
-          <th>Person</th>
-          <th>Most interest in</th>
-          <th>Age</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Chris</td>
-          <td>HTML tables</td>
-          <td>22</td>
-        </tr>
-        <tr>
-          <td>Dennis</td>
-          <td>Web accessibility</td>
-          <td>45</td>
-        </tr>
-      </tbody>
-      <caption>
-        Table caption
-      </caption>
+      ${header()} ${body()} ${caption()}
+    </table>
+  `;
+
+  const tableWithFiltersTemplate = (classInfo: ClassInfo): TemplateResult => html`
+    <table class=${classMap(classInfo)}>
+      ${headerWithFilters()} ${body()} ${caption()}
     </table>
   `;
 
@@ -78,6 +113,19 @@ describe(`table`, () => {
         visualDiffDefault.with(async (setup) => {
           await setup.withFixture(
             tableTemplate({
+              'sbb-table-xs': size === 'xs',
+              'sbb-table-s': size === 's',
+              'sbb-table-m': size === 'm',
+            }),
+          );
+        }),
+      );
+
+      it(
+        `size=${size} inline-filters`,
+        visualDiffDefault.with(async (setup) => {
+          await setup.withFixture(
+            tableWithFiltersTemplate({
               'sbb-table-xs': size === 'xs',
               'sbb-table-s': size === 's',
               'sbb-table-m': size === 'm',


### PR DESCRIPTION
Propaedeutic to the angular table example

Implementation of https://www.figma.com/design/mWknI2rC5DJmOgRO61WKai/Lyne-Components?node-id=11340-100695&m=dev