### PR TITLE
fix(sbb-date-input): handle null like the native text input

### DIFF
--- a/src/elements/core/mixins/form-associated-input-mixin.ts
+++ b/src/elements/core/mixins/form-associated-input-mixin.ts
@@ -367,7 +367,7 @@ export const SbbFormAssociatedInputMixin = <T extends Constructor<LitElement>>(
 
     private _cleanText(value: string): string {
       // The native text input removes all newline characters if passed to the value property
-      return `${value}`.replace(/[\n\r]+/g, '');
+      return value === null ? '' : `${value}`.replace(/[\n\r]+/g, '');
     }
 
     private _dispatchInputEvent(): void {

--- a/src/elements/date-input/date-input.spec.ts
+++ b/src/elements/date-input/date-input.spec.ts
@@ -104,6 +104,18 @@ describe('sbb-date-input', () => {
     expect(element.valueAsDate).not.to.be.null;
   });
 
+  it('should handle value=null like the native text input', async () => {
+    element = await fixture(html`<sbb-date-input></sbb-date-input>`);
+    element.value = null!;
+    expect(element.value).to.be.equal('');
+  });
+
+  it('should handle value=undefined like the native text input', async () => {
+    element = await fixture(html`<sbb-date-input></sbb-date-input>`);
+    element.value = undefined!;
+    expect(element.value).to.be.equal('undefined');
+  });
+
   describe('with no value', () => {
     beforeEach(async () => {
       element = await fixture(html`<sbb-date-input></sbb-date-input>`);


### PR DESCRIPTION
Currently assigning null to `SbbDateInput.value` will result in `value` being `'null'`. This is in contrast to the native text input, where, if you assign `null`, it will result in `value` being `''`.
As our goal is to align as closely as possible to the native behavior, we also adapt this.