### PR TITLE
refactor: remove async overrides to avoid changing signature

### DIFF
--- a/src/elements/alert/alert/alert.ts
+++ b/src/elements/alert/alert/alert.ts
@@ -98,7 +98,7 @@ class SbbAlertElement extends SbbIconNameMixin(SbbOpenCloseBaseElement) {
     }
   }
 
-  protected override async firstUpdated(changedProperties: PropertyValues<this>): Promise<void> {
+  protected override firstUpdated(changedProperties: PropertyValues<this>): void {
     super.firstUpdated(changedProperties);
 
     this.open();

--- a/src/elements/clock/clock.ts
+++ b/src/elements/clock/clock.ts
@@ -109,12 +109,12 @@ class SbbClockElement extends LitElement {
     }
   }
 
-  protected override async firstUpdated(changedProperties: PropertyValues<this>): Promise<void> {
+  protected override firstUpdated(changedProperties: PropertyValues<this>): void {
     super.firstUpdated(changedProperties);
 
     if (!isServer) {
       document.addEventListener('visibilitychange', this._handlePageVisibilityChange, false);
-      await this._startOrConfigureClock();
+      this._startOrConfigureClock();
     }
   }
 

--- a/src/elements/core/mixins/form-associated-input-mixin.ts
+++ b/src/elements/core/mixins/form-associated-input-mixin.ts
@@ -338,7 +338,7 @@ export const SbbFormAssociatedInputMixin = <T extends Constructor<LitElement>>(
       }
     }
 
-    protected override async firstUpdated(changedProperties: PropertyValues<this>): Promise<void> {
+    protected override firstUpdated(changedProperties: PropertyValues<this>): void {
       super.firstUpdated(changedProperties);
 
       // If the value was assigned before firstUpdate, we have to

--- a/src/elements/image/image.ts
+++ b/src/elements/image/image.ts
@@ -380,14 +380,15 @@ class SbbImageElement extends LitElement {
     this._addFocusAbilityToLinksInCaption();
   }
 
-  protected override async firstUpdated(changedProperties: PropertyValues<this>): Promise<void> {
+  protected override firstUpdated(changedProperties: PropertyValues<this>): void {
     super.firstUpdated(changedProperties);
 
     // We need to wait until the update is complete to check whether the image has already been completely loaded.
-    await this.updateComplete;
-    if (this.complete) {
-      this.toggleAttribute('data-loaded', true);
-    }
+    this.updateComplete.then(() => {
+      if (this.complete) {
+        this.toggleAttribute('data-loaded', true);
+      }
+    });
   }
 
   private _logPerformanceMarks(): void {

--- a/src/elements/notification/notification.ts
+++ b/src/elements/notification/notification.ts
@@ -162,7 +162,7 @@ class SbbNotificationElement extends LitElement {
     super.connectedCallback();
   }
 
-  protected override async firstUpdated(changedProperties: PropertyValues<this>): Promise<void> {
+  protected override firstUpdated(changedProperties: PropertyValues<this>): void {
     super.firstUpdated(changedProperties);
 
     this._notificationElement = this.shadowRoot?.querySelector(
@@ -170,9 +170,10 @@ class SbbNotificationElement extends LitElement {
     ) as HTMLElement;
     // We need to wait for the component's `updateComplete` in order to set the correct
     // height to the notification element.
-    await this.updateComplete;
-    this._setNotificationHeight();
-    this._open();
+    this.updateComplete.then(() => {
+      this._setNotificationHeight();
+      this._open();
+    });
   }
 
   private _isZeroAnimationDuration(): boolean {

--- a/src/elements/radio-button/radio-button-group/radio-button-group.ts
+++ b/src/elements/radio-button/radio-button-group/radio-button-group.ts
@@ -146,11 +146,10 @@ class SbbRadioButtonGroupElement extends SbbDisabledMixin(LitElement) {
     }
   }
 
-  protected override async firstUpdated(changedProperties: PropertyValues<this>): Promise<void> {
+  protected override firstUpdated(changedProperties: PropertyValues<this>): void {
     super.firstUpdated(changedProperties);
 
-    await this.updateComplete;
-    this._updateRadioState();
+    this.updateComplete.then(() => this._updateRadioState());
   }
 
   private _onRadioChange(event: Event): void {

--- a/src/elements/stepper/stepper/stepper.ts
+++ b/src/elements/stepper/stepper/stepper.ts
@@ -301,15 +301,16 @@ class SbbStepperElement extends SbbHydrationMixin(LitElement) {
     window.removeEventListener('resize', this._onStepperResize);
   }
 
-  protected override async firstUpdated(changedProperties: PropertyValues<this>): Promise<void> {
+  protected override firstUpdated(changedProperties: PropertyValues<this>): void {
     super.firstUpdated(changedProperties);
-    await this.updateComplete;
-    this._loaded = true;
-    this.selectedIndex = this.linear ? 0 : Number(this.getAttribute('selected-index')) || 0;
-    this._observer.observe(this);
-    this._checkOrientation();
-    // Remove [data-disable-animation] after component init
-    setTimeout(() => this.toggleAttribute('data-disable-animation', false), DEBOUNCE_TIME);
+    this.updateComplete.then(() => {
+      this._loaded = true;
+      this.selectedIndex = this.linear ? 0 : Number(this.getAttribute('selected-index')) || 0;
+      this._observer.observe(this);
+      this._checkOrientation();
+      // Remove [data-disable-animation] after component init
+      setTimeout(() => this.toggleAttribute('data-disable-animation', false), DEBOUNCE_TIME);
+    });
   }
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {

--- a/src/elements/toggle/toggle/toggle.ts
+++ b/src/elements/toggle/toggle/toggle.ts
@@ -110,12 +110,13 @@ class SbbToggleElement extends SbbDisabledMixin(SbbFormAssociatedMixin(LitElemen
     }
   }
 
-  protected override async firstUpdated(changedProperties: PropertyValues<this>): Promise<void> {
+  protected override firstUpdated(changedProperties: PropertyValues<this>): void {
     super.firstUpdated(changedProperties);
 
-    await this.updateComplete;
-    this._loaded = true;
-    this.statusChanged();
+    this.updateComplete.then(() => {
+      this._loaded = true;
+      this.statusChanged();
+    });
   }
 
   /**


### PR DESCRIPTION
BREAKING CHANGE: removed async modifier of all firstUpdated() overrides.