### PR TITLE
refactor(sbb-menu-button, sbb-menu-link): remove amount property

### DIFF
--- a/src/elements/header/header/header.stories.ts
+++ b/src/elements/header/header/header.stories.ts
@@ -111,7 +111,7 @@ const TemplateWithUserMenu = (args: Args): TemplateResult => html`
       <sbb-menu trigger="user-menu-trigger">
         <sbb-menu-link icon-name="user-small" href="/"> Account </sbb-menu-link>
         <sbb-menu-button icon-name="tickets-class-small">Tickets</sbb-menu-button>
-        <sbb-menu-button icon-name="shopping-cart-small" amount="1">
+        <sbb-menu-button icon-name="shopping-cart-small" sbb-badge="1">
           Shopping cart
         </sbb-menu-button>
         <sbb-divider></sbb-divider>

--- a/src/elements/menu/common/menu-action-common.ts
+++ b/src/elements/menu/common/menu-action-common.ts
@@ -1,9 +1,8 @@
-import { type CSSResultGroup, nothing, type TemplateResult } from 'lit';
-import { property } from 'lit/decorators.js';
+import { type CSSResultGroup, type TemplateResult } from 'lit';
 import { html } from 'lit/static-html.js';
 
 import type { SbbActionBaseElement } from '../../core/base-elements.js';
-import { forceType, slotState } from '../../core/decorators.js';
+import { slotState } from '../../core/decorators.js';
 import { type AbstractConstructor, SbbDisabledMixin } from '../../core/mixins.js';
 import { SbbIconNameMixin } from '../../icon.js';
 
@@ -11,12 +10,7 @@ import style from './menu-action.scss?lit&inline';
 
 export declare class SbbMenuActionCommonElementMixinType extends SbbIconNameMixin(
   SbbDisabledMixin(SbbActionBaseElement),
-) {
-  /**
-   * @deprecated Will be removed with next major version. Use the sbb-badge attribute on a sbb-icon as alternative.
-   */
-  public accessor amount: string;
-}
+) {}
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const SbbMenuActionCommonElementMixin = <
@@ -27,18 +21,9 @@ export const SbbMenuActionCommonElementMixin = <
   @slotState()
   abstract class SbbMenuActionCommonElement
     extends SbbIconNameMixin(SbbDisabledMixin(superClass))
-    implements Partial<SbbMenuActionCommonElementMixinType>
+    implements SbbMenuActionCommonElementMixinType
   {
     public static styles: CSSResultGroup = style;
-
-    /**
-     * Value shown as badge at component end.
-     * @deprecated Will be removed with next major version. Use the sbb-badge attribute on a sbb-icon as alternative.
-     * @internal
-     */
-    @forceType()
-    @property()
-    public accessor amount: string = '';
 
     protected override renderTemplate(): TemplateResult {
       return html`
@@ -47,9 +32,6 @@ export const SbbMenuActionCommonElementMixin = <
           <span class="sbb-menu-action__label">
             <slot></slot>
           </span>
-          ${this.amount && !this.disabled
-            ? html`<span class="sbb-menu-action__amount">${this.amount}</span>`
-            : nothing}
         </span>
       `;
     }

--- a/src/elements/menu/common/menu-action.scss
+++ b/src/elements/menu/common/menu-action.scss
@@ -126,14 +126,3 @@ $disabled: '[disabled], :disabled, [disabled-interactive]';
     text-decoration: line-through;
   }
 }
-
-.sbb-menu-action__amount {
-  @include sbb.badge;
-
-  flex-shrink: 0;
-  margin-inline-start: auto;
-
-  @include sbb.if-forced-colors {
-    color: var(--sbb-menu-action-color);
-  }
-}

--- a/src/elements/menu/menu-button/__snapshots__/menu-button.snapshot.spec.snap.js
+++ b/src/elements/menu/menu-button/__snapshots__/menu-button.snapshot.spec.snap.js
@@ -33,9 +33,8 @@ snapshots["sbb-menu-button renders Shadow DOM"] =
 `;
 /* end snapshot sbb-menu-button renders Shadow DOM */
 
-snapshots["sbb-menu-button renders component with icon and amount DOM"] = 
+snapshots["sbb-menu-button renders component with icon DOM"] = 
 `<sbb-menu-button
-  amount="123456"
   data-action=""
   data-button=""
   data-slot-names="unnamed"
@@ -45,9 +44,9 @@ snapshots["sbb-menu-button renders component with icon and amount DOM"] =
   Action
 </sbb-menu-button>
 `;
