### PR TITLE
fix(sbb-select, sbb-slider): display readonly state correctly if set by property

### DIFF
--- a/src/elements/select/select.component.ts
+++ b/src/elements/select/select.component.ts
@@ -118,7 +118,7 @@ class SbbSelectElement extends SbbUpdateSchedulerMixin(
   @handleDistinctChange((e: SbbSelectElement, newValue: boolean) =>
     e._closeOnDisabledReadonlyChanged(newValue),
   )
-  @property({ type: Boolean })
+  @property({ type: Boolean, reflect: true })
   public accessor readonly: boolean = false;
 
   /**

--- a/src/elements/slider/slider.component.ts
+++ b/src/elements/slider/slider.component.ts
@@ -97,7 +97,7 @@ class SbbSliderElement extends SbbDisabledMixin(SbbFormAssociatedMixin(LitElemen
    * Since the input range does not allow this attribute, it will be merged with the `disabled` one.
    */
   @forceType()
-  @property({ type: Boolean })
+  @property({ type: Boolean, reflect: true })
   public accessor readonly: boolean = false;
 
   /** Name of the icon at component's start, which will be forward to the nested `sbb-icon`. */


### PR DESCRIPTION
Closes #3697