### PR TITLE
refactor: remove autocompleteOptionSelectionChange event

### DIFF
--- a/src/elements/autocomplete-grid/autocomplete-grid-option/autocomplete-grid-option.component.ts
+++ b/src/elements/autocomplete-grid/autocomplete-grid-option/autocomplete-grid-option.component.ts
@@ -14,7 +14,6 @@ export const autocompleteGridOptionId: string = `sbb-autocomplete-grid-option`;
  *
  * @slot - Use the unnamed slot to add content to the option label.
  * @slot icon - Use this slot to provide an icon. If `icon-name` is set, a sbb-icon will be used.
- * @event {CustomEvent<void>} autocompleteOptionSelectionChange - Emits when the option selection status changes.
  * @event {CustomEvent<void>} autocompleteOptionSelected - Emits when an option was selected by user.
  * @cssprop [--sbb-option-icon-container-display=none] - Can be used to reserve space even
  * when preserve-icon-space on autocomplete is not set or iconName is not set.
@@ -27,17 +26,10 @@ export
 class SbbAutocompleteGridOptionElement extends SbbOptionBaseElement {
   public static override styles: CSSResultGroup = style;
   public static readonly events = {
-    selectionChange: 'autocompleteOptionSelectionChange',
     optionSelected: 'autocompleteOptionSelected',
   } as const;
 
   protected optionId = autocompleteGridOptionId;
-
-  /** Emits when the option selection status changes. */
-  protected selectionChange: EventEmitter = new EventEmitter(
-    this,
-    SbbAutocompleteGridOptionElement.events.selectionChange,
-  );
 
   /** Emits when an option was selected by user. */
   protected optionSelected: EventEmitter = new EventEmitter(
@@ -85,7 +77,7 @@ class SbbAutocompleteGridOptionElement extends SbbOptionBaseElement {
       return;
     }
 
-    this.setSelectedViaUserInteraction(true);
+    this.selectViaUserInteraction(true);
   }
 }
 
@@ -96,6 +88,6 @@ declare global {
   }
 
   interface GlobalEventHandlersEventMap {
-    autocompleteOptionSelectionChange: CustomEvent<void>;
+    autocompleteOptionSelected: CustomEvent<void>;
   }
 }