-/* end snapshot sbb-menu-button renders component with icon and amount DOM */
+/* end snapshot sbb-menu-button renders component with icon DOM */
 
-snapshots["sbb-menu-button renders component with icon and amount Shadow DOM"] = 
+snapshots["sbb-menu-button renders component with icon Shadow DOM"] = 
 `<span class="sbb-action-base sbb-menu-button">
   <span class="sbb-menu-action__content">
     <span class="sbb-menu-action__icon">
@@ -65,15 +64,12 @@ snapshots["sbb-menu-button renders component with icon and amount Shadow DOM"] =
       <slot>
       </slot>
     </span>
-    <span class="sbb-menu-action__amount">
-      123456
-    </span>
   </span>
 </span>
 `;
-/* end snapshot sbb-menu-button renders component with icon and amount Shadow DOM */
+/* end snapshot sbb-menu-button renders component with icon Shadow DOM */
 
-snapshots["sbb-menu-button renders component with icon and amount A11y tree Chrome"] = 
+snapshots["sbb-menu-button renders component with icon A11y tree Chrome"] = 
 `<p>
   {
   "role": "WebArea",
@@ -81,15 +77,15 @@ snapshots["sbb-menu-button renders component with icon and amount A11y tree Chro
   "children": [
     {
       "role": "button",
-      "name": "Action 123456"
+      "name": "Action"
     }
   ]
 }
 </p>
 `;
-/* end snapshot sbb-menu-button renders component with icon and amount A11y tree Chrome */
+/* end snapshot sbb-menu-button renders component with icon A11y tree Chrome */
 
-snapshots["sbb-menu-button renders component with icon and amount A11y tree Firefox"] = 
+snapshots["sbb-menu-button renders component with icon A11y tree Firefox"] = 
 `<p>
   {
   "role": "document",
@@ -97,11 +93,11 @@ snapshots["sbb-menu-button renders component with icon and amount A11y tree Fire
   "children": [
     {
       "role": "button",
-      "name": "Action 123456"
+      "name": "Action"
     }
   ]
 }
 </p>
 `;
-/* end snapshot sbb-menu-button renders component with icon and amount A11y tree Firefox */
+/* end snapshot sbb-menu-button renders component with icon A11y tree Firefox */
 

--- a/src/elements/menu/menu-button/menu-button.snapshot.spec.ts
+++ b/src/elements/menu/menu-button/menu-button.snapshot.spec.ts
@@ -28,12 +28,12 @@ describe(`sbb-menu-button`, () => {
     });
   });
 
