### PR TITLE
build: add lint rule for only using relative imports inside package

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,6 +43,7 @@ export default [
   ...eslintPluginYml.configs['flat/standard'],
   ...eslintPluginYml.configs['flat/prettier'],
   eslintPluginImportX.flatConfigs.recommended,
+  eslintPluginImportX.flatConfigs.typescript,
   eslintPluginLit.configs['flat/recommended'],
   eslintPluginLyne.configs.recommended,
   {
@@ -119,6 +120,7 @@ export default [
       '@typescript-eslint/semi': 'error',
 
       'import-x/first': 'error',
+      'import-x/newline-after-import': 'error',
       'import-x/no-absolute-path': 'error',
       'import-x/no-cycle': 'error',
       'import-x/no-self-import': 'error',

--- a/scripts/calculate-stats.ts
+++ b/scripts/calculate-stats.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { brotliCompress, gzip } from 'node:zlib';
 
-import ts from 'typescript';
+import * as ts from 'typescript';
 
 const gzipAsync = promisify(gzip);
 const brotliAsync = promisify(brotliCompress);

--- a/scripts/migrate-ssr-e2e.ts
+++ b/scripts/migrate-ssr-e2e.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import { basename, dirname, relative } from 'path';
 
 import * as glob from 'glob';
-import ts from 'typescript';
+import * as ts from 'typescript';
 
 /*
  * Convert e2e test files to use the lit fixture, to enable ssr testing.

--- a/scripts/migrate-ssr.ts
+++ b/scripts/migrate-ssr.ts
@@ -3,7 +3,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import * as glob from 'glob';
 // eslint-disable-next-line @typescript-eslint/naming-convention
 import MagicString from 'magic-string';
-import ts from 'typescript';
+import * as ts from 'typescript';
 
 /*
  * Convert e2e test files to use the lit fixture, to enable ssr testing.

--- a/scripts/migrate-toggle-data-entry.ts
+++ b/scripts/migrate-toggle-data-entry.ts
@@ -3,7 +3,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import * as glob from 'glob';
 // eslint-disable-next-line @typescript-eslint/naming-convention
 import MagicString from 'magic-string';
-import ts from 'typescript';
+import * as ts from 'typescript';
 
 function* iterate(node: ts.Node): Generator<ts.Node, void, unknown> {
   yield node;

--- a/src/react/core/create-component.ts
+++ b/src/react/core/create-component.ts
@@ -3,6 +3,8 @@
   @typescript-eslint/naming-convention,
   @typescript-eslint/naming-convention,
   @typescript-eslint/no-empty-object-type,
+  import-x/default,
+  import-x/no-named-as-default-member,
 */
 /**
  * Copied from https://github.com/lit/lit/blob/main/packages/react/src/create-component.ts

--- a/src/visual-regression-app/package.json
+++ b/src/visual-regression-app/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@sbb-esta/visual-regression-app",
+  "version": "0.0.0-PLACEHOLDER"
+}

--- a/src/visual-regression-app/src/components/test-case/image-diff/fullscreen-diff/fullscreen-diff.ts
+++ b/src/visual-regression-app/src/components/test-case/image-diff/fullscreen-diff/fullscreen-diff.ts
@@ -1,3 +1,4 @@
+import type { SbbRadioButtonGroupElement } from '@sbb-esta/lyne-elements/radio-button/radio-button-group/radio-button-group.js';
 import { LitElement, html, type TemplateResult, type CSSResultGroup, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 // eslint-disable-next-line import-x/no-unresolved
@@ -9,7 +10,6 @@ import style from './fullscreen-diff.scss?lit&inline';
 
 import '@sbb-esta/lyne-elements/chip-label.js';
 import '@sbb-esta/lyne-elements/radio-button.js';
-import type { SbbRadioButtonGroupElement } from '@sbb-esta/lyne-elements/radio-button/radio-button-group/radio-button-group.js';
 
 export type DiffFileType = 'baselineFile' | 'failedFile' | 'diffFile';
 

--- a/src/visual-regression-app/src/components/test-case/image-diff/image-diff.ts
+++ b/src/visual-regression-app/src/components/test-case/image-diff/image-diff.ts
@@ -1,3 +1,6 @@
+import { forceType } from '@sbb-esta/lyne-elements/core/decorators.js';
+import { SbbOverlayElement } from '@sbb-esta/lyne-elements/overlay/overlay.js';
+import type { SbbToggleCheckElement } from '@sbb-esta/lyne-elements/toggle-check/toggle-check.js';
 import { type CSSResultGroup, html, LitElement, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 // eslint-disable-next-line import-x/no-unresolved
@@ -6,10 +9,6 @@ import { meta } from 'virtual:meta';
 import type { ScreenshotFiles } from '../../../interfaces.js';
 
 import style from './image-diff.scss?lit&inline';
-
-import { forceType } from '@sbb-esta/lyne-elements/core/decorators.js';
-import { SbbOverlayElement } from '@sbb-esta/lyne-elements/overlay/overlay.js';
-import type { SbbToggleCheckElement } from '@sbb-esta/lyne-elements/toggle-check/toggle-check.js';
 
 import '@sbb-esta/lyne-elements/chip-label.js';
 import '@sbb-esta/lyne-elements/status.js';

--- a/src/visual-regression-app/src/components/test-case/test-case-filter/test-case-filter.ts
+++ b/src/visual-regression-app/src/components/test-case/test-case-filter/test-case-filter.ts
@@ -1,3 +1,4 @@
+import type { SbbTagElement } from '@sbb-esta/lyne-elements/tag/tag/tag.js';
 import { LitElement, html, type TemplateResult, type CSSResultGroup } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
@@ -5,7 +6,6 @@ import { type ScreenshotTestCase } from '../../../screenshots.js';
 
 import style from './test-case-filter.scss?lit&inline';
 
-import type { SbbTagElement } from '@sbb-esta/lyne-elements/tag/tag/tag.js';
 import '@sbb-esta/lyne-elements/title.js';
 import '@sbb-esta/lyne-elements/tag.js';
 

--- a/src/visual-regression-app/src/components/test-case/test-case.ts
+++ b/src/visual-regression-app/src/components/test-case/test-case.ts
@@ -1,3 +1,4 @@
+import type { SbbToggleCheckElement } from '@sbb-esta/lyne-elements/toggle-check.js';
 import {
   type CSSResultGroup,
   html,
@@ -10,17 +11,15 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 import { screenshots, type ScreenshotTestCase } from '../../screenshots.js';
 
+import type { TestCaseFilter } from './test-case-filter/test-case-filter.js';
+import style from './test-case.scss?lit&inline';
+
 import '@sbb-esta/lyne-elements/button/secondary-button-link.js';
 import '@sbb-esta/lyne-elements/chip-label.js';
 import '@sbb-esta/lyne-elements/container.js';
 import '@sbb-esta/lyne-elements/header.js';
 import '@sbb-esta/lyne-elements/notification.js';
 import '@sbb-esta/lyne-elements/title.js';
-
-import type { TestCaseFilter } from './test-case-filter/test-case-filter.js';
-import style from './test-case.scss?lit&inline';
-
-import type { SbbToggleCheckElement } from '@sbb-esta/lyne-elements/toggle-check.js';
 
 import './test-title-chip-list/test-title-chip-list.js';
 import './image-diff/image-diff.js';

--- a/tools/eslint/index.ts
+++ b/tools/eslint/index.ts
@@ -16,6 +16,7 @@ export const rules = (
       'property-decorator-accessor-rule',
       'property-decorator-setter-initializer-rule',
       'property-type-rule',
+      'relative-imports-rule',
       'test-describe-title-rule',
       'test-tabkey-rule',
     ].map((name) =>

--- a/tools/eslint/relative-imports-rule.ts
+++ b/tools/eslint/relative-imports-rule.ts
@@ -1,0 +1,68 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+export default ESLintUtils.RuleCreator.withoutDocs({
+  create(context) {
+    let packageRoot = '';
+    let packageName = '';
+    const findPackageName = (): string => {
+      if (packageName) {
+        return packageName;
+      }
+
+      let dir = dirname(context.physicalFilename);
+      while (dir !== dirname(dir)) {
+        const potentialPackageJsonPath = join(dir, 'package.json');
+        if (existsSync(potentialPackageJsonPath)) {
+          packageRoot = dir;
+          packageName = JSON.parse(readFileSync(potentialPackageJsonPath, 'utf8')).name;
+          return packageName;
+        }
+
+        dir = dirname(dir);
+      }
+
+      throw new Error('package.json not found');
+    };
+
+    return {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      ImportDeclaration(node) {
+        // Our packages all start with @sbb, so we can save a bit of
+        // computation time if we exclude anything that does not start
+        // with that.
+        if (
+          node.source.value.startsWith('@sbb') &&
+          node.source.value.startsWith(findPackageName())
+        ) {
+          context.report({
+            messageId: 'nonRelativeImport',
+            node,
+            fix: (fixer) =>
+              fixer.replaceText(
+                node.source,
+                `'${relative(
+                  dirname(context.physicalFilename),
+                  packageRoot + node.source.value.substring(packageName.length),
+                )}'`,
+              ),
+          });
+        }
+      },
+    };
+  },
+  meta: {
+    docs: {
+      description: 'Imports to a module inside the same package should be relative',
+    },
+    messages: {
+      nonRelativeImport: 'Import should not use own package name',
+    },
+    fixable: 'code',
+    type: 'problem',
+    schema: [],
+  },
+  defaultOptions: [],
+});

--- a/tools/web-test-runner/configure-container-playwright-browser.ts
+++ b/tools/web-test-runner/configure-container-playwright-browser.ts
@@ -29,6 +29,7 @@ export function configureRemotePlaywrightBrowser(browser: PlaywrightLauncher): v
 
     if (!this.browser || !this.browser?.isConnected()) {
       this.__connectBrowserPromise = (async () => {
+        // eslint-disable-next-line import-x/namespace
         const browser = await playwright[this.product].connect(playwrightWebsocketAddress, {
           headers: { 'x-playwright-launch-options': JSON.stringify(this.launchOptions) },
         });


### PR DESCRIPTION
This PR adds an eslint rule to only allow relative imports inside a package. It also implements a fixer to automatically fix failing cases.