### PR TITLE
fix(sbb-toast): fix a11y on windows browsers

### DIFF
--- a/src/elements/toast/__snapshots__/toast.snapshot.spec.snap.js
+++ b/src/elements/toast/__snapshots__/toast.snapshot.spec.snap.js
@@ -12,7 +12,7 @@ snapshots["sbb-toast renders DOM"] =
   position="bottom-center"
 >
   <span>
-    'Lorem ipsum dolor'
+    Lorem ipsum dolor
   </span>
 </sbb-toast>
 `;
@@ -77,4 +77,75 @@ snapshots["sbb-toast renders A11y tree Firefox"] =
 </p>
 `;
 /* end snapshot sbb-toast renders A11y tree Firefox */
+
+snapshots["sbb-toast renders with action DOM"] = 
+`<sbb-toast
+  aria-live="polite"
+  data-slot-names="action unnamed"
+  data-state="closed"
+  dismissible=""
+  icon-name="circle-tick-small"
+  popover="manual"
+  position="bottom-center"
+>
+  <span>
+    Lorem ipsum dolor
+  </span>
+  <sbb-link
+    data-action=""
+    data-link=""
+    data-sbb-link=""
+    data-slot-names="unnamed"
+    href="https://www.sbb.ch"
+    negative=""
+    sbb-toast-close=""
+    size="s"
+    slot="action"
+    target="_blank"
+  >
+    Link action
+  </sbb-link>
+</sbb-toast>
+`;
+/* end snapshot sbb-toast renders with action DOM */
+
+snapshots["sbb-toast renders with action Shadow DOM"] = 
+`<div class="sbb-toast__overlay-container">
+  <div class="sbb-toast">
+    <div class="sbb-toast__icon">
+      <slot name="icon">
+        <sbb-icon
+          aria-hidden="true"
+          data-namespace="default"
+          name="circle-tick-small"
+          role="img"
+        >
+        </sbb-icon>
+      </slot>
+    </div>
+    <div class="sbb-toast__content">
+      <slot>
+      </slot>
+    </div>
+    <div class="sbb-toast__action">
+      <slot name="action">
+        <sbb-transparent-button
+          aria-label="Close message"
+          class="sbb-toast__action-button"
+          data-action=""
+          data-button=""
+          data-sbb-button=""
+          icon-name="cross-small"
+          negative=""
+          sbb-toast-close=""
+          size="m"
+          tabindex="0"
+        >
+        </sbb-transparent-button>
+      </slot>
+    </div>
+  </div>
+</div>
+`;
+/* end snapshot sbb-toast renders with action Shadow DOM */
 

--- a/src/elements/toast/__snapshots__/toast.snapshot.spec.snap.js
+++ b/src/elements/toast/__snapshots__/toast.snapshot.spec.snap.js
@@ -1,8 +1,9 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["sbb-toast renders Chrome-Safari DOM"] = 
+snapshots["sbb-toast renders DOM"] = 
 `<sbb-toast
+  aria-live="polite"
   data-slot-names="unnamed"
   data-state="closed"
   dismissible=""
@@ -15,9 +16,9 @@ snapshots["sbb-toast renders Chrome-Safari DOM"] =
   </span>
 </sbb-toast>
 `;
-/* end snapshot sbb-toast renders Chrome-Safari DOM */
+/* end snapshot sbb-toast renders DOM */
 
-snapshots["sbb-toast renders Chrome-Safari Shadow DOM"] = 
+snapshots["sbb-toast renders Shadow DOM"] = 
 `<div class="sbb-toast__overlay-container">
   <div class="sbb-toast">
     <div class="sbb-toast__icon">
@@ -31,10 +32,7 @@ snapshots["sbb-toast renders Chrome-Safari Shadow DOM"] =
         </sbb-icon>
       </slot>
     </div>
-    <div
-      aria-live="polite"
-      class="sbb-toast__content"
-    >
+    <div class="sbb-toast__content">
       <slot>
       </slot>
     </div>
@@ -58,7 +56,7 @@ snapshots["sbb-toast renders Chrome-Safari Shadow DOM"] =
   </div>
 </div>
 `;
-/* end snapshot sbb-toast renders Chrome-Safari Shadow DOM */
+/* end snapshot sbb-toast renders Shadow DOM */
 
 snapshots["sbb-toast renders A11y tree Chrome"] = 
 `<p>
@@ -69,68 +67,6 @@ snapshots["sbb-toast renders A11y tree Chrome"] =
 </p>
 `;
 /* end snapshot sbb-toast renders A11y tree Chrome */