-  describe('renders component with icon and amount', () => {
+  describe('renders component with icon', () => {
     let element: SbbMenuButtonElement;
 
     beforeEach(async () => {
       element = await fixture(html`
-        <sbb-menu-button icon-name="menu-small" amount="123456"> Action </sbb-menu-button>
+        <sbb-menu-button icon-name="menu-small">Action</sbb-menu-button>
       `);
     });
 

--- a/src/elements/menu/menu-button/menu-button.visual.spec.ts
+++ b/src/elements/menu/menu-button/menu-button.visual.spec.ts
@@ -33,12 +33,7 @@ describe(`sbb-menu-button`, () => {
     ${repeat(
       new Array(3),
       (_, index) => html`
-        <!--
-          TODO: remove amount property usage.
-          Until we remove the amount property completely we keep both ways of displaying the badge in the same test.
-        -->
         <sbb-menu-button
-          amount=${badge || nothing}
           sbb-badge=${badge && !disabled && !disabledInteractive ? badge : nothing}
           icon-name=${iconName || nothing}
           ?disabled=${disabled}

--- a/src/elements/menu/menu-link/__snapshots__/menu-link.snapshot.spec.snap.js
+++ b/src/elements/menu/menu-link/__snapshots__/menu-link.snapshot.spec.snap.js
@@ -40,10 +40,9 @@ snapshots["sbb-menu-link renders Shadow DOM"] =
 `;
 /* end snapshot sbb-menu-link renders Shadow DOM */
 
-snapshots["sbb-menu-link renders component with icon and amount DOM"] = 
+snapshots["sbb-menu-link renders component with icon DOM"] = 
 `<sbb-menu-link
   accessibility-label="a11y label"
-  amount="123456"
   data-action=""
   data-link=""
   data-slot-names="unnamed"
@@ -54,9 +53,9 @@ snapshots["sbb-menu-link renders component with icon and amount DOM"] =
   Action
 </sbb-menu-link>
 `;
-/* end snapshot sbb-menu-link renders component with icon and amount DOM */
+/* end snapshot sbb-menu-link renders component with icon DOM */
 
-snapshots["sbb-menu-link renders component with icon and amount Shadow DOM"] = 
+snapshots["sbb-menu-link renders component with icon Shadow DOM"] = 
 `<a
   aria-label="a11y label"
   class="sbb-action-base sbb-menu-link"
@@ -80,18 +79,15 @@ snapshots["sbb-menu-link renders component with icon and amount Shadow DOM"] =
       <slot>
       </slot>
     </span>
-    <span class="sbb-menu-action__amount">
-      123456
-    </span>
   </span>
   <sbb-screen-reader-only>
     . Link target opens in a new window.
   </sbb-screen-reader-only>
 </a>
 `;
-/* end snapshot sbb-menu-link renders component with icon and amount Shadow DOM */
+/* end snapshot sbb-menu-link renders component with icon Shadow DOM */
 
-snapshots["sbb-menu-link renders component with icon and amount A11y tree Chrome"] = 
+snapshots["sbb-menu-link renders component with icon A11y tree Chrome"] = 
 `<p>
   {
   "role": "WebArea",
@@ -105,9 +101,9 @@ snapshots["sbb-menu-link renders component with icon and amount A11y tree Chrome
 }
 </p>
 `;
-/* end snapshot sbb-menu-link renders component with icon and amount A11y tree Chrome */
+/* end snapshot sbb-menu-link renders component with icon A11y tree Chrome */
 
-snapshots["sbb-menu-link renders component with icon and amount A11y tree Firefox"] = 
+snapshots["sbb-menu-link renders component with icon A11y tree Firefox"] = 
 `<p>
   {
   "role": "document",
@@ -122,5 +118,5 @@ snapshots["sbb-menu-link renders component with icon and amount A11y tree Firefo
 }
 </p>
 `;
-/* end snapshot sbb-menu-link renders component with icon and amount A11y tree Firefox */
+/* end snapshot sbb-menu-link renders component with icon A11y tree Firefox */
 

--- a/src/elements/menu/menu-link/menu-link.snapshot.spec.ts
+++ b/src/elements/menu/menu-link/menu-link.snapshot.spec.ts
@@ -32,14 +32,13 @@ describe(`sbb-menu-link`, () => {
     });
   });
 
-  describe('renders component with icon and amount', () => {
+  describe('renders component with icon', () => {
     let element: SbbMenuLinkElement;
 
     beforeEach(async () => {
       element = await fixture(html`
         <sbb-menu-link
           icon-name="menu-small"
-          amount="123456"
           href="https://github.com/sbb-design-systems/lyne-components"
           target="_blank"
           accessibility-label="a11y label"

--- a/src/elements/menu/menu-link/menu-link.visual.spec.ts
+++ b/src/elements/menu/menu-link/menu-link.visual.spec.ts
@@ -33,13 +33,8 @@ describe(`sbb-menu-link`, () => {
     ${repeat(
       new Array(3),
       (_, index) => html`
-        <!--
-          TODO: remove amount property usage.
-          Until we remove the amount property completely we keep both ways of displaying the badge in the same test.
-        -->
         <sbb-menu-link
           href="#"
-          amount=${badge || nothing}
           sbb-badge=${badge && !disabled && !disabledInteractive ? badge : nothing}
           icon-name=${iconName || nothing}
           ?disabled=${disabled}

--- a/src/storybook/pages/home/home-logged-in.ts
+++ b/src/storybook/pages/home/home-logged-in.ts
@@ -44,7 +44,7 @@ export const homeLoggedInTemplate = (args: Args): TemplateResult => html`
       <sbb-menu trigger="user-menu-trigger">
         <sbb-menu-link icon-name="user-small" href="/"> Account </sbb-menu-link>
         <sbb-menu-button icon-name="tickets-class-small">Tickets</sbb-menu-button>
-        <sbb-menu-button icon-name="shopping-cart-small" amount="1">
+        <sbb-menu-button icon-name="shopping-cart-small" sbb-badge="1">
           Shopping cart
         </sbb-menu-button>
         <sbb-divider></sbb-divider>


### PR DESCRIPTION
BREAKING CHANGE: removed amount property from `sbb-menu-button` and `sbb-menu-link`. Use `sbb-badge` attribute as replacement.