### PR TITLE
fix: avoid exceptions on storybook

### DIFF
--- a/src/elements/calendar/calendar.component.ts
+++ b/src/elements/calendar/calendar.component.ts
@@ -280,10 +280,12 @@ class SbbCalendarElement<T = Date> extends SbbHydrationMixin(LitElement) {
   public override connectedCallback(): void {
     super.connectedCallback();
     this.resetPosition();
-    this.focus = () => {
-      this._resetFocus = true;
-      this._focusCell();
-    };
+  }
+
+  /** @internal */
+  public override focus(): void {
+    this._resetFocus = true;
+    this._focusCell();
   }
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {

--- a/src/elements/select/select.component.ts
+++ b/src/elements/select/select.component.ts
@@ -368,15 +368,23 @@ class SbbSelectElement<T = string> extends SbbUpdateSchedulerMixin(
   protected override firstUpdated(changedProperties: PropertyValues<this>): void {
     super.firstUpdated(changedProperties);
 
-    // Override the default focus behavior
-    this.focus = () => this._triggerElement.focus();
-    this.blur = () => this._triggerElement.blur();
-
     // Wait for ssr hydration
     if (!isNextjs()) {
       this.startUpdate();
       this._setupSelect();
     }
+  }
+
+  /** @internal */
+  public override focus(): void {
+    // Forward focus to the trigger element.
+    this._triggerElement?.focus();
+  }
+
+  /** @internal */
+  public override blur(): void {
+    // Forward blur to the trigger element.
+    this._triggerElement?.blur();
   }
 
   /**


### PR DESCRIPTION
The new storybook version seems to patch focus and blur functions readonly. With the previous implementation this leads to an error. With the new implementation it works.