### PR TITLE
docs: fix broken docs

### DIFF
--- a/src/elements/datepicker/datepicker/readme.md
+++ b/src/elements/datepicker/datepicker/readme.md
@@ -1,7 +1,8 @@
 The `sbb-datepicker` is a component which can be used together with an `<sbb-date-input>` element
 to display the typed value as a formatted date (default: `dd.MM.yyyy`).
 
-The component allows the insertion of up to 10 numbers, possibly with separators like `.`, `-`, ` `, `,` or `/`,
+The component allows the insertion of up to 10 numbers,
+possibly with separators like empty space, dot (`.`), hyphen (`-`), comma (`,`), slash (`/`) or forward slash (`\`),
 then automatically formats the value as date and displays it.
 It also allows to get / set the value formatted as Date via the `valueAsDate` property.
 

--- a/src/elements/datepicker/datepicker/readme.md
+++ b/src/elements/datepicker/datepicker/readme.md
@@ -2,7 +2,7 @@ The `sbb-datepicker` is a component which can be used together with an `<sbb-dat
 to display the typed value as a formatted date (default: `dd.MM.yyyy`).
 
 The component allows the insertion of up to 10 numbers,
-possibly with separators like empty space, dot (`.`), hyphen (`-`), comma (`,`), slash (`/`) or forward slash (`\`),
+possibly with separators like white space, dot (`.`), hyphen (`-`), comma (`,`), slash (`/`) or backslash (`\`),
 then automatically formats the value as date and displays it.
 It also allows to get / set the value formatted as Date via the `valueAsDate` property.
 


### PR DESCRIPTION
The docs on the `sbb-datepicker` is broken

![image](https://github.com/user-attachments/assets/6a5b7a91-adf8-48d5-8cdb-8f3270ff0398)