-
-snapshots["sbb-toast renders Firefox DOM"] = 
-`<sbb-toast
-  data-slot-names="unnamed"
-  data-state="closed"
-  dismissible=""
-  icon-name="circle-tick-small"
-  popover="manual"
-  position="bottom-center"
->
-  <span>
-    'Lorem ipsum dolor'
-  </span>
-</sbb-toast>
-`;
-/* end snapshot sbb-toast renders Firefox DOM */
-
-snapshots["sbb-toast renders Firefox Shadow DOM"] = 
-`<div class="sbb-toast__overlay-container">
-  <div
-    class="sbb-toast"
-    role="status"
-  >
-    <div class="sbb-toast__icon">
-      <slot name="icon">
-        <sbb-icon
-          aria-hidden="true"
-          data-namespace="default"
-          name="circle-tick-small"
-          role="img"
-        >
-        </sbb-icon>
-      </slot>
-    </div>
-    <div
-      aria-live="polite"
-      class="sbb-toast__content"
-    >
-      <slot>
-      </slot>
-    </div>
-    <div class="sbb-toast__action">
-      <slot name="action">
-        <sbb-transparent-button
-          aria-label="Close message"
-          class="sbb-toast__action-button"
-          data-action=""
-          data-button=""
-          data-sbb-button=""
-          icon-name="cross-small"
-          negative=""
-          sbb-toast-close=""
-          size="m"
-          tabindex="0"
-        >
-        </sbb-transparent-button>
-      </slot>
-    </div>
-  </div>
-</div>
-`;
-/* end snapshot sbb-toast renders Firefox Shadow DOM */
 
 snapshots["sbb-toast renders A11y tree Firefox"] = 
 `<p>

--- a/src/elements/toast/toast.component.ts
+++ b/src/elements/toast/toast.component.ts
@@ -184,7 +184,7 @@ class SbbToastElement extends SbbIconNameMixin(SbbHydrationMixin(SbbOpenCloseBas
 
     if (slotNodes.some((el) => el.nodeType === Node.TEXT_NODE)) {
       const span = document.createElement('span');
-      this.appendChild(span);
+      this.prepend(span);
       span.append(...slotNodes);
     }
   }

--- a/src/elements/toast/toast.snapshot.spec.ts
+++ b/src/elements/toast/toast.snapshot.spec.ts
@@ -1,9 +1,7 @@
 import { expect } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
 
-import { isFirefox } from '../core/dom.js';
 import { fixture, testA11yTreeSnapshot } from '../core/testing/private.js';
-import { describeIf } from '../core/testing.js';
 
 import type { SbbToastElement } from './toast.component.js';
 
@@ -19,24 +17,12 @@ describe(`sbb-toast`, () => {
       `);
     });
 
-    describeIf(!isFirefox, 'Chrome-Safari', async () => {
-      it('DOM', async () => {
-        await expect(elem).dom.to.be.equalSnapshot();
-      });
-
-      it('Shadow DOM', async () => {
-        await expect(elem).shadowDom.to.be.equalSnapshot();
-      });
+    it('DOM', async () => {
+      await expect(elem).dom.to.be.equalSnapshot();
     });
 
-    describeIf(isFirefox, 'Firefox', async () => {
-      it('DOM', async () => {
-        await expect(elem).dom.to.be.equalSnapshot();
-      });
-
-      it('Shadow DOM', async () => {
-        await expect(elem).shadowDom.to.be.equalSnapshot();
-      });
+    it('Shadow DOM', async () => {
+      await expect(elem).shadowDom.to.be.equalSnapshot();
     });
 
     testA11yTreeSnapshot();

--- a/src/elements/toast/toast.snapshot.spec.ts
+++ b/src/elements/toast/toast.snapshot.spec.ts
@@ -6,14 +6,15 @@ import { fixture, testA11yTreeSnapshot } from '../core/testing/private.js';
 import type { SbbToastElement } from './toast.component.js';
 
 import './toast.component.js';
+import '../link/link.js';
 
 describe(`sbb-toast`, () => {
-  describe('renders', () => {
-    let elem: SbbToastElement;
+  let elem: SbbToastElement;
 
+  describe('renders', () => {
     beforeEach(async () => {
       elem = await fixture(html`
-        <sbb-toast icon-name="circle-tick-small" dismissible> 'Lorem ipsum dolor' </sbb-toast>
+        <sbb-toast icon-name="circle-tick-small" dismissible> Lorem ipsum dolor </sbb-toast>
       `);
     });
 
@@ -26,5 +27,26 @@ describe(`sbb-toast`, () => {
     });
 
     testA11yTreeSnapshot();
+  });
+
+  describe('renders with action', () => {
+    beforeEach(async () => {
+      elem = await fixture(html`
+        <sbb-toast icon-name="circle-tick-small" dismissible>
+          Lorem ipsum dolor
+          <sbb-link slot="action" sbb-toast-close href="https://www.sbb.ch" target="_blank">
+            Link action
+          </sbb-link>
+        </sbb-toast>
+      `);
+    });
+
+    it('DOM', async () => {
+      await expect(elem).dom.to.be.equalSnapshot();
+    });
+
+    it('Shadow DOM', async () => {
+      await expect(elem).shadowDom.to.be.equalSnapshot();
+    });
   });
 });

--- a/src/elements/toast/toast.spec.ts
+++ b/src/elements/toast/toast.spec.ts
@@ -22,6 +22,7 @@ describe(`sbb-toast`, () => {
     expect(element).not.to.have.attribute('data-has-action');
     expect(element).not.to.have.attribute('data-has-icon');
     expect(element).to.have.attribute('data-state', 'closed');
+    expect(element).to.have.attribute('aria-live', element.politeness);
   });
 
   it('opens and closes after timeout', async () => {


### PR DESCRIPTION
This PR Closes #3683

I had to move the `aria-live` in the light DOM (on the host) to be correctly interpreted by JAWS and NVDA