--- a/src/elements/autocomplete-grid/autocomplete-grid-option/autocomplete-grid-option.spec.ts
+++ b/src/elements/autocomplete-grid/autocomplete-grid-option/autocomplete-grid-option.spec.ts
@@ -47,9 +47,7 @@ describe(`sbb-autocomplete-grid-option`, () => {
   });
 
   it('set selected and emits on click', async () => {
-    const selectionChangeSpy = new EventSpy(
-      SbbAutocompleteGridOptionElement.events.selectionChange,
-    );
+    const optionSelectedSpy = new EventSpy(SbbAutocompleteGridOptionElement.events.optionSelected);
     const optionOne = element.querySelector<SbbAutocompleteGridOptionElement>(
       'sbb-autocomplete-grid-option',
     )!;
@@ -58,7 +56,7 @@ describe(`sbb-autocomplete-grid-option`, () => {
     await waitForLitRender(element);
 
     expect(optionOne.selected).to.be.equal(true);
-    expect(selectionChangeSpy.count).to.be.equal(1);
+    expect(optionSelectedSpy.count).to.be.equal(1);
   });
 
   it('highlight on input', async () => {

--- a/src/elements/autocomplete-grid/autocomplete-grid-option/autocomplete-grid-option.stories.ts
+++ b/src/elements/autocomplete-grid/autocomplete-grid-option/autocomplete-grid-option.stories.ts
@@ -161,10 +161,7 @@ const meta: Meta = {
     backgroundColor: (context: StoryContext) =>
       context.args.negative ? 'var(--sbb-color-black)' : 'var(--sbb-color-white)',
     actions: {
-      handles: [
-        SbbAutocompleteGridOptionElement.events.selectionChange,
-        SbbAutocompleteGridOptionElement.events.optionSelected,
-      ],
+      handles: [SbbAutocompleteGridOptionElement.events.optionSelected],
     },
     docs: {
       // Setting the iFrame height ensures that the story has enough space when used in the docs section.

--- a/src/elements/autocomplete-grid/autocomplete-grid-option/readme.md
+++ b/src/elements/autocomplete-grid/autocomplete-grid-option/readme.md
@@ -93,10 +93,9 @@ which is needed to correctly set the `aria-activedescendant` on the related `inp
 
 ## Events
 
-| Name                                | Type                | Description                                     | Inherited From |
-| ----------------------------------- | ------------------- | ----------------------------------------------- | -------------- |
-| `autocompleteOptionSelected`        | `CustomEvent<void>` | Emits when an option was selected by user.      |                |
-| `autocompleteOptionSelectionChange` | `CustomEvent<void>` | Emits when the option selection status changes. |                |
+| Name                         | Type                | Description                                | Inherited From |
+| ---------------------------- | ------------------- | ------------------------------------------ | -------------- |
+| `autocompleteOptionSelected` | `CustomEvent<void>` | Emits when an option was selected by user. |                |
 
 ## CSS Properties
 

--- a/src/elements/autocomplete-grid/autocomplete-grid/autocomplete-grid.component.ts
+++ b/src/elements/autocomplete-grid/autocomplete-grid/autocomplete-grid.component.ts
@@ -56,7 +56,7 @@ class SbbAutocompleteGridElement extends SbbAutocompleteBaseElement {
 
   public constructor() {
     super();
-    this.addEventListener?.('autocompleteOptionSelectionChange', (e: CustomEvent<void>) =>
+    this.addEventListener?.('autocompleteOptionSelected', (e: CustomEvent<void>) =>
       this.onOptionSelected(e),
     );
   }
@@ -114,7 +114,7 @@ class SbbAutocompleteGridElement extends SbbAutocompleteBaseElement {
         )[this._activeColumnIndex] as SbbAutocompleteGridButtonElement
       ).click();
     } else {
-      this.options[this._activeItemIndex]?.setSelectedViaUserInteraction(true);
+      this.options[this._activeItemIndex]?.['selectViaUserInteraction'](true);
     }
   }
 

--- a/src/elements/autocomplete/autocomplete-base-element.ts
+++ b/src/elements/autocomplete/autocomplete-base-element.ts
@@ -240,9 +240,6 @@ abstract class SbbAutocompleteBaseElement extends SbbNegativeMixin(
   /** When an option is selected, update the input value and close the autocomplete. */
   protected onOptionSelected(event: CustomEvent): void {
     const target = event.target as SbbOptionBaseElement;
-    if (!target.selected) {
-      return;
-    }
 
     // Deselect the previous options
     this.options

--- a/src/elements/autocomplete/autocomplete.component.ts
+++ b/src/elements/autocomplete/autocomplete.component.ts
@@ -44,9 +44,7 @@ class SbbAutocompleteElement extends SbbAutocompleteBaseElement {
 
   public constructor() {
     super();
-    this.addEventListener?.('optionSelectionChange', (e: CustomEvent<void>) =>
-      this.onOptionSelected(e),
-    );
+    this.addEventListener?.('optionSelected', (e: CustomEvent<void>) => this.onOptionSelected(e));
   }
 
   protected syncNegative(): void {
@@ -83,7 +81,7 @@ class SbbAutocompleteElement extends SbbAutocompleteBaseElement {
     const activeOption = this.options[this._activeItemIndex];
 
     if (activeOption) {
-      activeOption.setSelectedViaUserInteraction(true);
+      activeOption['selectViaUserInteraction'](true);
     }
   }
 

--- a/src/elements/option/option/option-base-element.ts
+++ b/src/elements/option/option/option-base-element.ts
@@ -59,9 +59,6 @@ abstract class SbbOptionBaseElement extends SbbDisabledMixin(
     return this.hasAttribute('selected');
   }
 
-  /** Emits when the option selection status changes. */
-  protected abstract selectionChange: EventEmitter;
-
   /** Emits when an option was selected by user. */
   protected abstract optionSelected: EventEmitter;
 
@@ -122,12 +119,8 @@ abstract class SbbOptionBaseElement extends SbbDisabledMixin(
     this._highlightString = value;
   }
 
-  /**
-   * @internal
-   */
-  public setSelectedViaUserInteraction(selected: boolean): void {
+  protected selectViaUserInteraction(selected: boolean): void {
     this.selected = selected;
-    this.selectionChange.emit();
     if (this.selected) {
       this.optionSelected.emit();
     }

--- a/src/elements/option/option/option.component.ts
+++ b/src/elements/option/option/option.component.ts
@@ -87,14 +87,19 @@ class SbbOptionElement extends SbbOptionBaseElement {
 
     if (this._isMultiple) {
       event.stopPropagation();
-      this.setSelectedViaUserInteraction(!this.selected);
+      this.selectViaUserInteraction(!this.selected);
     } else {
-      this.setSelectedViaUserInteraction(true);
+      this.selectViaUserInteraction(true);
     }
   }
 
   public override connectedCallback(): void {
     super.connectedCallback();
+  }
+
+  protected override selectViaUserInteraction(selected: boolean): void {
+    super.selectViaUserInteraction(selected);
+    this.selectionChange.emit();
   }
 
   protected override init(): void {
@@ -165,5 +170,6 @@ declare global {
 
   interface GlobalEventHandlersEventMap {
     optionSelectionChange: CustomEvent<void>;
+    optionSelected: CustomEvent<void>;
   }
 }

--- a/src/elements/select/select.component.ts
+++ b/src/elements/select/select.component.ts
@@ -777,7 +777,7 @@ class SbbSelectElement extends SbbUpdateSchedulerMixin(
     const activeOption: SbbOptionElement = this._filteredOptions[this._activeItemIndex];
 
     if (this.multiple) {
-      activeOption.setSelectedViaUserInteraction(!activeOption.selected);
+      activeOption['selectViaUserInteraction'](!activeOption.selected);
     } else {
       this.close();
     }
@@ -801,7 +801,7 @@ class SbbSelectElement extends SbbUpdateSchedulerMixin(
     if (!this.multiple) {
       this._setSelectedElement(nextOption, activeOption);
     } else if (event?.shiftKey) {
-      nextOption.setSelectedViaUserInteraction(!nextOption.selected);
+      nextOption['selectViaUserInteraction'](!nextOption.selected);
     }
     this._activeItemIndex = nextIndex;
   }
@@ -828,10 +828,10 @@ class SbbSelectElement extends SbbUpdateSchedulerMixin(
     nextActiveOption: SbbOptionElement,
     lastActiveOption: SbbOptionElement,
   ): void {
-    nextActiveOption.setSelectedViaUserInteraction(true);
+    nextActiveOption['selectViaUserInteraction'](true);
 
     if (lastActiveOption && lastActiveOption !== nextActiveOption) {
-      lastActiveOption.setSelectedViaUserInteraction(false);
+      lastActiveOption['selectViaUserInteraction'](false);
     }
   }
 


### PR DESCRIPTION
BREAKING CHANGE: Removed the following event and method
- removed autocompleteOptionSelectionChange event
- removed setSelectedViaUserInteraction method
