### PR TITLE
refactor: add SbbElementInternalsMixin as base for ElementInternals

### DIFF
--- a/src/elements-experimental/journey-summary/__snapshots__/journey-summary.snapshot.spec.snap.js
+++ b/src/elements-experimental/journey-summary/__snapshots__/journey-summary.snapshot.spec.snap.js
@@ -105,7 +105,6 @@ snapshots["sbb-journey-summary renders with second journey Shadow DOM"] =
       aria-orientation="horizontal"
       class="sbb-journey-summary__divider"
       orientation="horizontal"
-      role="separator"
     >
     </sbb-divider>
     <div>

--- a/src/elements-experimental/timetable-row/__snapshots__/timetable-row.snapshot.spec.snap.js
+++ b/src/elements-experimental/timetable-row/__snapshots__/timetable-row.snapshot.spec.snap.js
@@ -288,7 +288,6 @@ snapshots["sbb-timetable-row renders loading state Shadow DOM"] =
   <sbb-card-badge
     class="sbb-loading__badge"
     color="charcoal"
-    role="text"
     slot="badge"
   >
   </sbb-card-badge>

--- a/src/elements/accordion/__snapshots__/accordion.snapshot.spec.snap.js
+++ b/src/elements/accordion/__snapshots__/accordion.snapshot.spec.snap.js
@@ -27,7 +27,6 @@ snapshots["sbb-accordion renders DOM"] =
       aria-labelledby="sbb-expansion-panel-header-1"
       data-size="l"
       id="sbb-expansion-panel-content-1"
-      role="region"
       slot="content"
     >
       Content 1
@@ -57,7 +56,6 @@ snapshots["sbb-accordion renders DOM"] =
       aria-labelledby="sbb-expansion-panel-header-2"
       data-size="l"
       id="sbb-expansion-panel-content-2"
-      role="region"
       slot="content"
     >
       Content 2

