### PR TITLE
fix(sbb-toggle): fix animation glitches

### DIFF
--- a/src/elements/toggle/toggle-option/toggle-option.component.ts
+++ b/src/elements/toggle/toggle-option/toggle-option.component.ts
@@ -64,11 +64,18 @@ class SbbToggleOptionElement extends SbbDisabledMixin(SbbIconNameMixin(LitElemen
     // We can use closest here, as we expect the parent sbb-toggle to be in light DOM.
     this._toggle = this.closest?.('sbb-toggle') ?? null;
     this._verifyTabindex();
+    this._toggle?.updatePillPosition(true);
   }
 
   public override disconnectedCallback(): void {
     super.disconnectedCallback();
     this._toggle = null;
+  }
+
+  public override firstUpdated(changedProperties: PropertyValues<this>): void {
+    super.firstUpdated(changedProperties);
+
+    this._toggle?.updatePillPosition(true);
   }
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {

--- a/src/elements/toggle/toggle-option/toggle-option.component.ts
+++ b/src/elements/toggle/toggle-option/toggle-option.component.ts
@@ -53,7 +53,7 @@ class SbbToggleOptionElement extends SbbDisabledMixin(SbbIconNameMixin(LitElemen
     this.addController(
       new ResizeController(this, {
         skipInitial: true,
-        callback: () => this._toggle?.updatePillPosition(true),
+        callback: () => this._toggle?.updatePillPosition?.(true),
       }),
     );
   }
@@ -64,7 +64,7 @@ class SbbToggleOptionElement extends SbbDisabledMixin(SbbIconNameMixin(LitElemen
     // We can use closest here, as we expect the parent sbb-toggle to be in light DOM.
     this._toggle = this.closest?.('sbb-toggle') ?? null;
     this._verifyTabindex();
-    this._toggle?.updatePillPosition(true);
+    this._toggle?.updatePillPosition?.(true);
   }
 
   public override disconnectedCallback(): void {
@@ -75,7 +75,7 @@ class SbbToggleOptionElement extends SbbDisabledMixin(SbbIconNameMixin(LitElemen
   public override firstUpdated(changedProperties: PropertyValues<this>): void {
     super.firstUpdated(changedProperties);
 
-    this._toggle?.updatePillPosition(true);
+    this._toggle?.updatePillPosition?.(true);
   }
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {

--- a/src/elements/toggle/toggle-option/toggle-option.scss
+++ b/src/elements/toggle/toggle-option/toggle-option.scss
@@ -35,11 +35,6 @@
   height: var(--sbb-toggle-height);
   padding-inline: var(--sbb-toggle-padding-inline);
   color: var(--sbb-toggle-option-color);
-
-  // if ![icon-only]
-  :host([data-slot-names~='unnamed']:where([data-slot-names~='icon'], [icon-name])) & {
-    gap: var(--sbb-spacing-fixed-1x);
-  }
 }
 
 .sbb-toggle-option__label {
@@ -50,4 +45,5 @@ sbb-icon,
 ::slotted(sbb-icon) {
   min-width: var(--sbb-toggle-option-icon-min-size);
   min-height: var(--sbb-toggle-option-icon-min-size);
+  margin-inline-end: var(--sbb-spacing-fixed-1x);
 }

--- a/src/elements/toggle/toggle/__snapshots__/toggle.snapshot.spec.snap.js
+++ b/src/elements/toggle/toggle/__snapshots__/toggle.snapshot.spec.snap.js
@@ -2,7 +2,10 @@
 export const snapshots = {};
 
 snapshots["sbb-toggle renders DOM"] = 
-`<sbb-toggle size="m">
+`<sbb-toggle
+  data-initialized=""
+  size="m"
+>
   <sbb-toggle-option
     aria-checked="true"
     checked=""

--- a/src/elements/toggle/toggle/toggle.scss
+++ b/src/elements/toggle/toggle/toggle.scss
@@ -78,11 +78,7 @@
   border-radius: var(--sbb-toggle-border-radius);
 
   &::before {
-    // We have to hide the pill until initialized to avoid an transition glitch
-    :host([data-initialized]) & {
-      content: '';
-    }
-
+    content: '';
     grid-area: start / start / end / end;
     padding-inline: var(--sbb-toggle-padding-inline);
     margin-inline: var(--sbb-toggle-option-left, 0) var(--sbb-toggle-option-right, 0);


### PR DESCRIPTION
With the previous solution, on sbb.ch it causes problems when resizing the window. Furthermore, with the new solution, the correct pill can be shown earlier, preventing a rendering without the pill and therefore provides a smoother experience.