### PR TITLE
fix(sbb-skiplink-list): avoid invisible content block

### DIFF
--- a/src/elements/skiplink-list/skiplink-list.scss
+++ b/src/elements/skiplink-list/skiplink-list.scss
@@ -4,6 +4,7 @@
 @include sbb.box-sizing;
 
 :host {
+  --sbb-skiplink-list-wrapper-size: 0;
   --sbb-skiplink-list-height: 0;
   --sbb-skiplink-list-overflow: hidden;
   --sbb-skiplink-list-background: transparent;
@@ -21,6 +22,13 @@
 
 .sbb-skiplink-list {
   @include sbb.list-reset;
+
+  height: var(--sbb-skiplink-list-wrapper-size);
+  width: var(--sbb-skiplink-list-wrapper-size);
+
+  &:focus-within {
+    --sbb-skiplink-list-wrapper-size: auto;
+  }
 
   & > :is(li, span) {
     @include sbb.shadow-level-5-hard;

--- a/src/elements/skiplink-list/skiplink-list.scss
+++ b/src/elements/skiplink-list/skiplink-list.scss
@@ -4,7 +4,6 @@
 @include sbb.box-sizing;
 
 :host {
-  --sbb-skiplink-list-wrapper-size: 0;
   --sbb-skiplink-list-height: 0;
   --sbb-skiplink-list-overflow: hidden;
   --sbb-skiplink-list-background: transparent;
@@ -22,14 +21,6 @@
 
 .sbb-skiplink-list {
   @include sbb.list-reset;
-
-  display: block;
-  height: var(--sbb-skiplink-list-wrapper-size);
-  width: var(--sbb-skiplink-list-wrapper-size);
-
-  &:focus-within {
-    --sbb-skiplink-list-wrapper-size: auto;
-  }
 
   & > :is(li, span) {
     @include sbb.shadow-level-5-hard;

--- a/src/elements/skiplink-list/skiplink-list.scss
+++ b/src/elements/skiplink-list/skiplink-list.scss
@@ -23,6 +23,7 @@
 .sbb-skiplink-list {
   @include sbb.list-reset;
 
+  display: block;
   height: var(--sbb-skiplink-list-wrapper-size);
   width: var(--sbb-skiplink-list-wrapper-size);
 
@@ -33,7 +34,7 @@
   & > :is(li, span) {
     @include sbb.shadow-level-5-hard;
 
-    display: inline-block;
+    display: list-item;
     height: var(--sbb-skiplink-list-height);
     overflow: var(--sbb-skiplink-list-overflow);
     border-radius: var(--sbb-border-radius-4x);


### PR DESCRIPTION
With our previous fix, we unintentionally caused the skiplink list to block the content behind it. This fix basically resets that behavior and prevents the skiplink list from taking up space.