--- a/src/elements/action-group/action-group.component.ts
+++ b/src/elements/action-group/action-group.component.ts
@@ -2,7 +2,7 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import type { SbbButtonCommonElement, SbbButtonSize } from '../button.js';
+import type { SbbButtonCommonElementMixinType, SbbButtonSize } from '../button.js';
 import { isLean } from '../core/dom.js';
 import type { SbbHorizontalFrom, SbbOrientation } from '../core/interfaces.js';
 import type {
@@ -70,7 +70,7 @@ class SbbActionGroupElement extends LitElement {
   }
 
   private _syncButtons(): void {
-    this.querySelectorAll?.<SbbButtonCommonElement>('[data-sbb-button]').forEach(
+    this.querySelectorAll?.<SbbButtonCommonElementMixinType>('[data-sbb-button]').forEach(
       (b) => (b.size = this.buttonSize),
     );
   }

--- a/src/elements/alert/alert/__snapshots__/alert.snapshot.spec.snap.js
+++ b/src/elements/alert/alert/__snapshots__/alert.snapshot.spec.snap.js
@@ -52,7 +52,6 @@ snapshots["sbb-alert should render default properties Shadow DOM"] =
           class="sbb-alert__close-button-divider"
           negative=""
           orientation="vertical"
-          role="separator"
         >
         </sbb-divider>
         <sbb-transparent-button
@@ -138,7 +137,6 @@ snapshots["sbb-alert should render customized properties Shadow DOM"] =
           class="sbb-alert__close-button-divider"
           negative=""
           orientation="vertical"
-          role="separator"
         >
         </sbb-divider>
         <sbb-transparent-button

--- a/src/elements/alert/alert/__snapshots__/alert.snapshot.spec.snap.js
+++ b/src/elements/alert/alert/__snapshots__/alert.snapshot.spec.snap.js
@@ -30,11 +30,9 @@ snapshots["sbb-alert should render default properties Shadow DOM"] =
       </span>
       <span class="sbb-alert__content">
         <sbb-title
-          aria-level="3"
           class="sbb-alert__title"
           level="3"
           negative=""
-          role="heading"
           visual-level="5"
         >
           <slot name="title">
@@ -115,11 +113,9 @@ snapshots["sbb-alert should render customized properties Shadow DOM"] =
       </span>
       <span class="sbb-alert__content">
         <sbb-title
-          aria-level="2"
           class="sbb-alert__title"
           level="2"
           negative=""
-          role="heading"
           visual-level="3"
         >
           <slot name="title">

--- a/src/elements/autocomplete-grid/autocomplete-grid-button/__snapshots__/autocomplete-grid-button.snapshot.spec.snap.js
+++ b/src/elements/autocomplete-grid/autocomplete-grid-button/__snapshots__/autocomplete-grid-button.snapshot.spec.snap.js
@@ -7,7 +7,6 @@ snapshots["sbb-autocomplete-grid-button renders DOM"] =
   data-button=""
   icon-name="pie-small"
   id="sbb-autocomplete-grid-button-1"
-  role="button"
 >
 </sbb-autocomplete-grid-button>
 `;
@@ -36,7 +35,6 @@ snapshots["sbb-autocomplete-grid-button renders disabled DOM"] =
   disabled=""
   icon-name="pie-small"
   id="sbb-autocomplete-grid-button-3"
-  role="button"
 >
 </sbb-autocomplete-grid-button>
 `;
@@ -63,7 +61,6 @@ snapshots["sbb-autocomplete-grid-button renders negative without icon DOM"] =
   data-button=""
   id="sbb-autocomplete-grid-button-5"
   negative=""
-  role="button"
 >
 </sbb-autocomplete-grid-button>
 `;

--- a/src/elements/autocomplete-grid/autocomplete-grid-button/autocomplete-grid-button.component.ts
+++ b/src/elements/autocomplete-grid/autocomplete-grid-button/autocomplete-grid-button.component.ts
@@ -26,7 +26,6 @@ const buttonObserverConfig: MutationObserverInit = {
 export
 @customElement('sbb-autocomplete-grid-button')
 @hostAttributes({
-  role: 'button',
   tabindex: null,
   'data-button': '',
 })
@@ -34,6 +33,7 @@ export
 class SbbAutocompleteGridButtonElement extends SbbDisabledMixin(
   SbbNegativeMixin(SbbIconNameMixin(SbbActionBaseElement)),
 ) {
+  public static override readonly role = 'button';
   public static override styles: CSSResultGroup = style;
 
   /** Gets the SbbAutocompleteGridOptionElement on the same row of the button. */

--- a/src/elements/autocomplete-grid/autocomplete-grid-cell/__snapshots__/autocomplete-grid-cell.snapshot.spec.snap.js
+++ b/src/elements/autocomplete-grid/autocomplete-grid-cell/__snapshots__/autocomplete-grid-cell.snapshot.spec.snap.js
@@ -2,13 +2,12 @@
 export const snapshots = {};
 
 snapshots["sbb-autocomplete-grid-cell renders DOM"] = 
-`<sbb-autocomplete-grid-cell role="gridcell">
+`<sbb-autocomplete-grid-cell>
   <sbb-autocomplete-grid-button
     data-action=""
     data-button=""
     icon-name="pie-small"
     id="sbb-autocomplete-grid-button-1"
-    role="button"
   >
   </sbb-autocomplete-grid-button>
 </sbb-autocomplete-grid-cell>

--- a/src/elements/autocomplete-grid/autocomplete-grid-cell/autocomplete-grid-cell.component.ts
+++ b/src/elements/autocomplete-grid/autocomplete-grid-cell/autocomplete-grid-cell.component.ts
@@ -1,7 +1,7 @@
 import { type CSSResultGroup, html, LitElement, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-import { hostAttributes } from '../../core/decorators.js';
+import { SbbElementInternalsMixin } from '../../core/mixins.js';
 
 import style from './autocomplete-grid-cell.scss?lit&inline';
 
@@ -12,10 +12,8 @@ import style from './autocomplete-grid-cell.scss?lit&inline';
  */
 export
 @customElement('sbb-autocomplete-grid-cell')
-@hostAttributes({
-  role: 'gridcell',
-})
-class SbbAutocompleteGridCellElement extends LitElement {
+class SbbAutocompleteGridCellElement extends SbbElementInternalsMixin(LitElement) {
+  public static override readonly role = 'gridcell';
   public static override styles: CSSResultGroup = style;
 
   protected override render(): TemplateResult {

--- a/src/elements/autocomplete-grid/autocomplete-grid-optgroup/__snapshots__/autocomplete-grid-optgroup.snapshot.spec.snap.js
+++ b/src/elements/autocomplete-grid/autocomplete-grid-optgroup/__snapshots__/autocomplete-grid-optgroup.snapshot.spec.snap.js
@@ -9,7 +9,6 @@ snapshots["sbb-autocomplete-grid-optgroup renders Safari DOM"] =
       data-group-label="Group"
       data-slot-names="unnamed"
       id="sbb-autocomplete-grid-option-0"
-      role="gridcell"
       value="1"
     >
       Option 1
@@ -21,7 +20,6 @@ snapshots["sbb-autocomplete-grid-optgroup renders Safari DOM"] =
       data-group-label="Group"
       data-slot-names="unnamed"
       id="sbb-autocomplete-grid-option-1"
-      role="gridcell"
       value="2"
     >
       Option 2
@@ -58,14 +56,12 @@ snapshots["sbb-autocomplete-grid-optgroup renders Chrome-Firefox DOM"] =
 `<sbb-autocomplete-grid-optgroup
   aria-label="Group"
   label="Group"
-  role="group"
 >
   <sbb-autocomplete-grid-row id="sbb-autocomplete-grid-row-1">
     <sbb-autocomplete-grid-option
       aria-selected="false"
       data-slot-names="unnamed"
       id="sbb-autocomplete-grid-option-0"
-      role="gridcell"
       value="1"
     >
       Option 1
@@ -76,7 +72,6 @@ snapshots["sbb-autocomplete-grid-optgroup renders Chrome-Firefox DOM"] =
       aria-selected="false"
       data-slot-names="unnamed"
       id="sbb-autocomplete-grid-option-1"
-      role="gridcell"
       value="2"
     >
       Option 2

--- a/src/elements/autocomplete-grid/autocomplete-grid-optgroup/__snapshots__/autocomplete-grid-optgroup.snapshot.spec.snap.js
+++ b/src/elements/autocomplete-grid/autocomplete-grid-optgroup/__snapshots__/autocomplete-grid-optgroup.snapshot.spec.snap.js
@@ -3,10 +3,7 @@ export const snapshots = {};
 
 snapshots["sbb-autocomplete-grid-optgroup renders Safari DOM"] = 
 `<sbb-autocomplete-grid-optgroup label="Group">
-  <sbb-autocomplete-grid-row
-    id="sbb-autocomplete-grid-row-1"
-    role="row"
-  >
+  <sbb-autocomplete-grid-row id="sbb-autocomplete-grid-row-1">
     <sbb-autocomplete-grid-option
       aria-selected="false"
       data-group-label="Group"
@@ -18,10 +15,7 @@ snapshots["sbb-autocomplete-grid-optgroup renders Safari DOM"] =
       Option 1
     </sbb-autocomplete-grid-option>
   </sbb-autocomplete-grid-row>
-  <sbb-autocomplete-grid-row
-    id="sbb-autocomplete-grid-row-2"
-    role="row"
-  >
+  <sbb-autocomplete-grid-row id="sbb-autocomplete-grid-row-2">
     <sbb-autocomplete-grid-option
       aria-selected="false"
       data-group-label="Group"
@@ -42,7 +36,6 @@ snapshots["sbb-autocomplete-grid-optgroup renders Safari Shadow DOM"] =
   <sbb-divider
     aria-orientation="horizontal"
     orientation="horizontal"
-    role="separator"
   >
   </sbb-divider>
 </div>
@@ -67,10 +60,7 @@ snapshots["sbb-autocomplete-grid-optgroup renders Chrome-Firefox DOM"] =
   label="Group"
   role="group"
 >
-  <sbb-autocomplete-grid-row
-    id="sbb-autocomplete-grid-row-1"
-    role="row"
-  >
+  <sbb-autocomplete-grid-row id="sbb-autocomplete-grid-row-1">
     <sbb-autocomplete-grid-option
       aria-selected="false"
       data-slot-names="unnamed"
@@ -81,10 +71,7 @@ snapshots["sbb-autocomplete-grid-optgroup renders Chrome-Firefox DOM"] =
       Option 1
     </sbb-autocomplete-grid-option>
   </sbb-autocomplete-grid-row>
-  <sbb-autocomplete-grid-row
-    id="sbb-autocomplete-grid-row-2"
-    role="row"
-  >
+  <sbb-autocomplete-grid-row id="sbb-autocomplete-grid-row-2">
     <sbb-autocomplete-grid-option
       aria-selected="false"
       data-slot-names="unnamed"
@@ -104,7 +91,6 @@ snapshots["sbb-autocomplete-grid-optgroup renders Chrome-Firefox Shadow DOM"] =
   <sbb-divider
     aria-orientation="horizontal"
     orientation="horizontal"
-    role="separator"
   >
   </sbb-divider>
 </div>

--- a/src/elements/autocomplete-grid/autocomplete-grid-option/__snapshots__/autocomplete-grid-option.snapshot.spec.snap.js
+++ b/src/elements/autocomplete-grid/autocomplete-grid-option/__snapshots__/autocomplete-grid-option.snapshot.spec.snap.js
@@ -6,7 +6,6 @@ snapshots["sbb-autocomplete-grid-option renders DOM"] =
   aria-selected="false"
   data-slot-names="unnamed"
   id="sbb-autocomplete-grid-option-0"
-  role="gridcell"
   value="1"
 >
   Option 1
@@ -38,7 +37,6 @@ snapshots["sbb-autocomplete-grid-option renders disabled DOM"] =
   data-slot-names="unnamed"
   disabled=""
   id="sbb-autocomplete-grid-option-2"
-  role="gridcell"
   value="1"
 >
   Option 1

--- a/src/elements/autocomplete-grid/autocomplete-grid-option/autocomplete-grid-option.component.ts
+++ b/src/elements/autocomplete-grid/autocomplete-grid-option/autocomplete-grid-option.component.ts
@@ -1,7 +1,6 @@
 import type { CSSResultGroup, PropertyValues } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-import { hostAttributes } from '../../core/decorators.js';
 import { EventEmitter } from '../../core/eventing.js';
 import { SbbOptionBaseElement } from '../../option.js';
 
@@ -21,10 +20,8 @@ export const autocompleteGridOptionId: string = `sbb-autocomplete-grid-option`;
  */
 export
 @customElement('sbb-autocomplete-grid-option')
-@hostAttributes({
-  role: 'gridcell',
-})
 class SbbAutocompleteGridOptionElement<T = string> extends SbbOptionBaseElement<T> {
+  public static override readonly role = 'gridcell';
   public static override styles: CSSResultGroup = style;
   public static readonly events = {
     optionSelected: 'autocompleteOptionSelected',

--- a/src/elements/autocomplete-grid/autocomplete-grid-row/__snapshots__/autocomplete-grid-row.snapshot.spec.snap.js
+++ b/src/elements/autocomplete-grid/autocomplete-grid-row/__snapshots__/autocomplete-grid-row.snapshot.spec.snap.js
@@ -7,18 +7,16 @@ snapshots["sbb-autocomplete-grid-row renders DOM"] =
     aria-selected="false"
     data-slot-names="unnamed"
     id="sbb-autocomplete-grid-option-0"
-    role="gridcell"
     value="1"
   >
     Option 1
   </sbb-autocomplete-grid-option>
-  <sbb-autocomplete-grid-cell role="gridcell">
+  <sbb-autocomplete-grid-cell>
     <sbb-autocomplete-grid-button
       data-action=""
       data-button=""
       icon-name="pie-small"
       id="sbb-autocomplete-grid-button-1"
-      role="button"
     >
     </sbb-autocomplete-grid-button>
   </sbb-autocomplete-grid-cell>

--- a/src/elements/autocomplete-grid/autocomplete-grid-row/__snapshots__/autocomplete-grid-row.snapshot.spec.snap.js
+++ b/src/elements/autocomplete-grid/autocomplete-grid-row/__snapshots__/autocomplete-grid-row.snapshot.spec.snap.js
@@ -2,10 +2,7 @@
 export const snapshots = {};
 
 snapshots["sbb-autocomplete-grid-row renders DOM"] = 
-`<sbb-autocomplete-grid-row
-  id="sbb-autocomplete-grid-row-1"
-  role="row"
->
+`<sbb-autocomplete-grid-row id="sbb-autocomplete-grid-row-1">
   <sbb-autocomplete-grid-option
     aria-selected="false"
     data-slot-names="unnamed"

--- a/src/elements/autocomplete-grid/autocomplete-grid-row/autocomplete-grid-row.component.ts
+++ b/src/elements/autocomplete-grid/autocomplete-grid-row/autocomplete-grid-row.component.ts
@@ -1,7 +1,7 @@
 import { type CSSResultGroup, html, LitElement, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-import { hostAttributes } from '../../core/decorators.js';
+import { SbbElementInternalsMixin } from '../../core/mixins.js';
 
 import style from './autocomplete-grid-row.scss?lit&inline';
 
@@ -14,10 +14,8 @@ let autocompleteRowNextId = 0;
  */
 export
 @customElement('sbb-autocomplete-grid-row')
-@hostAttributes({
-  role: 'row',
-})
-class SbbAutocompleteGridRowElement extends LitElement {
+class SbbAutocompleteGridRowElement extends SbbElementInternalsMixin(LitElement) {
+  public static override readonly role = 'row';
   public static override styles: CSSResultGroup = style;
 
   public override connectedCallback(): void {

--- a/src/elements/autocomplete-grid/autocomplete-grid/__snapshots__/autocomplete-grid.snapshot.spec.snap.js
+++ b/src/elements/autocomplete-grid/autocomplete-grid/__snapshots__/autocomplete-grid.snapshot.spec.snap.js
@@ -11,17 +11,15 @@ snapshots["sbb-autocomplete-grid Chrome-Firefox DOM"] =
       aria-selected="false"
       data-slot-names="unnamed"
       id="sbb-autocomplete-grid-option-0"
-      role="gridcell"
     >
       Option 1
     </sbb-autocomplete-grid-option>
-    <sbb-autocomplete-grid-cell role="gridcell">
+    <sbb-autocomplete-grid-cell>
       <sbb-autocomplete-grid-button
         data-action=""
         data-button=""
         icon-name="dog-small"
         id="sbb-autocomplete-grid-button-1"
-        role="button"
       >
       </sbb-autocomplete-grid-button>
     </sbb-autocomplete-grid-cell>
@@ -31,17 +29,15 @@ snapshots["sbb-autocomplete-grid Chrome-Firefox DOM"] =
       aria-selected="false"
       data-slot-names="unnamed"
       id="sbb-autocomplete-grid-option-1"
-      role="gridcell"
     >
       Option 2
     </sbb-autocomplete-grid-option>
-    <sbb-autocomplete-grid-cell role="gridcell">
+    <sbb-autocomplete-grid-cell>
       <sbb-autocomplete-grid-button
         data-action=""
         data-button=""
         icon-name="dog-small"
         id="sbb-autocomplete-grid-button-2"
-        role="button"
       >
       </sbb-autocomplete-grid-button>
     </sbb-autocomplete-grid-cell>
@@ -91,24 +87,21 @@ snapshots["sbb-autocomplete-grid Safari DOM"] =
   data-state="closed"
   id="sbb-autocomplete-grid-1"
   popover="manual"
-  role="grid"
 >
   <sbb-autocomplete-grid-row id="sbb-autocomplete-grid-row-1">
     <sbb-autocomplete-grid-option
       aria-selected="false"
       data-slot-names="unnamed"
       id="sbb-autocomplete-grid-option-0"
-      role="gridcell"
     >
       Option 1
     </sbb-autocomplete-grid-option>
-    <sbb-autocomplete-grid-cell role="gridcell">
+    <sbb-autocomplete-grid-cell>
       <sbb-autocomplete-grid-button
         data-action=""
         data-button=""
         icon-name="dog-small"
         id="sbb-autocomplete-grid-button-1"
-        role="button"
       >
       </sbb-autocomplete-grid-button>
     </sbb-autocomplete-grid-cell>
@@ -118,17 +111,15 @@ snapshots["sbb-autocomplete-grid Safari DOM"] =
       aria-selected="false"
       data-slot-names="unnamed"
       id="sbb-autocomplete-grid-option-1"
-      role="gridcell"
     >
       Option 2
     </sbb-autocomplete-grid-option>
-    <sbb-autocomplete-grid-cell role="gridcell">
+    <sbb-autocomplete-grid-cell>
       <sbb-autocomplete-grid-button
         data-action=""
         data-button=""
         icon-name="dog-small"
         id="sbb-autocomplete-grid-button-2"
-        role="button"
       >
       </sbb-autocomplete-grid-button>
     </sbb-autocomplete-grid-cell>

--- a/src/elements/autocomplete-grid/autocomplete-grid/__snapshots__/autocomplete-grid.snapshot.spec.snap.js
+++ b/src/elements/autocomplete-grid/autocomplete-grid/__snapshots__/autocomplete-grid.snapshot.spec.snap.js
@@ -6,10 +6,7 @@ snapshots["sbb-autocomplete-grid Chrome-Firefox DOM"] =
   data-state="closed"
   popover="manual"
 >
-  <sbb-autocomplete-grid-row
-    id="sbb-autocomplete-grid-row-1"
-    role="row"
-  >
+  <sbb-autocomplete-grid-row id="sbb-autocomplete-grid-row-1">
     <sbb-autocomplete-grid-option
       aria-selected="false"
       data-slot-names="unnamed"
@@ -29,10 +26,7 @@ snapshots["sbb-autocomplete-grid Chrome-Firefox DOM"] =
       </sbb-autocomplete-grid-button>
     </sbb-autocomplete-grid-cell>
   </sbb-autocomplete-grid-row>
-  <sbb-autocomplete-grid-row
-    id="sbb-autocomplete-grid-row-2"
-    role="row"
-  >
+  <sbb-autocomplete-grid-row id="sbb-autocomplete-grid-row-2">
     <sbb-autocomplete-grid-option
       aria-selected="false"
       data-slot-names="unnamed"
@@ -99,10 +93,7 @@ snapshots["sbb-autocomplete-grid Safari DOM"] =
   popover="manual"
   role="grid"
 >
-  <sbb-autocomplete-grid-row
-    id="sbb-autocomplete-grid-row-1"
-    role="row"
-  >
+  <sbb-autocomplete-grid-row id="sbb-autocomplete-grid-row-1">
     <sbb-autocomplete-grid-option
       aria-selected="false"
       data-slot-names="unnamed"
@@ -122,10 +113,7 @@ snapshots["sbb-autocomplete-grid Safari DOM"] =
       </sbb-autocomplete-grid-button>
     </sbb-autocomplete-grid-cell>
   </sbb-autocomplete-grid-row>
-  <sbb-autocomplete-grid-row
-    id="sbb-autocomplete-grid-row-2"
-    role="row"
-  >
+  <sbb-autocomplete-grid-row id="sbb-autocomplete-grid-row-2">
     <sbb-autocomplete-grid-option
       aria-selected="false"
       data-slot-names="unnamed"

--- a/src/elements/autocomplete-grid/autocomplete-grid/autocomplete-grid.component.ts
+++ b/src/elements/autocomplete-grid/autocomplete-grid/autocomplete-grid.component.ts
@@ -2,7 +2,6 @@ import { customElement } from 'lit/decorators.js';
 
 import { SbbAutocompleteBaseElement } from '../../autocomplete.js';
 import { getNextElementIndex } from '../../core/a11y.js';
-import { hostAttributes } from '../../core/decorators.js';
 import { isSafari } from '../../core/dom.js';
 import { setAriaComboBoxAttributes } from '../../core/overlay.js';
 import type { SbbDividerElement } from '../../divider.js';
@@ -33,10 +32,8 @@ const ariaRoleOnHost = isSafari;
  */
 export
 @customElement('sbb-autocomplete-grid')
-@hostAttributes({
-  role: ariaRoleOnHost ? 'grid' : null,
-})
 class SbbAutocompleteGridElement<T = string> extends SbbAutocompleteBaseElement<T> {
+  public static override readonly role = ariaRoleOnHost ? 'grid' : null;
   protected overlayId = `sbb-autocomplete-grid-${++nextId}`;
   protected panelRole = 'grid';
   private _activeItemIndex = -1;

--- a/src/elements/autocomplete/__snapshots__/autocomplete.snapshot.spec.snap.js
+++ b/src/elements/autocomplete/__snapshots__/autocomplete.snapshot.spec.snap.js
@@ -7,7 +7,6 @@ snapshots["sbb-autocomplete renders standalone Safari DOM"] =
   id="sbb-autocomplete-1"
   origin="origin"
   popover="manual"
-  role="listbox"
   trigger="trigger"
 >
   <sbb-option
@@ -15,7 +14,6 @@ snapshots["sbb-autocomplete renders standalone Safari DOM"] =
     data-slot-names="unnamed"
     data-variant="autocomplete"
     id="sbb-option-0"
-    role="option"
     value="1"
   >
     1
@@ -25,7 +23,6 @@ snapshots["sbb-autocomplete renders standalone Safari DOM"] =
     data-slot-names="unnamed"
     data-variant="autocomplete"
     id="sbb-option-1"
-    role="option"
     value="2"
   >
     2
@@ -88,14 +85,12 @@ snapshots["sbb-autocomplete renders in form field Safari DOM"] =
     data-state="closed"
     id="sbb-autocomplete-3"
     popover="manual"
-    role="listbox"
   >
     <sbb-option
       aria-selected="false"
       data-slot-names="unnamed"
       data-variant="autocomplete"
       id="sbb-option-4"
-      role="option"
       value="1"
     >
       1
@@ -105,7 +100,6 @@ snapshots["sbb-autocomplete renders in form field Safari DOM"] =
       data-slot-names="unnamed"
       data-variant="autocomplete"
       id="sbb-option-5"
-      role="option"
       value="2"
     >
       2
@@ -163,7 +157,6 @@ snapshots["sbb-autocomplete renders standalone Chrome-Firefox DOM"] =
     data-slot-names="unnamed"
     data-variant="autocomplete"
     id="sbb-option-0"
-    role="option"
     value="1"
   >
     1
@@ -173,7 +166,6 @@ snapshots["sbb-autocomplete renders standalone Chrome-Firefox DOM"] =
     data-slot-names="unnamed"
     data-variant="autocomplete"
     id="sbb-option-1"
-    role="option"
     value="2"
   >
     2
@@ -207,7 +199,6 @@ snapshots["sbb-autocomplete renders standalone Chrome-Firefox Shadow DOM"] =
       <div
         class="sbb-autocomplete__options"
         id="sbb-autocomplete-2"
-        role="listbox"
       >
         <slot>
         </slot>
@@ -245,7 +236,6 @@ snapshots["sbb-autocomplete renders in form field Chrome-Firefox DOM"] =
       data-slot-names="unnamed"
       data-variant="autocomplete"
       id="sbb-option-4"
-      role="option"
       value="1"
     >
       1
@@ -255,7 +245,6 @@ snapshots["sbb-autocomplete renders in form field Chrome-Firefox DOM"] =
       data-slot-names="unnamed"
       data-variant="autocomplete"
       id="sbb-option-5"
-      role="option"
       value="2"
     >
       2

--- a/src/elements/autocomplete/__snapshots__/autocomplete.snapshot.spec.snap.js
+++ b/src/elements/autocomplete/__snapshots__/autocomplete.snapshot.spec.snap.js
@@ -199,6 +199,7 @@ snapshots["sbb-autocomplete renders standalone Chrome-Firefox Shadow DOM"] =
       <div
         class="sbb-autocomplete__options"
         id="sbb-autocomplete-2"
+        role="listbox"
       >
         <slot>
         </slot>

--- a/src/elements/autocomplete/autocomplete.component.ts
+++ b/src/elements/autocomplete/autocomplete.component.ts
@@ -1,7 +1,6 @@
 import { customElement } from 'lit/decorators.js';
 
 import { getNextElementIndex } from '../core/a11y.js';
-import { hostAttributes } from '../core/decorators.js';
 import { isSafari } from '../core/dom.js';
 import { setAriaComboBoxAttributes } from '../core/overlay.js';
 import type { SbbOptGroupElement, SbbOptionElement } from '../option.js';
@@ -30,10 +29,8 @@ const ariaRoleOnHost = isSafari;
  */
 export
 @customElement('sbb-autocomplete')
-@hostAttributes({
-  role: ariaRoleOnHost ? 'listbox' : null,
-})
 class SbbAutocompleteElement<T = string> extends SbbAutocompleteBaseElement<T> {
+  public static override readonly role = ariaRoleOnHost ? 'listbox' : null;
   protected overlayId = `sbb-autocomplete-${++nextId}`;
   protected panelRole = 'listbox';
   private _activeItemIndex = -1;

--- a/src/elements/breadcrumb/breadcrumb-group/__snapshots__/breadcrumb-group.snapshot.spec.snap.js
+++ b/src/elements/breadcrumb/breadcrumb-group/__snapshots__/breadcrumb-group.snapshot.spec.snap.js
@@ -2,9 +2,7 @@
 export const snapshots = {};
 
 snapshots["sbb-breadcrumb-group renders DOM"] = 
-`<sbb-breadcrumb-group
-  data-loaded=""
->
+`<sbb-breadcrumb-group data-loaded="">
   <sbb-breadcrumb
     data-action=""
     data-link=""

--- a/src/elements/breadcrumb/breadcrumb-group/__snapshots__/breadcrumb-group.snapshot.spec.snap.js
+++ b/src/elements/breadcrumb/breadcrumb-group/__snapshots__/breadcrumb-group.snapshot.spec.snap.js
@@ -4,7 +4,6 @@ export const snapshots = {};
 snapshots["sbb-breadcrumb-group renders DOM"] = 
 `<sbb-breadcrumb-group
   data-loaded=""
-  role="navigation"
 >
   <sbb-breadcrumb
     data-action=""

--- a/src/elements/breadcrumb/breadcrumb-group/breadcrumb-group.component.ts
+++ b/src/elements/breadcrumb/breadcrumb-group/breadcrumb-group.component.ts
@@ -15,10 +15,13 @@ import {
   sbbInputModalityDetector,
 } from '../../core/a11y.js';
 import { SbbLanguageController } from '../../core/controllers.js';
-import { hostAttributes } from '../../core/decorators.js';
 import { setOrRemoveAttribute } from '../../core/dom.js';
 import { i18nBreadcrumbEllipsisButtonLabel } from '../../core/i18n.js';
-import { SbbNamedSlotListMixin, type WithListChildren } from '../../core/mixins.js';
+import {
+  SbbElementInternalsMixin,
+  SbbNamedSlotListMixin,
+  type WithListChildren,
+} from '../../core/mixins.js';
 import type { SbbBreadcrumbElement } from '../breadcrumb.js';
 
 import style from './breadcrumb-group.scss?lit&inline';
@@ -34,13 +37,11 @@ const MIN_BREADCRUMBS_TO_COLLAPSE = 3;
  */
 export
 @customElement('sbb-breadcrumb-group')
-@hostAttributes({
-  role: 'navigation',
-})
 class SbbBreadcrumbGroupElement extends SbbNamedSlotListMixin<
   SbbBreadcrumbElement,
   typeof LitElement
->(LitElement) {
+>(SbbElementInternalsMixin(LitElement)) {
+  public static readonly role = 'navigation';
   public static override styles: CSSResultGroup = style;
   protected override readonly listChildLocalNames = ['sbb-breadcrumb'];
 

--- a/src/elements/button/common/button-common.ts
+++ b/src/elements/button/common/button-common.ts
@@ -5,26 +5,19 @@ import { html } from 'lit/static-html.js';
 import type { SbbActionBaseElement } from '../../core/base-elements.js';
 import { hostAttributes, slotState } from '../../core/decorators.js';
 import { isLean } from '../../core/dom.js';
-import type {
-  AbstractConstructor,
-  SbbDisabledMixinType,
-  SbbNegativeMixinType,
-} from '../../core/mixins.js';
+import type { AbstractConstructor } from '../../core/mixins.js';
 import { SbbNegativeMixin } from '../../core/mixins.js';
-import { SbbIconNameMixin, type SbbIconNameMixinType } from '../../icon.js';
-
-export type SbbButtonCommonElement = SbbButtonCommonElementMixinType & SbbActionBaseElement;
+import { SbbIconNameMixin } from '../../icon.js';
 
 export type SbbButtonSize = 'l' | 'm' | 's';
 
-export declare class SbbButtonCommonElementMixinType
-  extends SbbIconNameMixinType
-  implements SbbNegativeMixinType, Partial<SbbDisabledMixinType>
-{
+export declare class SbbButtonCommonElementMixinType extends SbbNegativeMixin(
+  SbbIconNameMixin(SbbActionBaseElement),
+) {
   public accessor size: SbbButtonSize;
-  public accessor disabled: boolean;
-  public accessor negative: boolean;
 }
+
+export type SbbButtonCommonElement = SbbButtonCommonElementMixinType;
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const SbbButtonCommonElementMixin = <T extends AbstractConstructor<SbbActionBaseElement>>(

--- a/src/elements/button/common/button-common.ts
+++ b/src/elements/button/common/button-common.ts
@@ -17,8 +17,6 @@ export declare class SbbButtonCommonElementMixinType extends SbbNegativeMixin(
   public accessor size: SbbButtonSize;
 }
 
-export type SbbButtonCommonElement = SbbButtonCommonElementMixinType;
-
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const SbbButtonCommonElementMixin = <T extends AbstractConstructor<SbbActionBaseElement>>(
   superClass: T,

--- a/src/elements/button/mini-button-group/__snapshots__/mini-button-group.snapshot.spec.snap.js
+++ b/src/elements/button/mini-button-group/__snapshots__/mini-button-group.snapshot.spec.snap.js
@@ -17,7 +17,6 @@ snapshots["sbb-mini-button-group renders DOM"] =
   <sbb-divider
     aria-orientation="vertical"
     orientation="vertical"
-    role="separator"
     slot="li-1"
   >
   </sbb-divider>

--- a/src/elements/card/card-badge/__snapshots__/card-badge.snapshot.spec.snap.js
+++ b/src/elements/card/card-badge/__snapshots__/card-badge.snapshot.spec.snap.js
@@ -4,7 +4,6 @@ export const snapshots = {};
 snapshots["sbb-card-badge renders DOM"] = 
 `<sbb-card-badge
   color="charcoal"
-  role="text"
   slot="badge"
 >
   Black Friday Special

--- a/src/elements/card/card-badge/card-badge.component.ts
+++ b/src/elements/card/card-badge/card-badge.component.ts
@@ -2,7 +2,7 @@ import type { CSSResultGroup, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { hostAttributes } from '../../core/decorators.js';
+import { SbbElementInternalsMixin } from '../../core/mixins.js';
 
 import style from './card-badge.scss?lit&inline';
 
@@ -14,11 +14,8 @@ import style from './card-badge.scss?lit&inline';
  */
 export
 @customElement('sbb-card-badge')
-@hostAttributes({
-  slot: 'badge',
-  role: 'text',
-})
-class SbbCardBadgeElement extends LitElement {
+class SbbCardBadgeElement extends SbbElementInternalsMixin(LitElement) {
+  public static override readonly role = 'text';
   public static override styles: CSSResultGroup = style;
 
   /** Color of the card badge. */
@@ -28,6 +25,7 @@ class SbbCardBadgeElement extends LitElement {
 
   public override connectedCallback(): void {
     super.connectedCallback();
+    this.slot ||= 'badge';
     this._parentElement = this.parentElement;
     if (this._parentElement) {
       this._parentElement.toggleAttribute('data-has-card-badge', true);

--- a/src/elements/card/card/__snapshots__/card.snapshot.spec.snap.js
+++ b/src/elements/card/card/__snapshots__/card.snapshot.spec.snap.js
@@ -13,7 +13,6 @@ snapshots["sbb-card should render with sbb-card-badge - DOM"] =
   Content text
   <sbb-card-badge
     color="charcoal"
-    role="text"
     slot="badge"
   >
     <span>

--- a/src/elements/checkbox/common/checkbox-common.ts
+++ b/src/elements/checkbox/common/checkbox-common.ts
@@ -2,21 +2,14 @@ import type { LitElement, PropertyValues } from 'lit';
 import { property } from 'lit/decorators.js';
 
 import { forceType } from '../../core/decorators.js';
-import {
-  type Constructor,
-  type SbbDisabledMixinType,
-  SbbFormAssociatedCheckboxMixin,
-  type SbbFormAssociatedCheckboxMixinType,
-  type SbbRequiredMixinType,
-} from '../../core/mixins.js';
+import { type Constructor, SbbFormAssociatedCheckboxMixin } from '../../core/mixins.js';
 import type { SbbCheckboxGroupElement } from '../checkbox-group.js';
 
 export type SbbCheckboxSize = 'xs' | 's' | 'm';
 
-export declare abstract class SbbCheckboxCommonElementMixinType
-  extends SbbFormAssociatedCheckboxMixinType
-  implements Partial<SbbDisabledMixinType>, Partial<SbbRequiredMixinType>
-{
+export declare abstract class SbbCheckboxCommonElementMixinType extends SbbFormAssociatedCheckboxMixin(
+  LitElement,
+) {
   public accessor indeterminate: boolean;
 
   public get group(): SbbCheckboxGroupElement | null;

--- a/src/elements/chip/chip-group/chip-group.component.ts
+++ b/src/elements/chip/chip-group/chip-group.component.ts
@@ -17,6 +17,7 @@ import {
   type FormRestoreReason,
   type FormRestoreState,
   SbbDisabledMixin,
+  SbbElementInternalsMixin,
   SbbFormAssociatedMixin,
   SbbNegativeMixin,
   SbbRequiredMixin,
@@ -56,8 +57,9 @@ export interface SbbChipInputTokenEndEventDetails<T = string> {
 export
 @customElement('sbb-chip-group')
 class SbbChipGroupElement<T = string> extends SbbRequiredMixin(
-  SbbDisabledMixin(SbbNegativeMixin(SbbFormAssociatedMixin<typeof LitElement>(LitElement))),
+  SbbDisabledMixin(SbbNegativeMixin(SbbFormAssociatedMixin(SbbElementInternalsMixin(LitElement)))),
 ) {
+  public static override readonly role = 'listbox';
   public static override styles: CSSResultGroup = style;
   public static readonly events = {
     input: 'input',
@@ -139,9 +141,6 @@ class SbbChipGroupElement<T = string> extends SbbRequiredMixin(
 
   public constructor() {
     super();
-
-    /** @internal */
-    this.internals.role = 'listbox';
 
     this.addEventListener?.(SbbChipElement.events.requestDelete, (ev) =>
       this._deleteChip(ev.target as SbbChipElement<T>),

--- a/src/elements/chip/chip/chip.component.ts
+++ b/src/elements/chip/chip/chip.component.ts
@@ -10,7 +10,12 @@ import { customElement, property } from 'lit/decorators.js';
 import { SbbLanguageController } from '../../core/controllers.js';
 import { EventEmitter } from '../../core/eventing.js';
 import { i18nChipDelete } from '../../core/i18n.js';
-import { SbbDisabledMixin, SbbNegativeMixin, SbbReadonlyMixin } from '../../core/mixins.js';
+import {
+  SbbDisabledMixin,
+  SbbElementInternalsMixin,
+  SbbNegativeMixin,
+  SbbReadonlyMixin,
+} from '../../core/mixins.js';
 
 import '../../button/mini-button.js';
 import '../../screen-reader-only.js';
@@ -26,8 +31,9 @@ import style from './chip.scss?lit&inline';
 export
 @customElement('sbb-chip')
 class SbbChipElement<T = string> extends SbbNegativeMixin(
-  SbbDisabledMixin(SbbReadonlyMixin(LitElement)),
+  SbbDisabledMixin(SbbReadonlyMixin(SbbElementInternalsMixin(LitElement))),
 ) {
+  public static override readonly role = 'option';
   public static override styles: CSSResultGroup = style;
   public static readonly events = {
     requestDelete: 'requestDelete',
@@ -40,13 +46,6 @@ class SbbChipElement<T = string> extends SbbNegativeMixin(
   private _requestDelete = new EventEmitter<any>(this, SbbChipElement.events.requestDelete);
 
   private _language = new SbbLanguageController(this);
-
-  public constructor() {
-    super();
-    const internals: ElementInternals = this.attachInternals();
-    /** @internal */
-    internals.role = 'option';
-  }
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     super.willUpdate(changedProperties);

--- a/src/elements/core/base-elements/action-base-element.ts
+++ b/src/elements/core/base-elements/action-base-element.ts
@@ -1,6 +1,7 @@
 import { html, LitElement, type TemplateResult } from 'lit';
 
 import { hostAttributes } from '../decorators.js';
+import { SbbElementInternalsMixin } from '../mixins.js';
 
 /**
  * Whenever an element can be disabled it has disabled property
@@ -17,7 +18,7 @@ export
 @hostAttributes({
   'data-action': '',
 })
-abstract class SbbActionBaseElement extends LitElement {
+abstract class SbbActionBaseElement extends SbbElementInternalsMixin(LitElement) {
   protected get maybeDisabled(): boolean | undefined {
     const maybeDisabled = this as MaybeDisabled;
     return maybeDisabled.disabled || maybeDisabled.formDisabled;

--- a/src/elements/core/base-elements/button-base-element.ts
+++ b/src/elements/core/base-elements/button-base-element.ts
@@ -26,9 +26,6 @@ abstract class SbbButtonLikeBaseElement extends SbbFormAssociatedMixin(SbbAction
   public constructor() {
     super();
 
-    /** @internal */
-    this.internals.role = 'button';
-
     if (!isServer) {
       this.setupBaseEventHandlers();
 

--- a/src/elements/core/base-elements/button-base-element.ts
+++ b/src/elements/core/base-elements/button-base-element.ts
@@ -21,6 +21,8 @@ export
   'data-button': '',
 })
 abstract class SbbButtonLikeBaseElement extends SbbFormAssociatedMixin(SbbActionBaseElement) {
+  public static override readonly role: ElementInternals['role'] = 'button';
+
   public constructor() {
     super();
 

--- a/src/elements/core/base-elements/open-close-base-element.ts
+++ b/src/elements/core/base-elements/open-close-base-element.ts
@@ -2,6 +2,7 @@ import { LitElement } from 'lit';
 
 import { EventEmitter } from '../eventing.js';
 import type { SbbOpenedClosedState } from '../interfaces.js';
+import { SbbElementInternalsMixin } from '../mixins.js';
 
 /**
  * Base class for overlay components.
@@ -11,7 +12,7 @@ import type { SbbOpenedClosedState } from '../interfaces.js';
  * @event willClose - Emits whenever the component begins the closing transition. Can be canceled.
  * @event didClose - Emits whenever the component is closed.
  */
-export abstract class SbbOpenCloseBaseElement extends LitElement {
+export abstract class SbbOpenCloseBaseElement extends SbbElementInternalsMixin(LitElement) {
   public static readonly events = {
     willOpen: 'willOpen',
     didOpen: 'didOpen',

--- a/src/elements/core/mixins.ts
+++ b/src/elements/core/mixins.ts
@@ -4,6 +4,7 @@
 export * from './mixins/animation-complete-mixin.js';
 export * from './mixins/constructor.js';
 export * from './mixins/disabled-mixin.js';
+export * from './mixins/element-internals-mixin.js';
 export * from './mixins/form-associated-checkbox-mixin.js';
 export * from './mixins/form-associated-input-mixin.js';
 export * from './mixins/form-associated-mixin.js';

--- a/src/elements/core/mixins/animation-complete-mixin.ts
+++ b/src/elements/core/mixins/animation-complete-mixin.ts
@@ -2,7 +2,7 @@ import type { LitElement } from 'lit';
 
 import type { AbstractConstructor } from './constructor.js';
 
-export declare class SbbAnimationCompleteMixinType {
+export declare abstract class SbbAnimationCompleteMixinType {
   public isAnimating: boolean;
   public get animationComplete(): Promise<void> | null;
   protected startAnimation(): void;

--- a/src/elements/core/mixins/disabled-mixin.ts
+++ b/src/elements/core/mixins/disabled-mixin.ts
@@ -4,7 +4,7 @@ import { property } from 'lit/decorators.js';
 import { forceType, getOverride } from '../decorators.js';
 
 import type { AbstractConstructor } from './constructor.js';
-import type { SbbFormAssociatedMixinType } from './form-associated-mixin.js';
+import type { SbbElementInternalsMixinType } from './element-internals-mixin.js';
 
 export declare class SbbDisabledMixinType {
   public accessor disabled: boolean;
@@ -66,7 +66,7 @@ export const SbbDisabledInteractiveMixin = <
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const SbbDisabledTabIndexActionMixin = <
-  T extends AbstractConstructor<LitElement & SbbFormAssociatedMixinType>,
+  T extends AbstractConstructor<LitElement & SbbElementInternalsMixinType>,
 >(
   superClass: T,
 ): AbstractConstructor<SbbDisabledMixinType & SbbDisabledInteractiveMixinType> & T => {

--- a/src/elements/core/mixins/element-internals-mixin.ts
+++ b/src/elements/core/mixins/element-internals-mixin.ts
@@ -21,7 +21,7 @@ const CustomStateSetPolyfill: (new (host: LitElement) => CustomStateSetInterface
         }
 
         public override add(state: string): this {
-          if (this._host.hasUpdated) {
+          if (this._host.isConnected) {
             this._toggleState(state, true);
           }
           return super.add(state);

--- a/src/elements/core/mixins/element-internals-mixin.ts
+++ b/src/elements/core/mixins/element-internals-mixin.ts
@@ -1,0 +1,91 @@
+import { isServer, type LitElement, type ReactiveController } from 'lit';
+
+import type { AbstractConstructor } from './constructor.js';
+
+// Most of our target browsers support the :state() pseudo class, but not all of them.
+// We patch the states property of the element internals to use attributes instead,
+// if :state() is not supported.
+// Note that for SSR, the states property is a simple Set, implemented in Lit SSR.
+// TODO: Remove in 2026.
+type CustomStateSetInterface = CustomStateSet;
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const CustomStateSetPolyfill: (new (host: LitElement) => CustomStateSetInterface) | null =
+  !isServer && !CSS.supports('selector(:state(loading))')
+    ? class CustomStateSet
+        extends Set<string>
+        implements CustomStateSetInterface, ReactiveController
+      {
+        public constructor(private _host: LitElement) {
+          super();
+          this._host.addController(this);
+        }
+
+        public override add(state: string): this {
+          if (this._host.hasUpdated) {
+            this._toggleState(state, true);
+          }
+          return super.add(state);
+        }
+
+        public override delete(state: string): boolean {
+          this._toggleState(state, false);
+          return super.delete(state);
+        }
+
+        public override clear(): void {
+          this.forEach((state) => this.delete(state));
+        }
+
+        public hostConnected(): void {
+          this.forEach((state) => this._toggleState(state, true));
+        }
+
+        private _toggleState(state: string, enabled: boolean): void {
+          this._host.toggleAttribute(`data-state--${state}`, enabled);
+        }
+      }
+    : null;
+
+export interface SbbElementInternalsConstructor {
+  role?: ElementInternals['role'];
+}
+
+export declare abstract class SbbElementInternalsMixinType {
+  protected readonly internals: ElementInternals;
+}
+
+/**
+ * The SbbElementInternalsMixin attaches ElementInternals to the element and sets
+ * the role, if defined.
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const SbbElementInternalsMixin = <T extends AbstractConstructor<LitElement>>(
+  superClass: T,
+): AbstractConstructor<SbbElementInternalsMixinType> & T & SbbElementInternalsConstructor => {
+  abstract class SbbElementInternalElement
+    extends superClass
+    implements Partial<SbbElementInternalsMixinType>
+  {
+    /** @internal */
+    protected readonly internals: ElementInternals = this.attachInternals();
+
+    public constructor(...args: any[]) {
+      super(...args);
+      if (CustomStateSetPolyfill) {
+        Object.defineProperty(this.internals, 'states', {
+          value: new CustomStateSetPolyfill(this),
+          writable: false,
+          configurable: false,
+          enumerable: false,
+        });
+      }
+      const role = (this.constructor as SbbElementInternalsConstructor).role;
+      if (role) {
+        this.internals.role = role;
+      }
+    }
+  }
+  return SbbElementInternalElement as unknown as AbstractConstructor<SbbElementInternalsMixinType> &
+    T &
+    SbbElementInternalsConstructor;
+};

--- a/src/elements/core/mixins/form-associated-checkbox-mixin.ts
+++ b/src/elements/core/mixins/form-associated-checkbox-mixin.ts
@@ -6,35 +6,26 @@ import { hostAttributes } from '../decorators.js';
 import { preventScrollOnSpacebarPress } from '../eventing.js';
 import { i18nCheckboxRequired } from '../i18n.js';
 
-import type { Constructor } from './constructor.js';
-import { SbbDisabledMixin, type SbbDisabledMixinType } from './disabled-mixin.js';
+import type { AbstractConstructor } from './constructor.js';
+import { SbbDisabledMixin } from './disabled-mixin.js';
+import { SbbElementInternalsMixin } from './element-internals-mixin.js';
 import {
   SbbFormAssociatedMixin,
   type FormRestoreReason,
   type FormRestoreState,
-  type SbbFormAssociatedMixinType,
 } from './form-associated-mixin.js';
-import { SbbRequiredMixin, type SbbRequiredMixinType } from './required-mixin.js';
+import { SbbRequiredMixin } from './required-mixin.js';
 
 type CheckedSetterValue = { value: boolean; attribute: boolean };
 
-export declare abstract class SbbFormAssociatedCheckboxMixinType
-  extends SbbFormAssociatedMixinType
-  implements Partial<SbbDisabledMixinType>, Partial<SbbRequiredMixinType>
-{
-  public get checked(): boolean;
-  public set checked(value: boolean);
-
-  public set disabled(value: boolean);
-  public get disabled(): boolean;
-
-  public set required(value: boolean);
-  public get required(): boolean;
+export declare abstract class SbbFormAssociatedCheckboxMixinType extends SbbDisabledMixin(
+  SbbRequiredMixin(SbbFormAssociatedMixin(SbbElementInternalsMixin(LitElement))),
+) {
+  public accessor checked: boolean;
 
   public formResetCallback(): void;
   public formStateRestoreCallback(state: FormRestoreState | null, reason: FormRestoreReason): void;
 
-  protected isDisabledExternally(): boolean;
   protected isRequiredExternally(): boolean;
   protected withUserInteraction?(): void;
   protected updateFormValue(): void;
@@ -46,16 +37,20 @@ export declare abstract class SbbFormAssociatedCheckboxMixinType
  * Inherited classes MUST implement the ariaChecked state (ElementInternals) themselves.
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export const SbbFormAssociatedCheckboxMixin = <T extends Constructor<LitElement>>(
+export const SbbFormAssociatedCheckboxMixin = <T extends AbstractConstructor<LitElement>>(
   superClass: T,
-): Constructor<SbbFormAssociatedCheckboxMixinType> & T => {
+): AbstractConstructor<SbbFormAssociatedCheckboxMixinType> & T => {
   @hostAttributes({
     tabindex: '0',
   })
   abstract class SbbFormAssociatedCheckboxElement
-    extends SbbDisabledMixin(SbbRequiredMixin(SbbFormAssociatedMixin(superClass)))
+    extends SbbDisabledMixin(
+      SbbRequiredMixin(SbbFormAssociatedMixin(SbbElementInternalsMixin(superClass))),
+    )
     implements Partial<SbbFormAssociatedCheckboxMixinType>
   {
+    public static override readonly role = 'checkbox';
+
     private _attributeMutationBlocked = false;
     private _languageController = new SbbLanguageController(this);
 
@@ -101,9 +96,6 @@ export const SbbFormAssociatedCheckboxMixin = <T extends Constructor<LitElement>
 
     protected constructor() {
       super();
-      /** @internal */
-      this.internals.role = 'checkbox';
-
       this.addEventListener?.('click', this._handleUserInteraction);
       this.addEventListener?.('keydown', preventScrollOnSpacebarPress);
       this.addEventListener?.('keyup', this._handleKeyboardInteraction);
@@ -203,6 +195,6 @@ export const SbbFormAssociatedCheckboxMixin = <T extends Constructor<LitElement>
     };
   }
 
-  return SbbFormAssociatedCheckboxElement as unknown as Constructor<SbbFormAssociatedCheckboxMixinType> &
+  return SbbFormAssociatedCheckboxElement as unknown as AbstractConstructor<SbbFormAssociatedCheckboxMixinType> &
     T;
 };

--- a/src/elements/core/mixins/form-associated-mixin.ts
+++ b/src/elements/core/mixins/form-associated-mixin.ts
@@ -5,6 +5,7 @@ import { property, state } from 'lit/decorators.js';
 import { isWebkit } from '../dom.js';
 
 import type { AbstractConstructor } from './constructor.js';
+import type { SbbElementInternalsMixinType } from './element-internals-mixin.js';
 
 declare global {
   /**
@@ -54,15 +55,13 @@ export declare abstract class SbbFormAssociatedMixinType {
   public accessor name: string;
   public get type(): string;
 
-  public abstract get value(): unknown;
-  public abstract set value(value: unknown);
+  public abstract accessor value: unknown;
 
   public get validity(): ValidityState;
   public get validationMessage(): string;
   public get willValidate(): boolean;
 
   protected formDisabled: boolean;
-  protected readonly internals: ElementInternals;
 
   public checkValidity(): boolean;
   public reportValidity(): boolean;
@@ -92,7 +91,9 @@ export declare abstract class SbbFormAssociatedMixinType {
  * The FormAssociatedMixin enables native form support for custom controls.
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export const SbbFormAssociatedMixin = <T extends AbstractConstructor<LitElement>>(
+export const SbbFormAssociatedMixin = <
+  T extends AbstractConstructor<LitElement & SbbElementInternalsMixinType>,
+>(
   superClass: T,
 ): AbstractConstructor<SbbFormAssociatedMixinType> & T => {
   abstract class SbbFormAssociatedElement
@@ -101,8 +102,7 @@ export const SbbFormAssociatedMixin = <T extends AbstractConstructor<LitElement>
   {
     public static formAssociated = true;
 
-    public abstract get value(): unknown;
-    public abstract set value(value: unknown);
+    public abstract accessor value: unknown;
 
     /**
      * Returns the form owner of this element.
@@ -160,9 +160,6 @@ export const SbbFormAssociatedMixin = <T extends AbstractConstructor<LitElement>
     public get willValidate(): boolean {
       return this.internals.willValidate;
     }
-
-    /** @internal */
-    protected readonly internals: ElementInternals = this.attachInternals();
 
     private _validityStates = new Map<
       keyof ValidityStateFlags,

--- a/src/elements/core/mixins/form-associated-radio-button-mixin.ts
+++ b/src/elements/core/mixins/form-associated-radio-button-mixin.ts
@@ -6,14 +6,14 @@ import { SbbConnectedAbortController, SbbLanguageController } from '../controlle
 import { i18nSelectionRequired } from '../i18n.js';
 
 import type { AbstractConstructor } from './constructor.js';
-import { SbbDisabledMixin, type SbbDisabledMixinType } from './disabled-mixin.js';
+import { SbbDisabledMixin } from './disabled-mixin.js';
+import { SbbElementInternalsMixin } from './element-internals-mixin.js';
 import {
   type FormRestoreReason,
   type FormRestoreState,
   SbbFormAssociatedMixin,
-  type SbbFormAssociatedMixinType,
 } from './form-associated-mixin.js';
-import { SbbRequiredMixin, type SbbRequiredMixinType } from './required-mixin.js';
+import { SbbRequiredMixin } from './required-mixin.js';
 
 /**
  * A static registry that holds a collection of grouped `radio-buttons`.
@@ -27,13 +27,10 @@ export const radioButtonRegistry = new WeakMap<
   Map<string, Set<SbbFormAssociatedRadioButtonMixinType>>
 >();
 
-export declare abstract class SbbFormAssociatedRadioButtonMixinType
-  extends SbbFormAssociatedMixinType
-  implements Partial<SbbDisabledMixinType>, Partial<SbbRequiredMixinType>
-{
+export declare abstract class SbbFormAssociatedRadioButtonMixinType extends SbbDisabledMixin(
+  SbbRequiredMixin(SbbFormAssociatedMixin(SbbElementInternalsMixin(LitElement))),
+) {
   public accessor checked: boolean;
-  public accessor disabled: boolean;
-  public accessor required: boolean;
 
   protected associatedRadioButtons?: Set<SbbFormAssociatedRadioButtonMixinType>;
   /** @deprecated No longer used internally. */
@@ -42,9 +39,6 @@ export declare abstract class SbbFormAssociatedRadioButtonMixinType
   public formResetCallback(): void;
   public formStateRestoreCallback(state: FormRestoreState | null, reason: FormRestoreReason): void;
 
-  protected isDisabledExternally(): boolean;
-  protected isRequiredExternally(): boolean;
-  protected withUserInteraction?(): void;
   protected updateFormValue(): void;
   protected updateFocusableRadios(): void;
   protected emitChangeEvents(): void;
@@ -59,9 +53,13 @@ export const SbbFormAssociatedRadioButtonMixin = <T extends AbstractConstructor<
   superClass: T,
 ): AbstractConstructor<SbbFormAssociatedRadioButtonMixinType> & T => {
   abstract class SbbFormAssociatedRadioButtonElement
-    extends SbbDisabledMixin(SbbRequiredMixin(SbbFormAssociatedMixin(superClass)))
+    extends SbbDisabledMixin(
+      SbbRequiredMixin(SbbFormAssociatedMixin(SbbElementInternalsMixin(superClass))),
+    )
     implements Partial<SbbFormAssociatedRadioButtonMixinType>
   {
+    public static override readonly role = 'radio';
+
     /**
      * Whether the radio button is checked.
      */
@@ -112,8 +110,6 @@ export const SbbFormAssociatedRadioButtonMixin = <T extends AbstractConstructor<
 
     protected constructor() {
       super();
-      /** @internal */
-      this.internals.role = 'radio';
       this.addEventListener?.('keydown', (e) => this._handleArrowKeyDown(e));
     }
 

--- a/src/elements/core/mixins/required-mixin.ts
+++ b/src/elements/core/mixins/required-mixin.ts
@@ -2,7 +2,7 @@ import type { LitElement, PropertyValues } from 'lit';
 import { property } from 'lit/decorators.js';
 
 import type { AbstractConstructor } from './constructor.js';
-import type { SbbFormAssociatedMixinType } from './form-associated-mixin.js';
+import type { SbbElementInternalsMixinType } from './element-internals-mixin.js';
 
 export declare class SbbRequiredMixinType {
   public accessor required: boolean;
@@ -14,7 +14,7 @@ export declare class SbbRequiredMixinType {
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const SbbRequiredMixin = <
-  T extends AbstractConstructor<LitElement & SbbFormAssociatedMixinType>,
+  T extends AbstractConstructor<LitElement & SbbElementInternalsMixinType>,
 >(
   superClass: T,
 ): AbstractConstructor<SbbRequiredMixinType> & T => {

--- a/src/elements/dialog/dialog-title/__snapshots__/dialog-title.snapshot.spec.snap.js
+++ b/src/elements/dialog/dialog-title/__snapshots__/dialog-title.snapshot.spec.snap.js
@@ -3,9 +3,7 @@ export const snapshots = {};
 
 snapshots["sbb-dialog-title renders Light DOM"] = 
 `<sbb-dialog-title
-  aria-level="2"
   level="2"
-  role="heading"
   visual-level="3"
 >
   Title

--- a/src/elements/dialog/dialog/__snapshots__/dialog.snapshot.spec.snap.js
+++ b/src/elements/dialog/dialog/__snapshots__/dialog.snapshot.spec.snap.js
@@ -8,9 +8,7 @@ snapshots["sbb-dialog renders an open dialog DOM"] =
   popover="manual"
 >
   <sbb-dialog-title
-    aria-level="2"
     level="2"
-    role="heading"
     visual-level="3"
   >
     Title

--- a/src/elements/divider/__snapshots__/divider.snapshot.spec.snap.js
+++ b/src/elements/divider/__snapshots__/divider.snapshot.spec.snap.js
@@ -5,7 +5,6 @@ snapshots["sbb-divider renders DOM"] =
 `<sbb-divider
   aria-orientation="horizontal"
   orientation="horizontal"
-  role="separator"
 >
 </sbb-divider>
 `;
@@ -21,7 +20,6 @@ snapshots["sbb-divider renders horizontal DOM"] =
 `<sbb-divider
   aria-orientation="horizontal"
   orientation="horizontal"
-  role="separator"
 >
 </sbb-divider>
 `;
@@ -37,7 +35,6 @@ snapshots["sbb-divider renders vertical DOM"] =
 `<sbb-divider
   aria-orientation="vertical"
   orientation="vertical"
-  role="separator"
 >
 </sbb-divider>
 `;

--- a/src/elements/divider/divider.component.ts
+++ b/src/elements/divider/divider.component.ts
@@ -2,9 +2,8 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { hostAttributes } from '../core/decorators.js';
 import type { SbbOrientation } from '../core/interfaces.js';
-import { SbbNegativeMixin } from '../core/mixins.js';
+import { SbbElementInternalsMixin, SbbNegativeMixin } from '../core/mixins.js';
 
 import style from './divider.scss?lit&inline';
 
@@ -13,10 +12,8 @@ import style from './divider.scss?lit&inline';
  */
 export
 @customElement('sbb-divider')
-@hostAttributes({
-  role: 'separator',
-})
-class SbbDividerElement extends SbbNegativeMixin(LitElement) {
+class SbbDividerElement extends SbbNegativeMixin(SbbElementInternalsMixin(LitElement)) {
+  public static override readonly role = 'separator';
   public static override styles: CSSResultGroup = style;
 
   /** Orientation property with possible values 'horizontal' | 'vertical'. Defaults to horizontal. */

--- a/src/elements/expansion-panel/expansion-panel-content/__snapshots__/expansion-panel-content.snapshot.spec.snap.js
+++ b/src/elements/expansion-panel/expansion-panel-content/__snapshots__/expansion-panel-content.snapshot.spec.snap.js
@@ -2,9 +2,7 @@
 export const snapshots = {};
 
 snapshots["sbb-expansion-panel-content renders DOM"] = 
-`<sbb-expansion-panel-content
-  slot="content"
->
+`<sbb-expansion-panel-content slot="content">
   Content
 </sbb-expansion-panel-content>
 `;

--- a/src/elements/expansion-panel/expansion-panel-content/__snapshots__/expansion-panel-content.snapshot.spec.snap.js
+++ b/src/elements/expansion-panel/expansion-panel-content/__snapshots__/expansion-panel-content.snapshot.spec.snap.js
@@ -3,7 +3,6 @@ export const snapshots = {};
 
 snapshots["sbb-expansion-panel-content renders DOM"] = 
 `<sbb-expansion-panel-content
-  role="region"
   slot="content"
 >
   Content

--- a/src/elements/expansion-panel/expansion-panel-content/expansion-panel-content.component.ts
+++ b/src/elements/expansion-panel/expansion-panel-content/expansion-panel-content.component.ts
@@ -2,7 +2,7 @@ import type { CSSResultGroup, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-import { hostAttributes } from '../../core/decorators.js';
+import { SbbElementInternalsMixin } from '../../core/mixins.js';
 
 import style from './expansion-panel-content.scss?lit&inline';
 
@@ -13,12 +13,14 @@ import style from './expansion-panel-content.scss?lit&inline';
  */
 export
 @customElement('sbb-expansion-panel-content')
-@hostAttributes({
-  role: 'region',
-  slot: 'content',
-})
-class SbbExpansionPanelContentElement extends LitElement {
+class SbbExpansionPanelContentElement extends SbbElementInternalsMixin(LitElement) {
+  public static override readonly role = 'region';
   public static override styles: CSSResultGroup = style;
+
+  public override connectedCallback(): void {
+    super.connectedCallback();
+    this.slot ||= 'content';
+  }
 
   protected override render(): TemplateResult {
     return html`

--- a/src/elements/expansion-panel/expansion-panel/__snapshots__/expansion-panel.snapshot.spec.snap.js
+++ b/src/elements/expansion-panel/expansion-panel/__snapshots__/expansion-panel.snapshot.spec.snap.js
@@ -24,7 +24,6 @@ snapshots["sbb-expansion-panel renders DOM"] =
     aria-labelledby="sbb-expansion-panel-header-1"
     data-size="l"
     id="sbb-expansion-panel-content-1"
-    role="region"
     slot="content"
   >
     Content
@@ -72,7 +71,6 @@ snapshots["sbb-expansion-panel renders size s DOM"] =
     aria-labelledby="sbb-expansion-panel-header-3"
     data-size="s"
     id="sbb-expansion-panel-content-3"
-    role="region"
     slot="content"
   >
     Content
@@ -121,7 +119,6 @@ snapshots["sbb-expansion-panel renders with level set DOM"] =
     aria-labelledby="sbb-expansion-panel-header-5"
     data-size="l"
     id="sbb-expansion-panel-content-5"
-    role="region"
     slot="content"
   >
     Content

--- a/src/elements/file-selector/common/file-selector-common.ts
+++ b/src/elements/file-selector/common/file-selector-common.ts
@@ -20,30 +20,29 @@ import {
   type FormRestoreState,
   SbbDisabledMixin,
   SbbFormAssociatedMixin,
-  type SbbFormAssociatedMixinType,
   type Constructor,
+  SbbElementInternalsMixin,
 } from '../../core/mixins.js';
 
 import '../../button/secondary-button.js';
 import '../../button/secondary-button-static.js';
 import '../../icon.js';
 
-export declare abstract class SbbFileSelectorCommonElementMixinType extends SbbFormAssociatedMixinType {
+export declare abstract class SbbFileSelectorCommonElementMixinType extends SbbDisabledMixin(
+  SbbFormAssociatedMixin(SbbElementInternalsMixin(LitElement)),
+) {
   public accessor size: 's' | 'm';
   public accessor multiple: boolean;
   public accessor multipleMode: 'default' | 'persistent';
   public accessor accept: string;
   public accessor accessibilityLabel: string;
-  public accessor disabled: boolean;
   public accessor files: Readonly<File>[];
   public override get value(): string | null;
   public override set value(value: string | null);
-  protected formDisabled: boolean;
   protected loadButton: SbbSecondaryButtonStaticElement;
   protected language: SbbLanguageController;
   protected abstract renderTemplate(input: TemplateResult): TemplateResult;
   protected createFileList(files: FileList): void;
-  protected updateFormValue(): void;
   public formResetCallback(): void;
   public formStateRestoreCallback(state: FormRestoreState | null, reason: FormRestoreReason): void;
 }
@@ -53,7 +52,7 @@ export const SbbFileSelectorCommonElementMixin = <T extends Constructor<LitEleme
   superclass: T,
 ): Constructor<SbbFileSelectorCommonElementMixinType> & T => {
   abstract class SbbFileSelectorCommonElement
-    extends SbbDisabledMixin(SbbFormAssociatedMixin(superclass))
+    extends SbbDisabledMixin(SbbFormAssociatedMixin(SbbElementInternalsMixin(superclass)))
     implements Partial<SbbFileSelectorCommonElementMixinType>
   {
     public static readonly events = {

--- a/src/elements/flip-card/flip-card-summary/__snapshots__/flip-card-summary.snapshot.spec.snap.js
+++ b/src/elements/flip-card/flip-card-summary/__snapshots__/flip-card-summary.snapshot.spec.snap.js
@@ -23,11 +23,7 @@ snapshots["sbb-flip-card-summary DOM"] =
   image-alignment="below"
   slot="summary"
 >
-  <sbb-title
-    aria-level="4"
-    level="4"
-    role="heading"
-  >
+  <sbb-title level="4">
     Summary
   </sbb-title>
   <sbb-image slot="image">

--- a/src/elements/flip-card/flip-card/__snapshots__/flip-card.snapshot.spec.snap.js
+++ b/src/elements/flip-card/flip-card/__snapshots__/flip-card.snapshot.spec.snap.js
@@ -32,11 +32,7 @@ snapshots["sbb-flip-card DOM"] =
     image-alignment="after"
     slot="summary"
   >
-    <sbb-title
-      aria-level="4"
-      level="4"
-      role="heading"
-    >
+    <sbb-title level="4">
       Summary
     </sbb-title>
     <sbb-image slot="image">

--- a/src/elements/header/common/header-action-common.ts
+++ b/src/elements/header/common/header-action-common.ts
@@ -6,15 +6,14 @@ import type { SbbActionBaseElement } from '../../core/base-elements.js';
 import { slotState } from '../../core/decorators/slot-state.js';
 import type { SbbHorizontalFrom } from '../../core/interfaces.js';
 import type { AbstractConstructor } from '../../core/mixins.js';
-import { SbbIconNameMixin, type SbbIconNameMixinType } from '../../icon.js';
+import { SbbIconNameMixin } from '../../icon.js';
 
 import style from './header-action.scss?lit&inline';
 
-export declare class SbbHeaderActionCommonElementMixinType
-  implements Partial<SbbIconNameMixinType>
-{
+export declare class SbbHeaderActionCommonElementMixinType extends SbbIconNameMixin(
+  SbbActionBaseElement,
+) {
   public accessor expandFrom: SbbHorizontalFrom;
-  public accessor iconName: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/elements/journey-header/__snapshots__/journey-header.snapshot.spec.snap.js
+++ b/src/elements/journey-header/__snapshots__/journey-header.snapshot.spec.snap.js
@@ -13,9 +13,7 @@ snapshots["sbb-journey-header renders DOM"] =
 
 snapshots["sbb-journey-header renders Shadow DOM"] = 
 `<sbb-title
-  aria-level="3"
   level="3"
-  role="heading"
   visual-level="5"
 >
   <span
@@ -58,10 +56,8 @@ snapshots["sbb-journey-header renders H1 L-sized round-trip negative DOM"] =
 
 snapshots["sbb-journey-header renders H1 L-sized round-trip negative Shadow DOM"] = 
 `<sbb-title
-  aria-level="1"
   level="1"
   negative=""
-  role="heading"
   visual-level="4"
 >
   <span

--- a/src/elements/link-list/link-list-anchor/__snapshots__/link-list-anchor.snapshot.spec.snap.js
+++ b/src/elements/link-list/link-list-anchor/__snapshots__/link-list-anchor.snapshot.spec.snap.js
@@ -50,11 +50,9 @@ snapshots["sbb-link-list-anchor renders DOM"] =
 snapshots["sbb-link-list-anchor renders Shadow DOM"] = 
 `<div class="sbb-link-list-wrapper">
   <sbb-title
-    aria-level="2"
     class="sbb-link-list-title"
     id="sbb-link-list-title-id"
     level="2"
-    role="heading"
     visual-level="5"
   >
     <slot name="title">

--- a/src/elements/link-list/link-list/__snapshots__/link-list.snapshot.spec.snap.js
+++ b/src/elements/link-list/link-list/__snapshots__/link-list.snapshot.spec.snap.js
@@ -4,11 +4,9 @@ export const snapshots = {};
 snapshots["sbb-link-list should render named slots if data-ssr-child-count attribute is set"] = 
 `<div class="sbb-link-list-wrapper">
   <sbb-title
-    aria-level="2"
     class="sbb-link-list-title"
     id="sbb-link-list-title-id"
     level="2"
-    role="heading"
     visual-level="5"
   >
     <slot name="title">
@@ -116,11 +114,9 @@ snapshots["sbb-link-list rendered with a slotted title DOM"] =
 snapshots["sbb-link-list rendered with a slotted title Shadow DOM"] = 
 `<div class="sbb-link-list-wrapper">
   <sbb-title
-    aria-level="2"
     class="sbb-link-list-title"
     id="sbb-link-list-title-id"
     level="2"
-    role="heading"
     visual-level="5"
   >
     <slot name="title">
@@ -234,11 +230,9 @@ snapshots["sbb-link-list rendered with a title from properties DOM"] =
 snapshots["sbb-link-list rendered with a title from properties Shadow DOM"] = 
 `<div class="sbb-link-list-wrapper">
   <sbb-title
-    aria-level="2"
     class="sbb-link-list-title"
     id="sbb-link-list-title-id"
     level="2"
-    role="heading"
     visual-level="5"
   >
     <slot name="title">
@@ -351,11 +345,9 @@ snapshots["sbb-link-list rendered without a title DOM"] =
 snapshots["sbb-link-list rendered without a title Shadow DOM"] = 
 `<div class="sbb-link-list-wrapper">
   <sbb-title
-    aria-level="2"
     class="sbb-link-list-title"
     id="sbb-link-list-title-id"
     level="2"
-    role="heading"
     visual-level="5"
   >
     <slot name="title">

--- a/src/elements/link/common/block-link-common.ts
+++ b/src/elements/link/common/block-link-common.ts
@@ -5,19 +5,16 @@ import { html } from 'lit/static-html.js';
 import type { SbbActionBaseElement } from '../../core/base-elements.js';
 import type { SbbIconPlacement } from '../../core/interfaces.js';
 import type { AbstractConstructor } from '../../core/mixins.js';
-import type { SbbIconNameMixinType } from '../../icon.js';
 import { SbbIconNameMixin } from '../../icon.js';
 
-import { SbbLinkCommonElementMixin, type SbbLinkCommonElementMixinType } from './link-common.js';
+import { SbbLinkCommonElementMixin } from './link-common.js';
 // eslint-disable-next-line import-x/order
 import blockStyle from './block-link.scss?lit&inline';
 import style from './link.scss?lit&inline';
 
-export declare class SbbBlockLinkCommonElementMixinType
-  extends SbbLinkCommonElementMixinType
-  implements Partial<SbbIconNameMixinType>
-{
-  public accessor iconName: string;
+export declare class SbbBlockLinkCommonElementMixinType extends SbbLinkCommonElementMixin(
+  SbbIconNameMixin(SbbActionBaseElement),
+) {
   public accessor iconPlacement: SbbIconPlacement;
 }
 

--- a/src/elements/link/common/inline-link-common.ts
+++ b/src/elements/link/common/inline-link-common.ts
@@ -3,12 +3,14 @@ import type { CSSResultGroup } from 'lit';
 import type { SbbActionBaseElement } from '../../core/base-elements.js';
 import type { AbstractConstructor } from '../../core/mixins.js';
 
-import { SbbLinkCommonElementMixin, type SbbLinkCommonElementMixinType } from './link-common.js';
+import { SbbLinkCommonElementMixin } from './link-common.js';
 // eslint-disable-next-line import-x/order
 import inlineStyle from './inline-link.scss?lit&inline';
 import style from './link.scss?lit&inline';
 
-export declare class SbbInlineLinkCommonElementMixinType extends SbbLinkCommonElementMixinType {}
+export declare class SbbInlineLinkCommonElementMixinType extends SbbLinkCommonElementMixin(
+  SbbActionBaseElement,
+) {}
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const SbbInlineLinkCommonElementMixin = <

--- a/src/elements/link/common/link-common.ts
+++ b/src/elements/link/common/link-common.ts
@@ -5,17 +5,13 @@ import { html } from 'lit/static-html.js';
 import type { SbbActionBaseElement } from '../../core/base-elements.js';
 import { hostAttributes, slotState } from '../../core/decorators.js';
 import { isLean } from '../../core/dom.js';
-import {
-  SbbNegativeMixin,
-  type SbbNegativeMixinType,
-  type AbstractConstructor,
-} from '../../core/mixins.js';
+import { SbbNegativeMixin, type AbstractConstructor } from '../../core/mixins.js';
 
 import style from './link.scss?lit&inline';
 
 export type SbbLinkSize = 'xs' | 's' | 'm';
 
-export declare class SbbLinkCommonElementMixinType extends SbbNegativeMixinType {
+export declare class SbbLinkCommonElementMixinType extends SbbNegativeMixin(SbbActionBaseElement) {
   public accessor size: SbbLinkSize;
 }
 

--- a/src/elements/loading-indicator-circle/__snapshots__/loading-indicator-circle.snapshot.spec.snap.js
+++ b/src/elements/loading-indicator-circle/__snapshots__/loading-indicator-circle.snapshot.spec.snap.js
@@ -2,11 +2,7 @@
 export const snapshots = {};
 
 snapshots["sbb-loading-indicator-circle renders with variant `circle` DOM"] = 
-`<sbb-loading-indicator-circle
-  aria-busy="true"
-  color="default"
-  role="progressbar"
->
+`<sbb-loading-indicator-circle color="default">
 </sbb-loading-indicator-circle>
 `;
 /* end snapshot sbb-loading-indicator-circle renders with variant `circle` DOM */

--- a/src/elements/loading-indicator-circle/loading-indicator-circle.component.ts
+++ b/src/elements/loading-indicator-circle/loading-indicator-circle.component.ts
@@ -2,7 +2,7 @@ import type { CSSResultGroup, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { hostAttributes } from '../core/decorators.js';
+import { SbbElementInternalsMixin } from '../core/mixins.js';
 
 import style from './loading-indicator-circle.scss?lit&inline';
 
@@ -11,15 +11,17 @@ import style from './loading-indicator-circle.scss?lit&inline';
  */
 export
 @customElement('sbb-loading-indicator-circle')
-@hostAttributes({
-  role: 'progressbar',
-  'aria-busy': 'true',
-})
-class SbbLoadingIndicatorCircleElement extends LitElement {
+class SbbLoadingIndicatorCircleElement extends SbbElementInternalsMixin(LitElement) {
+  public static override readonly role = 'progressbar';
   public static override styles: CSSResultGroup = style;
 
   /** Color variant. */
   @property({ reflect: true }) public accessor color: 'default' | 'smoke' | 'white' = 'default';
+
+  public override connectedCallback(): void {
+    super.connectedCallback();
+    this.internals.ariaBusy = 'true';
+  }
 
   protected override render(): TemplateResult {
     return html`

--- a/src/elements/loading-indicator/__snapshots__/loading-indicator.snapshot.spec.snap.js
+++ b/src/elements/loading-indicator/__snapshots__/loading-indicator.snapshot.spec.snap.js
@@ -3,9 +3,7 @@ export const snapshots = {};
 
 snapshots["sbb-loading-indicator renders with variant `window` DOM"] = 
 `<sbb-loading-indicator
-  aria-busy="true"
   color="default"
-  role="progressbar"
   size="s"
 >
 </sbb-loading-indicator>

--- a/src/elements/loading-indicator/loading-indicator.component.ts
+++ b/src/elements/loading-indicator/loading-indicator.component.ts
@@ -2,7 +2,7 @@ import type { CSSResultGroup, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { hostAttributes } from '../core/decorators.js';
+import { SbbElementInternalsMixin } from '../core/mixins.js';
 
 import style from './loading-indicator.scss?lit&inline';
 
@@ -11,11 +11,8 @@ import style from './loading-indicator.scss?lit&inline';
  */
 export
 @customElement('sbb-loading-indicator')
-@hostAttributes({
-  role: 'progressbar',
-  'aria-busy': 'true',
-})
-class SbbLoadingIndicatorElement extends LitElement {
+class SbbLoadingIndicatorElement extends SbbElementInternalsMixin(LitElement) {
+  public static override readonly role = 'progressbar';
   public static override styles: CSSResultGroup = style;
 
   /** Size variant, either s or m. */
@@ -23,6 +20,11 @@ class SbbLoadingIndicatorElement extends LitElement {
 
   /** Color variant. */
   @property({ reflect: true }) public accessor color: 'default' | 'smoke' | 'white' = 'default';
+
+  public override connectedCallback(): void {
+    super.connectedCallback();
+    this.internals.ariaBusy = 'true';
+  }
 
   protected override render(): TemplateResult {
     return html`

--- a/src/elements/menu/common/menu-action-common.ts
+++ b/src/elements/menu/common/menu-action-common.ts
@@ -4,24 +4,18 @@ import { html } from 'lit/static-html.js';
 
 import type { SbbActionBaseElement } from '../../core/base-elements.js';
 import { forceType, slotState } from '../../core/decorators.js';
-import {
-  type AbstractConstructor,
-  SbbDisabledMixin,
-  type SbbDisabledMixinType,
-} from '../../core/mixins.js';
-import { SbbIconNameMixin, type SbbIconNameMixinType } from '../../icon.js';
+import { type AbstractConstructor, SbbDisabledMixin } from '../../core/mixins.js';
+import { SbbIconNameMixin } from '../../icon.js';
 
 import style from './menu-action.scss?lit&inline';
 
-export declare class SbbMenuActionCommonElementMixinType
-  extends SbbDisabledMixinType
-  implements Partial<SbbIconNameMixinType>
-{
+export declare class SbbMenuActionCommonElementMixinType extends SbbIconNameMixin(
+  SbbDisabledMixin(SbbActionBaseElement),
+) {
   /**
    * @deprecated Will be removed with next major version. Use the sbb-badge attribute on a sbb-icon as alternative.
    */
   public accessor amount: string;
-  public accessor iconName: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/elements/menu/menu/__snapshots__/menu.snapshot.spec.snap.js
+++ b/src/elements/menu/menu/__snapshots__/menu.snapshot.spec.snap.js
@@ -51,7 +51,6 @@ snapshots["sbb-menu renders DOM"] =
   <sbb-divider
     aria-orientation="horizontal"
     orientation="horizontal"
-    role="separator"
   >
   </sbb-divider>
   <sbb-menu-button

--- a/src/elements/message/__snapshots__/message.snapshot.spec.snap.js
+++ b/src/elements/message/__snapshots__/message.snapshot.spec.snap.js
@@ -33,10 +33,8 @@ snapshots["sbb-message renders Shadow DOM"] =
   <slot name="image">
   </slot>
   <sbb-title
-    aria-level="3"
     class="sbb-message__title"
     level="3"
-    role="heading"
     visual-level="5"
   >
     <slot name="title">
@@ -67,10 +65,8 @@ snapshots["sbb-message renders without optional slots Shadow DOM"] =
   <slot name="image">
   </slot>
   <sbb-title
-    aria-level="3"
     class="sbb-message__title"
     level="3"
-    role="heading"
     visual-level="5"
   >
     <slot name="title">

--- a/src/elements/navigation/navigation/__snapshots__/navigation.snapshot.spec.snap.js
+++ b/src/elements/navigation/navigation/__snapshots__/navigation.snapshot.spec.snap.js
@@ -6,7 +6,6 @@ snapshots["sbb-navigation renders DOM"] =
   data-state="closed"
   id="sbb-navigation-0"
   popover="manual"
-  role="navigation"
   trigger="nav-trigger"
 >
   <sbb-navigation-marker size="l">

--- a/src/elements/navigation/navigation/navigation.component.ts
+++ b/src/elements/navigation/navigation/navigation.component.ts
@@ -17,7 +17,7 @@ import {
   SbbInertController,
   SbbLanguageController,
 } from '../../core/controllers.js';
-import { forceType, hostAttributes, idReference } from '../../core/decorators.js';
+import { forceType, idReference } from '../../core/decorators.js';
 import { isZeroAnimationDuration, SbbScrollHandler } from '../../core/dom.js';
 import { i18nCloseNavigation } from '../../core/i18n.js';
 import { SbbUpdateSchedulerMixin } from '../../core/mixins.js';
@@ -57,11 +57,8 @@ const DEBOUNCE_TIME = 150;
  */
 export
 @customElement('sbb-navigation')
-@hostAttributes({
-  role: 'navigation',
-  popover: 'manual',
-})
 class SbbNavigationElement extends SbbUpdateSchedulerMixin(SbbOpenCloseBaseElement) {
+  public static override readonly role = 'navigation';
   public static override styles: CSSResultGroup = style;
 
   /**
@@ -327,6 +324,7 @@ class SbbNavigationElement extends SbbUpdateSchedulerMixin(SbbOpenCloseBaseEleme
 
   public override connectedCallback(): void {
     super.connectedCallback();
+    this.popover ||= 'manual';
     this.id ||= `sbb-navigation-${nextId++}`;
     this._configureTrigger();
   }

--- a/src/elements/notification/__snapshots__/notification.snapshot.spec.snap.js
+++ b/src/elements/notification/__snapshots__/notification.snapshot.spec.snap.js
@@ -27,10 +27,8 @@ snapshots["sbb-notification renders Shadow DOM"] =
     </sbb-icon>
     <span class="sbb-notification__content">
       <sbb-title
-        aria-level="3"
         class="sbb-notification__title"
         level="3"
-        role="heading"
         visual-level="5"
       >
         <slot name="title">
@@ -90,10 +88,8 @@ snapshots["sbb-notification renders with a title Shadow DOM"] =
     </sbb-icon>
     <span class="sbb-notification__content">
       <sbb-title
-        aria-level="3"
         class="sbb-notification__title"
         level="3"
-        role="heading"
         visual-level="5"
       >
         <slot name="title">
@@ -156,10 +152,8 @@ snapshots["sbb-notification renders with a slotted title Shadow DOM"] =
     </sbb-icon>
     <span class="sbb-notification__content">
       <sbb-title
-        aria-level="3"
         class="sbb-notification__title"
         level="3"
-        role="heading"
         visual-level="5"
       >
         <slot name="title">
@@ -220,10 +214,8 @@ snapshots["sbb-notification renders without the close button Shadow DOM"] =
     </sbb-icon>
     <span class="sbb-notification__content">
       <sbb-title
-        aria-level="3"
         class="sbb-notification__title"
         level="3"
-        role="heading"
         visual-level="5"
       >
         <slot name="title">
@@ -265,10 +257,8 @@ snapshots["sbb-notification renders size s Shadow DOM"] =
     </sbb-icon>
     <span class="sbb-notification__content">
       <sbb-title
-        aria-level="3"
         class="sbb-notification__title"
         level="3"
-        role="heading"
         visual-level="6"
       >
         <slot name="title">

--- a/src/elements/notification/__snapshots__/notification.snapshot.spec.snap.js
+++ b/src/elements/notification/__snapshots__/notification.snapshot.spec.snap.js
@@ -44,7 +44,6 @@ snapshots["sbb-notification renders Shadow DOM"] =
         aria-orientation="vertical"
         class="sbb-notification__divider"
         orientation="vertical"
-        role="separator"
       >
       </sbb-divider>
       <sbb-secondary-button
@@ -109,7 +108,6 @@ snapshots["sbb-notification renders with a title Shadow DOM"] =
         aria-orientation="vertical"
         class="sbb-notification__divider"
         orientation="vertical"
-        role="separator"
       >
       </sbb-divider>
       <sbb-secondary-button
@@ -175,7 +173,6 @@ snapshots["sbb-notification renders with a slotted title Shadow DOM"] =
         aria-orientation="vertical"
         class="sbb-notification__divider"
         orientation="vertical"
-        role="separator"
       >
       </sbb-divider>
       <sbb-secondary-button
@@ -286,7 +283,6 @@ snapshots["sbb-notification renders size s Shadow DOM"] =
         aria-orientation="vertical"
         class="sbb-notification__divider"
         orientation="vertical"
-        role="separator"
       >
       </sbb-divider>
       <sbb-secondary-button

--- a/src/elements/option/optgroup/__snapshots__/optgroup.snapshot.spec.snap.js
+++ b/src/elements/option/optgroup/__snapshots__/optgroup.snapshot.spec.snap.js
@@ -12,7 +12,6 @@ snapshots["sbb-optgroup autocomplete renders Safari DOM"] =
     data-slot-names="unnamed"
     data-variant="autocomplete"
     id="sbb-option-0"
-    role="option"
     value="1"
   >
     1
@@ -23,7 +22,6 @@ snapshots["sbb-optgroup autocomplete renders Safari DOM"] =
     data-slot-names="unnamed"
     data-variant="autocomplete"
     id="sbb-option-1"
-    role="option"
     value="2"
   >
     2
@@ -37,7 +35,6 @@ snapshots["sbb-optgroup autocomplete renders Safari Shadow DOM"] =
   <sbb-divider
     aria-orientation="horizontal"
     orientation="horizontal"
-    role="separator"
   >
   </sbb-divider>
 </div>
@@ -70,7 +67,6 @@ snapshots["sbb-optgroup autocomplete renders disabled Safari DOM"] =
     data-slot-names="unnamed"
     data-variant="autocomplete"
     id="sbb-option-4"
-    role="option"
     value="1"
   >
     1
@@ -83,7 +79,6 @@ snapshots["sbb-optgroup autocomplete renders disabled Safari DOM"] =
     data-slot-names="unnamed"
     data-variant="autocomplete"
     id="sbb-option-5"
-    role="option"
     value="2"
   >
     2
@@ -97,7 +92,6 @@ snapshots["sbb-optgroup autocomplete renders disabled Safari Shadow DOM"] =
   <sbb-divider
     aria-orientation="horizontal"
     orientation="horizontal"
-    role="separator"
   >
   </sbb-divider>
 </div>
@@ -128,7 +122,6 @@ snapshots["sbb-optgroup autocomplete renders Chrome-Firefox DOM"] =
     data-slot-names="unnamed"
     data-variant="autocomplete"
     id="sbb-option-0"
-    role="option"
     value="1"
   >
     1
@@ -138,7 +131,6 @@ snapshots["sbb-optgroup autocomplete renders Chrome-Firefox DOM"] =
     data-slot-names="unnamed"
     data-variant="autocomplete"
     id="sbb-option-1"
-    role="option"
     value="2"
   >
     2
@@ -152,7 +144,6 @@ snapshots["sbb-optgroup autocomplete renders Chrome-Firefox Shadow DOM"] =
   <sbb-divider
     aria-orientation="horizontal"
     orientation="horizontal"
-    role="separator"
   >
   </sbb-divider>
 </div>
@@ -212,7 +203,6 @@ snapshots["sbb-optgroup autocomplete renders disabled Chrome-Firefox DOM"] =
     data-slot-names="unnamed"
     data-variant="autocomplete"
     id="sbb-option-6"
-    role="option"
     value="1"
   >
     1
@@ -224,7 +214,6 @@ snapshots["sbb-optgroup autocomplete renders disabled Chrome-Firefox DOM"] =
     data-slot-names="unnamed"
     data-variant="autocomplete"
     id="sbb-option-7"
-    role="option"
     value="2"
   >
     2
@@ -238,7 +227,6 @@ snapshots["sbb-optgroup autocomplete renders disabled Chrome-Firefox Shadow DOM"
   <sbb-divider
     aria-orientation="horizontal"
     orientation="horizontal"
-    role="separator"
   >
   </sbb-divider>
 </div>

--- a/src/elements/option/optgroup/__snapshots__/optgroup.snapshot.spec.snap.js
+++ b/src/elements/option/optgroup/__snapshots__/optgroup.snapshot.spec.snap.js
@@ -115,7 +115,6 @@ snapshots["sbb-optgroup autocomplete renders Chrome-Firefox DOM"] =
   aria-label="Label"
   data-variant="autocomplete"
   label="Label"
-  role="group"
 >
   <sbb-option
     aria-selected="false"
@@ -194,7 +193,6 @@ snapshots["sbb-optgroup autocomplete renders disabled Chrome-Firefox DOM"] =
   data-variant="autocomplete"
   disabled=""
   label="Label"
-  role="group"
 >
   <sbb-option
     aria-disabled="true"

--- a/src/elements/option/optgroup/optgroup-base-element.ts
+++ b/src/elements/option/optgroup/optgroup-base-element.ts
@@ -9,9 +9,13 @@ import {
 import { property, state } from 'lit/decorators.js';
 
 import type { SbbAutocompleteBaseElement } from '../../autocomplete.js';
-import { forceType, hostAttributes } from '../../core/decorators.js';
+import { forceType } from '../../core/decorators.js';
 import { isSafari, setOrRemoveAttribute } from '../../core/dom.js';
-import { SbbDisabledMixin, SbbHydrationMixin } from '../../core/mixins.js';
+import {
+  SbbDisabledMixin,
+  SbbElementInternalsMixin,
+  SbbHydrationMixin,
+} from '../../core/mixins.js';
 import type { SbbOptionBaseElement } from '../option.js';
 
 import style from './optgroup-base-element.scss?lit&inline';
@@ -25,9 +29,10 @@ import '../../divider.js';
  */
 const inertAriaGroups = isSafari;
 
-export
-@hostAttributes({ role: !inertAriaGroups ? 'group' : null })
-abstract class SbbOptgroupBaseElement extends SbbDisabledMixin(SbbHydrationMixin(LitElement)) {
+export abstract class SbbOptgroupBaseElement extends SbbDisabledMixin(
+  SbbElementInternalsMixin(SbbHydrationMixin(LitElement)),
+) {
+  public static override readonly role = !inertAriaGroups ? 'group' : null;
   public static override styles: CSSResultGroup = style;
 
   /** Option group label. */

--- a/src/elements/option/option/__snapshots__/option.snapshot.spec.snap.js
+++ b/src/elements/option/option/__snapshots__/option.snapshot.spec.snap.js
@@ -7,7 +7,6 @@ snapshots["sbb-option autocomplete renders selected DOM"] =
   data-slot-names="unnamed"
   data-variant="autocomplete"
   id="sbb-option-0"
-  role="option"
   selected=""
   value="1"
 >
@@ -41,7 +40,6 @@ snapshots["sbb-option autocomplete renders disabled DOM"] =
   data-variant="autocomplete"
   disabled=""
   id="sbb-option-2"
-  role="option"
   value="1"
 >
   Option 1

--- a/src/elements/option/option/option-base-element.ts
+++ b/src/elements/option/option/option-base-element.ts
@@ -5,7 +5,11 @@ import { property, state } from 'lit/decorators.js';
 import { slotState } from '../../core/decorators.js';
 import { isAndroid, isSafari, setOrRemoveAttribute } from '../../core/dom.js';
 import type { EventEmitter } from '../../core/eventing.js';
-import { SbbDisabledMixin, SbbHydrationMixin } from '../../core/mixins.js';
+import {
+  SbbDisabledMixin,
+  SbbElementInternalsMixin,
+  SbbHydrationMixin,
+} from '../../core/mixins.js';
 import { SbbIconNameMixin } from '../../icon.js';
 
 import '../../screen-reader-only.js';
@@ -31,7 +35,7 @@ const optionObserverConfig: MutationObserverInit = {
 export
 @slotState()
 abstract class SbbOptionBaseElement<T = string> extends SbbDisabledMixin(
-  SbbIconNameMixin(SbbHydrationMixin(LitElement)),
+  SbbIconNameMixin(SbbElementInternalsMixin(SbbHydrationMixin(LitElement))),
 ) {
   protected abstract optionId: string;
 

--- a/src/elements/option/option/option.component.ts
+++ b/src/elements/option/option/option.component.ts
@@ -2,7 +2,6 @@ import type { CSSResultGroup, TemplateResult } from 'lit';
 import { html, nothing } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-import { hostAttributes } from '../../core/decorators.js';
 import { EventEmitter } from '../../core/eventing.js';
 
 import { SbbOptionBaseElement } from './option-base-element.js';
@@ -24,10 +23,8 @@ export type SbbOptionVariant = 'autocomplete' | 'select' | null;
  */
 export
 @customElement('sbb-option')
-@hostAttributes({
-  role: 'option',
-})
 class SbbOptionElement<T = string> extends SbbOptionBaseElement<T> {
+  public static override readonly role = 'option';
   public static override styles: CSSResultGroup = style;
   public static readonly events = {
     selectionChange: 'optionSelectionChange',

--- a/src/elements/paginator/common/paginator-common.ts
+++ b/src/elements/paginator/common/paginator-common.ts
@@ -2,19 +2,23 @@ import { html, type LitElement, type PropertyValues, type TemplateResult } from 
 import { property } from 'lit/decorators.js';
 
 import { SbbLanguageController } from '../../core/controllers.js';
-import { hostAttributes } from '../../core/decorators.js';
 import { isLean } from '../../core/dom.js';
 import { EventEmitter } from '../../core/eventing.js';
 import { i18nNextPage, i18nPreviousPage, i18nSelectedPage } from '../../core/i18n.js';
 import type { SbbPaginatorPageEventDetails } from '../../core/interfaces.js';
-import { type AbstractConstructor, SbbDisabledMixin, SbbNegativeMixin } from '../../core/mixins.js';
+import {
+  type AbstractConstructor,
+  SbbDisabledMixin,
+  SbbElementInternalsMixin,
+  SbbNegativeMixin,
+} from '../../core/mixins.js';
 
 import '../../button/mini-button.js';
 import '../../button/mini-button-group.js';
 import '../../divider.js';
 
 export declare abstract class SbbPaginatorCommonElementMixinType extends SbbNegativeMixin(
-  SbbDisabledMixin(LitElement),
+  SbbDisabledMixin(SbbElementInternalsMixin(LitElement)),
 ) {
   public accessor length: number;
   public accessor pageSize: number;
@@ -43,13 +47,11 @@ export declare abstract class SbbPaginatorCommonElementMixinType extends SbbNega
 export const SbbPaginatorCommonElementMixin = <T extends AbstractConstructor<LitElement>>(
   superClass: T,
 ): AbstractConstructor<SbbPaginatorCommonElementMixinType> & T => {
-  @hostAttributes({
-    role: 'group',
-  })
   abstract class SbbPaginatorCommonElement
-    extends SbbNegativeMixin(SbbDisabledMixin(superClass))
+    extends SbbNegativeMixin(SbbDisabledMixin(SbbElementInternalsMixin(superClass)))
     implements Partial<SbbPaginatorCommonElementMixinType>
   {
+    public static override role = 'group';
     public static readonly events: Record<string, string> = {
       page: 'page',
     } as const;

--- a/src/elements/paginator/common/paginator-common.ts
+++ b/src/elements/paginator/common/paginator-common.ts
@@ -13,9 +13,9 @@ import '../../button/mini-button.js';
 import '../../button/mini-button-group.js';
 import '../../divider.js';
 
-export declare abstract class SbbPaginatorCommonElementMixinType {
-  public accessor negative: boolean;
-  public accessor disabled: boolean;
+export declare abstract class SbbPaginatorCommonElementMixinType extends SbbNegativeMixin(
+  SbbDisabledMixin(LitElement),
+) {
   public accessor length: number;
   public accessor pageSize: number;
   public accessor pageIndex: number;

--- a/src/elements/paginator/compact-paginator/__snapshots__/compact-paginator.snapshot.spec.snap.js
+++ b/src/elements/paginator/compact-paginator/__snapshots__/compact-paginator.snapshot.spec.snap.js
@@ -6,7 +6,6 @@ snapshots["sbb-compact-paginator renders DOM"] =
   length="50"
   page-size="5"
   pager-position="start"
-  role="group"
   size="m"
 >
 </sbb-compact-paginator>

--- a/src/elements/paginator/compact-paginator/__snapshots__/compact-paginator.snapshot.spec.snap.js
+++ b/src/elements/paginator/compact-paginator/__snapshots__/compact-paginator.snapshot.spec.snap.js
@@ -29,7 +29,6 @@ snapshots["sbb-compact-paginator renders Shadow DOM"] =
     <sbb-divider
       aria-orientation="vertical"
       orientation="vertical"
-      role="separator"
       slot="li-1"
     >
     </sbb-divider>
@@ -51,7 +50,6 @@ snapshots["sbb-compact-paginator renders Shadow DOM"] =
       aria-orientation="vertical"
       class="sbb-compact-paginator__divider"
       orientation="vertical"
-      role="separator"
     >
     </sbb-divider>
     10

--- a/src/elements/paginator/paginator/__snapshots__/paginator.snapshot.spec.snap.js
+++ b/src/elements/paginator/paginator/__snapshots__/paginator.snapshot.spec.snap.js
@@ -30,7 +30,6 @@ snapshots["sbb-paginator renders Shadow DOM"] =
       <sbb-divider
         aria-orientation="vertical"
         orientation="vertical"
-        role="separator"
         slot="li-1"
       >
       </sbb-divider>
@@ -97,7 +96,6 @@ snapshots["sbb-paginator renders ellipsis on end side Shadow DOM"] =
       <sbb-divider
         aria-orientation="vertical"
         orientation="vertical"
-        role="separator"
         slot="li-1"
       >
       </sbb-divider>
@@ -214,7 +212,6 @@ snapshots["sbb-paginator renders ellipsis on start side Shadow DOM"] =
       <sbb-divider
         aria-orientation="vertical"
         orientation="vertical"
-        role="separator"
         slot="li-1"
       >
       </sbb-divider>
@@ -331,7 +328,6 @@ snapshots["sbb-paginator renders ellipsis on both side Shadow DOM"] =
       <sbb-divider
         aria-orientation="vertical"
         orientation="vertical"
-        role="separator"
         slot="li-1"
       >
       </sbb-divider>
@@ -452,7 +448,6 @@ snapshots["sbb-paginator renders with options Chrome-Firefox Shadow DOM"] =
       <sbb-divider
         aria-orientation="vertical"
         orientation="vertical"
-        role="separator"
         slot="li-1"
       >
       </sbb-divider>
@@ -564,7 +559,6 @@ snapshots["sbb-paginator renders with options Chrome-Firefox Shadow DOM"] =
           data-slot-names="unnamed"
           data-variant="select"
           id="sbb-option-3"
-          role="option"
           selected=""
           value="10"
         >
@@ -576,7 +570,6 @@ snapshots["sbb-paginator renders with options Chrome-Firefox Shadow DOM"] =
           data-slot-names="unnamed"
           data-variant="select"
           id="sbb-option-4"
-          role="option"
           value="25"
         >
           25
@@ -587,7 +580,6 @@ snapshots["sbb-paginator renders with options Chrome-Firefox Shadow DOM"] =
           data-slot-names="unnamed"
           data-variant="select"
           id="sbb-option-5"
-          role="option"
           value="50"
         >
           50
@@ -631,7 +623,6 @@ snapshots["sbb-paginator renders with options Safari Shadow DOM"] =
       <sbb-divider
         aria-orientation="vertical"
         orientation="vertical"
-        role="separator"
         slot="li-1"
       >
       </sbb-divider>
@@ -735,7 +726,6 @@ snapshots["sbb-paginator renders with options Safari Shadow DOM"] =
         data-option-panel-origin-borderless=""
         data-state="closed"
         id="select"
-        role="listbox"
         value="10"
       >
         <sbb-option
@@ -744,7 +734,6 @@ snapshots["sbb-paginator renders with options Safari Shadow DOM"] =
           data-slot-names="unnamed"
           data-variant="select"
           id="sbb-option-3"
-          role="option"
           selected=""
           value="10"
         >
@@ -756,7 +745,6 @@ snapshots["sbb-paginator renders with options Safari Shadow DOM"] =
           data-slot-names="unnamed"
           data-variant="select"
           id="sbb-option-4"
-          role="option"
           value="25"
         >
           25
@@ -767,7 +755,6 @@ snapshots["sbb-paginator renders with options Safari Shadow DOM"] =
           data-slot-names="unnamed"
           data-variant="select"
           id="sbb-option-5"
-          role="option"
           value="50"
         >
           50

--- a/src/elements/paginator/paginator/__snapshots__/paginator.snapshot.spec.snap.js
+++ b/src/elements/paginator/paginator/__snapshots__/paginator.snapshot.spec.snap.js
@@ -6,7 +6,6 @@ snapshots["sbb-paginator renders DOM"] =
   length="4"
   page-size="4"
   pager-position="start"
-  role="group"
   size="m"
 >
 </sbb-paginator>
@@ -72,7 +71,6 @@ snapshots["sbb-paginator renders ellipsis on end side DOM"] =
   length="50"
   page-size="4"
   pager-position="start"
-  role="group"
   size="m"
 >
 </sbb-paginator>
@@ -188,7 +186,6 @@ snapshots["sbb-paginator renders ellipsis on start side DOM"] =
   page-index="10"
   page-size="4"
   pager-position="start"
-  role="group"
   size="m"
 >
 </sbb-paginator>
@@ -304,7 +301,6 @@ snapshots["sbb-paginator renders ellipsis on both side DOM"] =
   page-index="7"
   page-size="4"
   pager-position="start"
-  role="group"
   size="m"
 >
 </sbb-paginator>
@@ -424,7 +420,6 @@ snapshots["sbb-paginator renders with options Chrome-Firefox DOM"] =
   length="50"
   page-size="10"
   pager-position="start"
-  role="group"
   size="m"
 >
 </sbb-paginator>
@@ -599,7 +594,6 @@ snapshots["sbb-paginator renders with options Safari DOM"] =
   length="50"
   page-size="10"
   pager-position="start"
-  role="group"
   size="m"
 >
 </sbb-paginator>

--- a/src/elements/radio-button/common/radio-button-common.ts
+++ b/src/elements/radio-button/common/radio-button-common.ts
@@ -5,13 +5,14 @@ import {
   type AbstractConstructor,
   type Constructor,
   SbbFormAssociatedRadioButtonMixin,
-  type SbbFormAssociatedRadioButtonMixinType,
 } from '../../core/mixins.js';
 import type { SbbRadioButtonGroupElement } from '../radio-button-group.js';
 
 export type SbbRadioButtonSize = 'xs' | 's' | 'm';
 
-export declare abstract class SbbRadioButtonCommonElementMixinType extends SbbFormAssociatedRadioButtonMixinType {
+export declare abstract class SbbRadioButtonCommonElementMixinType extends SbbFormAssociatedRadioButtonMixin(
+  LitElement,
+) {
   public get allowEmptySelection(): boolean;
   public set allowEmptySelection(boolean);
   public get group(): SbbRadioButtonGroupElement | null;

--- a/src/elements/radio-button/radio-button-group/__snapshots__/radio-button-group.snapshot.spec.snap.js
+++ b/src/elements/radio-button/radio-button-group/__snapshots__/radio-button-group.snapshot.spec.snap.js
@@ -5,7 +5,6 @@ snapshots["sbb-radio-button-group renders DOM"] =
 `<sbb-radio-button-group
   data-slot-names="unnamed"
   orientation="horizontal"
-  role="radiogroup"
   value="2"
 >
   <sbb-radio-button
@@ -52,7 +51,6 @@ snapshots["sbb-radio-button-group renders with panel DOM"] =
   data-has-panel=""
   data-slot-names="unnamed"
   orientation="horizontal"
-  role="radiogroup"
 >
   <sbb-radio-button-panel
     color="white"
@@ -100,7 +98,6 @@ snapshots["sbb-radio-button-group renders with selection-expansion-panel DOM"] =
   data-has-panel=""
   data-slot-names="unnamed"
   orientation="horizontal"
-  role="radiogroup"
 >
   <sbb-selection-expansion-panel
     color="white"

--- a/src/elements/radio-button/radio-button-group/radio-button-group.component.ts
+++ b/src/elements/radio-button/radio-button-group/radio-button-group.component.ts
@@ -2,11 +2,11 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { forceType, hostAttributes, slotState } from '../../core/decorators.js';
+import { forceType, slotState } from '../../core/decorators.js';
 import { isLean } from '../../core/dom.js';
 import { EventEmitter } from '../../core/eventing.js';
 import type { SbbHorizontalFrom, SbbOrientation } from '../../core/interfaces.js';
-import { SbbDisabledMixin } from '../../core/mixins.js';
+import { SbbDisabledMixin, SbbElementInternalsMixin } from '../../core/mixins.js';
 import type { SbbRadioButtonSize } from '../common.js';
 import type { SbbRadioButtonPanelElement } from '../radio-button-panel.js';
 import type { SbbRadioButtonElement } from '../radio-button.js';
@@ -25,11 +25,11 @@ let nextId = 0;
  */
 export
 @customElement('sbb-radio-button-group')
-@hostAttributes({
-  role: 'radiogroup',
-})
 @slotState()
-class SbbRadioButtonGroupElement<T = string> extends SbbDisabledMixin(LitElement) {
+class SbbRadioButtonGroupElement<T = string> extends SbbDisabledMixin(
+  SbbElementInternalsMixin(LitElement),
+) {
+  public static override readonly role = 'radiogroup';
   public static override styles: CSSResultGroup = style;
   public static readonly events = {
     didChange: 'didChange',

--- a/src/elements/select/__snapshots__/select.snapshot.spec.snap.js
+++ b/src/elements/select/__snapshots__/select.snapshot.spec.snap.js
@@ -5,7 +5,6 @@ snapshots["sbb-select renders Safari DOM"] =
 `<sbb-select
   data-state="closed"
   id="sbb-select-1"
-  role="listbox"
 >
   <sbb-option
     aria-selected="false"
@@ -13,7 +12,6 @@ snapshots["sbb-select renders Safari DOM"] =
     data-slot-names="unnamed"
     data-variant="select"
     id="sbb-option-0"
-    role="option"
     value="1"
   >
     Option 1
@@ -24,7 +22,6 @@ snapshots["sbb-select renders Safari DOM"] =
     data-slot-names="unnamed"
     data-variant="select"
     id="sbb-option-1"
-    role="option"
     value="2"
   >
     Option 2
@@ -35,7 +32,6 @@ snapshots["sbb-select renders Safari DOM"] =
     data-slot-names="unnamed"
     data-variant="select"
     id="sbb-option-2"
-    role="option"
     value="3"
   >
     Option 3
@@ -91,7 +87,6 @@ snapshots["sbb-select renders multiple Safari DOM"] =
   data-state="closed"
   id="sbb-select-3"
   multiple=""
-  role="listbox"
 >
   <sbb-option
     aria-selected="false"
@@ -100,7 +95,6 @@ snapshots["sbb-select renders multiple Safari DOM"] =
     data-slot-names="unnamed"
     data-variant="select"
     id="sbb-option-6"
-    role="option"
     value="1"
   >
     Option 1
@@ -112,7 +106,6 @@ snapshots["sbb-select renders multiple Safari DOM"] =
     data-slot-names="unnamed"
     data-variant="select"
     id="sbb-option-7"
-    role="option"
     value="2"
   >
     Option 2
@@ -124,7 +117,6 @@ snapshots["sbb-select renders multiple Safari DOM"] =
     data-slot-names="unnamed"
     data-variant="select"
     id="sbb-option-8"
-    role="option"
     value="3"
   >
     Option 3
@@ -186,7 +178,6 @@ snapshots["sbb-select renders Chrome-Firefox DOM"] =
     data-slot-names="unnamed"
     data-variant="select"
     id="sbb-option-0"
-    role="option"
     value="1"
   >
     Option 1
@@ -197,7 +188,6 @@ snapshots["sbb-select renders Chrome-Firefox DOM"] =
     data-slot-names="unnamed"
     data-variant="select"
     id="sbb-option-1"
-    role="option"
     value="2"
   >
     Option 2
@@ -208,7 +198,6 @@ snapshots["sbb-select renders Chrome-Firefox DOM"] =
     data-slot-names="unnamed"
     data-variant="select"
     id="sbb-option-2"
-    role="option"
     value="3"
   >
     Option 3
@@ -252,7 +241,6 @@ snapshots["sbb-select renders Chrome-Firefox Shadow DOM"] =
       <div
         class="sbb-select__options"
         id="sbb-select-2"
-        role="listbox"
       >
         <slot>
         </slot>
@@ -292,7 +280,6 @@ snapshots["sbb-select renders multiple Chrome-Firefox DOM"] =
     data-slot-names="unnamed"
     data-variant="select"
     id="sbb-option-9"
-    role="option"
     value="1"
   >
     Option 1
@@ -304,7 +291,6 @@ snapshots["sbb-select renders multiple Chrome-Firefox DOM"] =
     data-slot-names="unnamed"
     data-variant="select"
     id="sbb-option-10"
-    role="option"
     value="2"
   >
     Option 2
@@ -316,7 +302,6 @@ snapshots["sbb-select renders multiple Chrome-Firefox DOM"] =
     data-slot-names="unnamed"
     data-variant="select"
     id="sbb-option-11"
-    role="option"
     value="3"
   >
     Option 3
@@ -361,7 +346,6 @@ snapshots["sbb-select renders multiple Chrome-Firefox Shadow DOM"] =
         aria-multiselectable=""
         class="sbb-select__options"
         id="sbb-select-5"
-        role="listbox"
       >
         <slot>
         </slot>

--- a/src/elements/select/__snapshots__/select.snapshot.spec.snap.js
+++ b/src/elements/select/__snapshots__/select.snapshot.spec.snap.js
@@ -241,6 +241,7 @@ snapshots["sbb-select renders Chrome-Firefox Shadow DOM"] =
       <div
         class="sbb-select__options"
         id="sbb-select-2"
+        role="listbox"
       >
         <slot>
         </slot>
@@ -346,6 +347,7 @@ snapshots["sbb-select renders multiple Chrome-Firefox Shadow DOM"] =
         aria-multiselectable=""
         class="sbb-select__options"
         id="sbb-select-5"
+        role="listbox"
       >
         <slot>
         </slot>

--- a/src/elements/select/select.component.ts
+++ b/src/elements/select/select.component.ts
@@ -8,12 +8,7 @@ import { until } from 'lit/directives/until.js';
 import { getNextElementIndex } from '../core/a11y.js';
 import { SbbOpenCloseBaseElement } from '../core/base-elements.js';
 import { SbbEscapableOverlayController, SbbLanguageController } from '../core/controllers.js';
-import {
-  forceType,
-  getOverride,
-  handleDistinctChange,
-  hostAttributes,
-} from '../core/decorators.js';
+import { forceType, getOverride, handleDistinctChange } from '../core/decorators.js';
 import { isNextjs, isSafari, isZeroAnimationDuration, setOrRemoveAttribute } from '../core/dom.js';
 import { EventEmitter } from '../core/eventing.js';
 import { i18nSelectionRequired } from '../core/i18n.js';
@@ -66,9 +61,6 @@ export interface SelectChange<T = string> {
  */
 export
 @customElement('sbb-select')
-@hostAttributes({
-  role: ariaRoleOnHost ? 'listbox' : null,
-})
 class SbbSelectElement<T = string> extends SbbUpdateSchedulerMixin(
   SbbDisabledMixin(
     SbbNegativeMixin(
@@ -82,6 +74,7 @@ class SbbSelectElement<T = string> extends SbbUpdateSchedulerMixin(
     ),
   ),
 ) {
+  public static override readonly role = ariaRoleOnHost ? 'listbox' : null;
   public static override styles: CSSResultGroup = style;
 
   // TODO: fix using ...super.events requires: https://github.com/sbb-design-systems/lyne-components/issues/2600

--- a/src/elements/selection-expansion-panel/__snapshots__/selection-expansion-panel.snapshot.spec.snap.js
+++ b/src/elements/selection-expansion-panel/__snapshots__/selection-expansion-panel.snapshot.spec.snap.js
@@ -24,7 +24,6 @@ snapshots["sbb-selection-expansion-panel renders DOM"] =
     </span>
     <sbb-card-badge
       color="charcoal"
-      role="text"
       slot="badge"
     >
       %
@@ -51,7 +50,6 @@ snapshots["sbb-selection-expansion-panel renders Shadow DOM"] =
       <sbb-divider
         aria-orientation="horizontal"
         orientation="horizontal"
-        role="separator"
       >
       </sbb-divider>
       <slot name="content">

--- a/src/elements/sidebar/icon-sidebar/icon-sidebar.component.ts
+++ b/src/elements/sidebar/icon-sidebar/icon-sidebar.component.ts
@@ -1,6 +1,7 @@
 import { type CSSResultGroup, html, LitElement, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
+import { SbbElementInternalsMixin } from '../../core/mixins.js';
 import type { SbbIconSidebarContainerElement } from '../icon-sidebar-container.js';
 
 import style from './icon-sidebar.scss?lit&inline';
@@ -12,7 +13,8 @@ import style from './icon-sidebar.scss?lit&inline';
  */
 export
 @customElement('sbb-icon-sidebar')
-class SbbIconSidebarElement extends LitElement {
+class SbbIconSidebarElement extends SbbElementInternalsMixin(LitElement) {
+  public static override readonly role = 'navigation';
   public static override styles: CSSResultGroup = style;
 
   /** Background color of the icon sidebar. Either `white` or `milk`. **/
@@ -22,13 +24,6 @@ class SbbIconSidebarElement extends LitElement {
   /** Returns the SbbIconSidebarContainerElement where this icon-sidebar is contained. */
   public get container(): SbbIconSidebarContainerElement | null {
     return this.closest('sbb-icon-sidebar-container');
-  }
-
-  public constructor() {
-    super();
-    const internals: ElementInternals = this.attachInternals();
-    /** @internal */
-    internals.role = 'navigation';
   }
 
   public override connectedCallback(): void {

--- a/src/elements/sidebar/sidebar-title/__snapshots__/sidebar-title.snapshot.spec.snap.js
+++ b/src/elements/sidebar/sidebar-title/__snapshots__/sidebar-title.snapshot.spec.snap.js
@@ -3,9 +3,7 @@ export const snapshots = {};
 
 snapshots["sbb-sidebar-title renders Light DOM"] = 
 `<sbb-sidebar-title
-  aria-level="2"
   level="2"
-  role="heading"
   slot="title-section"
   visual-level="5"
 >

--- a/src/elements/skiplink-list/__snapshots__/skiplink-list.snapshot.spec.snap.js
+++ b/src/elements/skiplink-list/__snapshots__/skiplink-list.snapshot.spec.snap.js
@@ -4,12 +4,10 @@ export const snapshots = {};
 snapshots["sbb-skiplink-list should render named slots if data-ssr-child-count attribute is set"] = 
 `<div class="sbb-skiplink-list__wrapper">
   <sbb-title
-    aria-level="2"
     class="sbb-link-list-title"
     id="sbb-skiplink-list-title-id"
     level="2"
     negative=""
-    role="heading"
     visual-level="5"
     visually-hidden=""
   >
@@ -89,12 +87,10 @@ snapshots["sbb-skiplink-list renders DOM"] =
 snapshots["sbb-skiplink-list renders Shadow DOM"] = 
 `<div class="sbb-skiplink-list__wrapper">
   <sbb-title
-    aria-level="2"
     class="sbb-link-list-title"
     id="sbb-skiplink-list-title-id"
     level="2"
     negative=""
-    role="heading"
     visual-level="5"
     visually-hidden=""
   >
@@ -177,12 +173,10 @@ snapshots["sbb-skiplink-list renders with title DOM"] =
 snapshots["sbb-skiplink-list renders with title Shadow DOM"] = 
 `<div class="sbb-skiplink-list__wrapper">
   <sbb-title
-    aria-level="3"
     class="sbb-link-list-title"
     id="sbb-skiplink-list-title-id"
     level="3"
     negative=""
-    role="heading"
     visual-level="5"
     visually-hidden=""
   >

--- a/src/elements/slider/slider.component.ts
+++ b/src/elements/slider/slider.component.ts
@@ -9,6 +9,7 @@ import {
   type FormRestoreReason,
   type FormRestoreState,
   SbbDisabledMixin,
+  SbbElementInternalsMixin,
   SbbFormAssociatedMixin,
   SbbReadonlyMixin,
 } from '../core/mixins.js';
@@ -31,8 +32,9 @@ export
   tabindex: '0',
 })
 class SbbSliderElement extends SbbDisabledMixin(
-  SbbReadonlyMixin(SbbFormAssociatedMixin(LitElement)),
+  SbbReadonlyMixin(SbbFormAssociatedMixin(SbbElementInternalsMixin(LitElement))),
 ) {
+  public static override readonly role = 'slider';
   public static override styles: CSSResultGroup = style;
   public static readonly events = {
     didChange: 'didChange',
@@ -134,8 +136,6 @@ class SbbSliderElement extends SbbDisabledMixin(
 
   public constructor() {
     super();
-    /** @internal */
-    this.internals.role = 'slider';
     this.addEventListener?.('keydown', (e) => this._handleKeydown(e));
   }
 

--- a/src/elements/status/__snapshots__/status.snapshot.spec.snap.js
+++ b/src/elements/status/__snapshots__/status.snapshot.spec.snap.js
@@ -26,10 +26,8 @@ snapshots["sbb-status renders Shadow DOM"] =
   </span>
   <span class="sbb-status__content">
     <sbb-title
-      aria-level="3"
       class="sbb-status__title"
       level="3"
-      role="heading"
       visual-level="5"
     >
       <slot name="title">
@@ -70,10 +68,8 @@ snapshots["sbb-status renders with title Shadow DOM"] =
   </span>
   <span class="sbb-status__content">
     <sbb-title
-      aria-level="3"
       class="sbb-status__title"
       level="3"
-      role="heading"
       visual-level="5"
     >
       <slot name="title">

--- a/src/elements/stepper/step-label/__snapshots__/step-label.snapshot.spec.snap.js
+++ b/src/elements/stepper/step-label/__snapshots__/step-label.snapshot.spec.snap.js
@@ -6,7 +6,6 @@ snapshots["sbb-step-label renders DOM"] =
   data-action=""
   data-button=""
   id="sbb-step-label-0"
-  role="tab"
   slot="step-label"
   tabindex="-1"
 >
@@ -35,7 +34,6 @@ snapshots["sbb-step-label renders with icon DOM"] =
   data-button=""
   icon-name="tick-small"
   id="sbb-step-label-2"
-  role="tab"
   slot="step-label"
   tabindex="-1"
 >
@@ -72,7 +70,6 @@ snapshots["sbb-step-label renders disabled DOM"] =
   data-disabled=""
   disabled=""
   id="sbb-step-label-4"
-  role="tab"
   slot="step-label"
   tabindex="-1"
 >

--- a/src/elements/stepper/step-label/step-label.component.ts
+++ b/src/elements/stepper/step-label/step-label.component.ts
@@ -2,7 +2,6 @@ import { type CSSResultGroup, html, type TemplateResult, type PropertyValues } f
 import { customElement } from 'lit/decorators.js';
 
 import { SbbButtonBaseElement } from '../../core/base-elements.js';
-import { hostAttributes } from '../../core/decorators.js';
 import { SbbDisabledMixin } from '../../core/mixins.js';
 import { SbbIconNameMixin } from '../../icon.js';
 import type { SbbStepElement } from '../step.js';
@@ -21,12 +20,8 @@ let nextId = 0;
  */
 export
 @customElement('sbb-step-label')
-@hostAttributes({
-  slot: 'step-label',
-  tabindex: '-1',
-  role: 'tab',
-})
 class SbbStepLabelElement extends SbbIconNameMixin(SbbDisabledMixin(SbbButtonBaseElement)) {
+  public static override readonly role = 'tab';
   public static override styles: CSSResultGroup = style;
 
   /** The step controlled by the label. */
@@ -57,7 +52,11 @@ class SbbStepLabelElement extends SbbIconNameMixin(SbbDisabledMixin(SbbButtonBas
   public override connectedCallback(): void {
     super.connectedCallback();
     this.id ||= `sbb-step-label-${nextId++}`;
+    this.slot ||= 'step-label';
     this.internals.ariaSelected = 'false';
+    if (this.tabIndex < 0) {
+      this.tabIndex = -1;
+    }
     this._stepper = this.closest('sbb-stepper');
     this._step = this._getStep();
     // The `data-disabled` attribute is used to preserve the initial disabled state of

--- a/src/elements/stepper/step-label/step-label.component.ts
+++ b/src/elements/stepper/step-label/step-label.component.ts
@@ -54,9 +54,7 @@ class SbbStepLabelElement extends SbbIconNameMixin(SbbDisabledMixin(SbbButtonBas
     this.id ||= `sbb-step-label-${nextId++}`;
     this.slot ||= 'step-label';
     this.internals.ariaSelected = 'false';
-    if (this.tabIndex < 0) {
-      this.tabIndex = -1;
-    }
+    this.tabIndex = -1;
     this._stepper = this.closest('sbb-stepper');
     this._step = this._getStep();
     // The `data-disabled` attribute is used to preserve the initial disabled state of

--- a/src/elements/stepper/step/__snapshots__/step.snapshot.spec.snap.js
+++ b/src/elements/stepper/step/__snapshots__/step.snapshot.spec.snap.js
@@ -4,7 +4,6 @@ export const snapshots = {};
 snapshots["sbb-step renders DOM"] = 
 `<sbb-step
   id="sbb-step-0"
-  role="tabpanel"
   slot="step"
 >
   Step content

--- a/src/elements/stepper/step/step.component.ts
+++ b/src/elements/stepper/step/step.component.ts
@@ -8,8 +8,8 @@ import {
 } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-import { hostAttributes } from '../../core/decorators.js';
 import { EventEmitter } from '../../core/eventing.js';
+import { SbbElementInternalsMixin } from '../../core/mixins.js';
 import type { SbbStepLabelElement } from '../step-label.js';
 import type { SbbStepperElement } from '../stepper.js';
 
@@ -32,11 +32,8 @@ export type SbbStepValidateEventDetails = {
  */
 export
 @customElement('sbb-step')
-@hostAttributes({
-  slot: 'step',
-  role: 'tabpanel',
-})
-class SbbStepElement extends LitElement {
+class SbbStepElement extends SbbElementInternalsMixin(LitElement) {
+  public static override readonly role = 'tabpanel';
   public static override styles: CSSResultGroup = style;
   public static readonly events = {
     validate: 'validate',
@@ -165,6 +162,7 @@ class SbbStepElement extends LitElement {
   public override connectedCallback(): void {
     super.connectedCallback();
     this.id ||= `sbb-step-${nextId++}`;
+    this.slot ||= 'step';
     this._stepper = this.closest('sbb-stepper');
     this._label = this._getStepLabel();
   }

--- a/src/elements/stepper/stepper/__snapshots__/stepper.snapshot.spec.snap.js
+++ b/src/elements/stepper/stepper/__snapshots__/stepper.snapshot.spec.snap.js
@@ -16,7 +16,6 @@ snapshots["sbb-stepper renders DOM"] =
     data-selected=""
     data-size="m"
     id="sbb-step-label-0"
-    role="tab"
     slot="step-label"
     tabindex="0"
   >
@@ -27,7 +26,6 @@ snapshots["sbb-stepper renders DOM"] =
     data-orientation="horizontal"
     data-selected=""
     id="sbb-step-0"
-    role="tabpanel"
     slot="step"
   >
     Test step content 1
@@ -39,7 +37,6 @@ snapshots["sbb-stepper renders DOM"] =
     data-orientation="horizontal"
     data-size="m"
     id="sbb-step-label-1"
-    role="tab"
     slot="step-label"
     tabindex="-1"
   >
@@ -49,7 +46,6 @@ snapshots["sbb-stepper renders DOM"] =
     aria-labelledby="sbb-step-label-1"
     data-orientation="horizontal"
     id="sbb-step-1"
-    role="tabpanel"
     slot="step"
   >
     Test step content 2
@@ -63,7 +59,6 @@ snapshots["sbb-stepper renders DOM"] =
     data-size="m"
     disabled=""
     id="sbb-step-label-2"
-    role="tab"
     slot="step-label"
     tabindex="-1"
   >
@@ -73,7 +68,6 @@ snapshots["sbb-stepper renders DOM"] =
     aria-labelledby="sbb-step-label-2"
     data-orientation="horizontal"
     id="sbb-step-2"
-    role="tabpanel"
     slot="step"
   >
     Test step content 3
@@ -82,7 +76,6 @@ snapshots["sbb-stepper renders DOM"] =
     data-action=""
     data-button=""
     id="sbb-step-label-3"
-    role="tab"
     slot="step-label"
     tabindex="-1"
   >

--- a/src/elements/stepper/stepper/stepper.stories.ts
+++ b/src/elements/stepper/stepper/stepper.stories.ts
@@ -105,8 +105,10 @@ const firstFormElement = (sbbFormError: SbbFormErrorElement): TemplateResult => 
         const input = event.currentTarget as HTMLInputElement;
         if (input.value !== '') {
           sbbFormError.remove();
+          input.classList.remove('sbb-invalid');
         } else {
           input.closest('sbb-form-field')!.append(sbbFormError);
+          input.classList.add('sbb-invalid');
         }
       }}
       required

--- a/src/elements/stepper/stepper/stepper.stories.ts
+++ b/src/elements/stepper/stepper/stepper.stories.ts
@@ -6,7 +6,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 import { sbbSpread } from '../../../storybook/helpers/spread.js';
 import type { SbbFormErrorElement } from '../../form-error.js';
-import { SbbStepElement } from '../step.js';
+import { SbbStepElement, type SbbStepValidateEventDetails } from '../step.js';
 
 import readme from './readme.md?raw';
 
@@ -105,10 +105,8 @@ const firstFormElement = (sbbFormError: SbbFormErrorElement): TemplateResult => 
         const input = event.currentTarget as HTMLInputElement;
         if (input.value !== '') {
           sbbFormError.remove();
-          input.classList.remove('sbb-invalid');
         } else {
           input.closest('sbb-form-field')!.append(sbbFormError);
-          input.classList.add('sbb-invalid');
         }
       }}
       required
@@ -195,8 +193,12 @@ const WithSingleFormTemplate = (args: Args): TemplateResult => {
       <sbb-stepper ${sbbSpread(args)} aria-label="Purpose of this flow" selected-index="0">
         <sbb-step-label icon-name="pen-small">Step 1</sbb-step-label>
         <sbb-step
-          @validate=${(e: CustomEvent) => {
-            if (e.detail.currentStep.querySelector('sbb-form-field').hasAttribute('data-invalid')) {
+          @validate=${(e: CustomEvent<SbbStepValidateEventDetails>) => {
+            if (
+              e.detail
+                .currentStep!.querySelector('sbb-form-field')!
+                .inputElement!.matches(':invalid')
+            ) {
               e.preventDefault();
             }
           }}
@@ -267,8 +269,10 @@ const WithMultipleFormsTemplate = (args: Args): TemplateResult => {
     <sbb-stepper ${sbbSpread(args)} aria-label="Purpose of this flow" selected-index="0">
       <sbb-step-label icon-name="pen-small">Step 1</sbb-step-label>
       <sbb-step
-        @validate=${(e: CustomEvent) => {
-          if (e.detail.currentStep.querySelector('sbb-form-field').hasAttribute('data-invalid')) {
+        @validate=${(e: CustomEvent<SbbStepValidateEventDetails>) => {
+          if (
+            e.detail.currentStep!.querySelector('sbb-form-field')!.inputElement!.matches(':invalid')
+          ) {
             e.preventDefault();
           }
         }}

--- a/src/elements/table/table-wrapper/table-wrapper.component.ts
+++ b/src/elements/table/table-wrapper/table-wrapper.component.ts
@@ -10,7 +10,7 @@ import {
 import { customElement, property } from 'lit/decorators.js';
 
 import { forceType } from '../../core/decorators.js';
-import { SbbNegativeMixin } from '../../core/mixins.js';
+import { SbbElementInternalsMixin, SbbNegativeMixin } from '../../core/mixins.js';
 
 import style from './table-wrapper.scss?lit&inline';
 
@@ -21,7 +21,8 @@ import style from './table-wrapper.scss?lit&inline';
  */
 export
 @customElement('sbb-table-wrapper')
-class SbbTableWrapperElement extends SbbNegativeMixin(LitElement) {
+class SbbTableWrapperElement extends SbbNegativeMixin(SbbElementInternalsMixin(LitElement)) {
+  public static override readonly role = 'section';
   public static override styles: CSSResultGroup = style;
 
   /** Whether the table wrapper is focusable. */
@@ -31,11 +32,6 @@ class SbbTableWrapperElement extends SbbNegativeMixin(LitElement) {
 
   public constructor() {
     super();
-
-    const internals: ElementInternals = this.attachInternals();
-    /** @internal */
-    internals.role = 'section';
-
     this.addController(
       new ResizeController(this, {
         skipInitial: true,

--- a/src/elements/tabs/tab-group/__snapshots__/tab-group.snapshot.spec.snap.js
+++ b/src/elements/tabs/tab-group/__snapshots__/tab-group.snapshot.spec.snap.js
@@ -18,7 +18,6 @@ snapshots["sbb-tab-group renders DOM"] =
   <sbb-tab
     active=""
     id="sbb-tab-panel-1"
-    role="tabpanel"
     tabindex="0"
   >
     Test tab content 1
@@ -36,7 +35,6 @@ snapshots["sbb-tab-group renders DOM"] =
   </sbb-tab-label>
   <sbb-tab
     id="sbb-tab-panel-2"
-    role="tabpanel"
     tabindex="0"
   >
     Test tab content 2
@@ -55,7 +53,6 @@ snapshots["sbb-tab-group renders DOM"] =
   </sbb-tab-label>
   <sbb-tab
     id="sbb-tab-panel-3"
-    role="tabpanel"
     tabindex="0"
   >
     Test tab content 3
@@ -73,7 +70,6 @@ snapshots["sbb-tab-group renders DOM"] =
   </sbb-tab-label>
   <sbb-tab
     id="sbb-tab-panel-4"
-    role="tabpanel"
     tabindex="0"
   >
     Test tab content 4

--- a/src/elements/tabs/tab-group/__snapshots__/tab-group.snapshot.spec.snap.js
+++ b/src/elements/tabs/tab-group/__snapshots__/tab-group.snapshot.spec.snap.js
@@ -9,7 +9,6 @@ snapshots["sbb-tab-group renders DOM"] =
     aria-selected="true"
     data-size="l"
     data-slot-names="unnamed"
-    role="tab"
     slot="tab-bar"
     tabindex="0"
   >
@@ -27,7 +26,6 @@ snapshots["sbb-tab-group renders DOM"] =
     aria-selected="false"
     data-size="l"
     data-slot-names="unnamed"
-    role="tab"
     slot="tab-bar"
     tabindex="-1"
   >
@@ -45,7 +43,6 @@ snapshots["sbb-tab-group renders DOM"] =
     data-size="l"
     data-slot-names="unnamed"
     disabled=""
-    role="tab"
     slot="tab-bar"
     tabindex="-1"
   >
@@ -62,7 +59,6 @@ snapshots["sbb-tab-group renders DOM"] =
     aria-selected="false"
     data-size="l"
     data-slot-names="unnamed"
-    role="tab"
     slot="tab-bar"
     tabindex="-1"
   >

--- a/src/elements/tabs/tab-group/tab-group.component.ts
+++ b/src/elements/tabs/tab-group/tab-group.component.ts
@@ -344,14 +344,12 @@ class SbbTabGroupElement extends SbbHydrationMixin(LitElement) {
     tabLabel.tabIndex = -1;
     tabLabel.disabled = tabLabel.hasAttribute('disabled');
     tabLabel.active = tabLabel.hasAttribute('active') && !tabLabel.disabled;
-    tabLabel.setAttribute('role', 'tab');
     tabLabel.setAttribute('aria-selected', String(tabLabel.active));
     tabLabel.addEventListener('click', () => {
       tabLabel.tabGroupActions?.select();
     });
     if (tabLabel.tab) {
       tabLabel.setAttribute('aria-controls', tabLabel.tab.id);
-      tabLabel.tab.setAttribute('role', 'tabpanel');
       tabLabel.tab.toggleAttribute('active', tabLabel.active);
     }
 

--- a/src/elements/tabs/tab-group/tab-group.scss
+++ b/src/elements/tabs/tab-group/tab-group.scss
@@ -45,7 +45,7 @@
     }
   }
 
-  ::slotted([role='tabpanel']:focus-visible) {
+  ::slotted(sbb-tab:focus-visible) {
     @include sbb.focus-outline;
   }
 }

--- a/src/elements/tabs/tab-label/__snapshots__/tab-label.snapshot.spec.snap.js
+++ b/src/elements/tabs/tab-label/__snapshots__/tab-label.snapshot.spec.snap.js
@@ -105,9 +105,8 @@ snapshots["sbb-tab-label A11y tree Chrome"] =
   "name": "",
   "children": [
     {
-      "role": "heading",
-      "name": "Tab title",
-      "level": 1
+      "role": "tab",
+      "name": "Tab title"
     }
   ]
 }

--- a/src/elements/tabs/tab-label/tab-label.component.ts
+++ b/src/elements/tabs/tab-label/tab-label.component.ts
@@ -4,7 +4,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { html, unsafeStatic } from 'lit/static-html.js';
 
 import { forceType, omitEmptyConverter, slotState } from '../../core/decorators.js';
-import { SbbDisabledMixin } from '../../core/mixins.js';
+import { SbbDisabledMixin, SbbElementInternalsMixin } from '../../core/mixins.js';
 import { SbbIconNameMixin } from '../../icon.js';
 import type { SbbTitleLevel } from '../../title.js';
 
@@ -20,7 +20,10 @@ import style from './tab-label.scss?lit&inline';
 export
 @customElement('sbb-tab-label')
 @slotState()
-class SbbTabLabelElement extends SbbDisabledMixin(SbbIconNameMixin(LitElement)) {
+class SbbTabLabelElement extends SbbDisabledMixin(
+  SbbIconNameMixin(SbbElementInternalsMixin(LitElement)),
+) {
+  public static override role = 'tab';
   public static override styles: CSSResultGroup = style;
 
   /**

--- a/src/elements/tabs/tab/tab.component.ts
+++ b/src/elements/tabs/tab/tab.component.ts
@@ -2,6 +2,7 @@ import type { CSSResultGroup, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
+import { SbbElementInternalsMixin } from '../../core/mixins.js';
 import type { SbbTabLabelElement } from '../tab-label.js';
 
 import style from './tab.scss?lit&inline';
@@ -13,7 +14,8 @@ import style from './tab.scss?lit&inline';
  */
 export
 @customElement('sbb-tab')
-class SbbTabElement extends LitElement {
+class SbbTabElement extends SbbElementInternalsMixin(LitElement) {
+  public static override role = 'tabpanel';
   public static override styles: CSSResultGroup = style;
 
   /** The `sbb-tab-label` associated with the tab. */

--- a/src/elements/teaser-product/common/teaser-product-common.ts
+++ b/src/elements/teaser-product/common/teaser-product-common.ts
@@ -3,13 +3,11 @@ import { property } from 'lit/decorators.js';
 
 import type { SbbActionBaseElement } from '../../core/base-elements.js';
 import { slotState } from '../../core/decorators.js';
-import {
-  type AbstractConstructor,
-  SbbNegativeMixin,
-  type SbbNegativeMixinType,
-} from '../../core/mixins.js';
+import { type AbstractConstructor, SbbNegativeMixin } from '../../core/mixins.js';
 
-export declare class SbbTeaserProductCommonElementMixinType extends SbbNegativeMixinType {
+export declare class SbbTeaserProductCommonElementMixinType extends SbbNegativeMixin(
+  SbbActionBaseElement,
+) {
   public accessor imageAlignment: 'after' | 'before';
 }
 

--- a/src/elements/teaser/__snapshots__/teaser.snapshot.spec.snap.js
+++ b/src/elements/teaser/__snapshots__/teaser.snapshot.spec.snap.js
@@ -39,10 +39,8 @@ snapshots["sbb-teaser renders after centered Shadow DOM"] =
         </slot>
       </sbb-chip-label>
       <sbb-title
-        aria-level="5"
         class="sbb-teaser__lead"
         level="5"
-        role="heading"
         visual-level="5"
       >
         <slot name="title">
@@ -97,10 +95,8 @@ snapshots["sbb-teaser renders after with title level set Shadow DOM"] =
         </slot>
       </sbb-chip-label>
       <sbb-title
-        aria-level="2"
         class="sbb-teaser__lead"
         level="2"
-        role="heading"
         visual-level="5"
       >
         <slot name="title">
@@ -171,10 +167,8 @@ snapshots["sbb-teaser renders below with projected content Shadow DOM"] =
         </slot>
       </sbb-chip-label>
       <sbb-title
-        aria-level="5"
         class="sbb-teaser__lead"
         level="5"
-        role="heading"
         visual-level="5"
       >
         <slot name="title">

--- a/src/elements/title/__snapshots__/title.snapshot.spec.snap.js
+++ b/src/elements/title/__snapshots__/title.snapshot.spec.snap.js
@@ -3,9 +3,7 @@ export const snapshots = {};
 
 snapshots["sbb-title renders DOM"] = 
 `<sbb-title
-  aria-level="1"
   level="1"
-  role="heading"
   visual-level="2"
 >
   Sample Title Text

--- a/src/elements/title/title-base.ts
+++ b/src/elements/title/title-base.ts
@@ -3,7 +3,8 @@ import { LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
 import { html } from 'lit/static-html.js';
 
-import { forceType, hostAttributes } from '../core/decorators.js';
+import { forceType } from '../core/decorators.js';
+import { SbbElementInternalsMixin } from '../core/mixins.js';
 
 import style from './title-common.scss?lit&inline';
 
@@ -14,11 +15,8 @@ export type SbbTitleLevel = '1' | '2' | '3' | '4' | '5' | '6';
  *
  * @slot - Use the unnamed slot to place the content of the title.
  */
-export
-@hostAttributes({
-  role: 'heading',
-})
-abstract class SbbTitleBase extends LitElement {
+export abstract class SbbTitleBase extends SbbElementInternalsMixin(LitElement) {
+  public static override role = 'heading';
   public static override styles: CSSResultGroup = style;
 
   /** Title level */
@@ -41,7 +39,7 @@ abstract class SbbTitleBase extends LitElement {
     super.willUpdate(changedProperties);
 
     if (changedProperties.has('level')) {
-      this.setAttribute('aria-level', this.level);
+      this.internals.ariaLevel = this.level;
     }
   }
 

--- a/src/elements/toggle/toggle-option/toggle-option.component.ts
+++ b/src/elements/toggle/toggle-option/toggle-option.component.ts
@@ -5,7 +5,7 @@ import { customElement, property } from 'lit/decorators.js';
 
 import { forceType, slotState } from '../../core/decorators.js';
 import { setOrRemoveAttribute } from '../../core/dom.js';
-import { SbbDisabledMixin } from '../../core/mixins.js';
+import { SbbDisabledMixin, SbbElementInternalsMixin } from '../../core/mixins.js';
 import { SbbIconNameMixin } from '../../icon.js';
 import type { SbbToggleElement } from '../toggle.js';
 
@@ -21,7 +21,10 @@ import style from './toggle-option.scss?lit&inline';
 export
 @customElement('sbb-toggle-option')
 @slotState()
-class SbbToggleOptionElement<T = string> extends SbbDisabledMixin(SbbIconNameMixin(LitElement)) {
+class SbbToggleOptionElement<T = string> extends SbbDisabledMixin(
+  SbbIconNameMixin(SbbElementInternalsMixin(LitElement)),
+) {
+  public static override readonly role = 'radio';
   public static override styles: CSSResultGroup = style;
 
   /** Whether the toggle-option is checked. */
@@ -37,10 +40,6 @@ class SbbToggleOptionElement<T = string> extends SbbDisabledMixin(SbbIconNameMix
 
   public constructor() {
     super();
-    const internals: ElementInternals = this.attachInternals();
-    /** @internal */
-    internals.role = 'radio';
-
     // We need to listen input event on host as with keyboard navigation
     // the Input Event is triggered from sbb-toggle.
     this.addEventListener?.('input', () => this._handleInput());

--- a/src/elements/toggle/toggle/toggle.component.ts
+++ b/src/elements/toggle/toggle/toggle.component.ts
@@ -16,6 +16,7 @@ import {
   type FormRestoreReason,
   type FormRestoreState,
   SbbDisabledMixin,
+  SbbElementInternalsMixin,
   SbbFormAssociatedMixin,
 } from '../../core/mixins.js';
 import { type SbbToggleOptionElement } from '../toggle-option.js';
@@ -31,7 +32,10 @@ import style from './toggle.scss?lit&inline';
  */
 export
 @customElement('sbb-toggle')
-class SbbToggleElement<T = string> extends SbbDisabledMixin(SbbFormAssociatedMixin(LitElement)) {
+class SbbToggleElement<T = string> extends SbbDisabledMixin(
+  SbbFormAssociatedMixin(SbbElementInternalsMixin(LitElement)),
+) {
+  public static override readonly role = 'radiogroup';
   public static override styles: CSSResultGroup = style;
   public static readonly events = {
     change: 'change',
@@ -85,9 +89,6 @@ class SbbToggleElement<T = string> extends SbbDisabledMixin(SbbFormAssociatedMix
 
   public constructor() {
     super();
-    /** @internal */
-    this.internals.role = 'radiogroup';
-
     this.addEventListener?.('input', () => this._handleInput(), { passive: true });
     this.addEventListener?.('keydown', (e) => this._handleKeyDown(e));
   }

--- a/tools/manifest/custom-elements-manifest.config.js
+++ b/tools/manifest/custom-elements-manifest.config.js
@@ -148,8 +148,9 @@ export function createManifestConfig(library = '') {
           for (const module of customElementsManifest.modules) {
             fixModulePaths(module, fixTsPaths);
             for (const declaration of module.declarations.filter((d) => d.kind === 'class')) {
-              // Abstract base classes are considered components even if they don't have the `customElement` annotation.
-              if (declaration.name.includes('Base')) {
+              // Abstract base classes or mixins are considered components
+              // even if they don't have the `customElement` annotation.
+              if (declaration.name.includes('Base') || declaration.name.includes('MixinType')) {
                 delete declaration.customElement;
               }
 


### PR DESCRIPTION
This PR extracts ElementInternals handling to its own mixin and replaces attribute usage of role.