### PR TITLE
fix(sbb-toggle): change elements dimensions to fit intrinsic size

### DIFF
--- a/src/elements/core/styles/core.scss
+++ b/src/elements/core/styles/core.scss
@@ -511,8 +511,6 @@ sbb-header + :where(sbb-sidebar-container, sbb-icon-sidebar-container) {
 
 sbb-toggle:has(:focus-visible) {
   @include a11y.focus-outline;
-
-  --sbb-focus-outline-offset: #{functions.px-to-rem-build(5)};
 }
 
 :where(sbb-select, sbb-autocomplete, sbb-autocomplete-grid)[size='s']

--- a/src/elements/toggle/toggle/toggle.scss
+++ b/src/elements/toggle/toggle/toggle.scss
@@ -6,6 +6,8 @@
 :host {
   display: block;
   width: fit-content;
+
+  // Border-radius is used for the focus outline which is toggled in core.scss.
   border-radius: var(--sbb-toggle-border-radius);
 
   --sbb-toggle-width: fit-content;
@@ -16,18 +18,15 @@
   --sbb-toggle-selected-option-border-style: solid;
   --sbb-toggle-selected-option-border-color: var(--sbb-color-smoke);
   --sbb-toggle-selected-option-background-color: var(--sbb-color-white);
-  --sbb-toggle-selected-option-border-offset: #{sbb.px-to-rem-build(2)};
-  --sbb-toggle-padding-inline: var(--sbb-spacing-responsive-xxxs);
+  --sbb-toggle-background-inset: #{sbb.px-to-rem-build(2)};
+  --sbb-toggle-padding-inline: var(--sbb-spacing-responsive-xs);
   --sbb-toggle-animation-duration: var(
     --sbb-disable-animation-duration,
     var(--sbb-animation-duration-6x)
   );
-  --sbb-toggle-height: var(--sbb-size-element-xxs);
+  --sbb-toggle-height: var(--sbb-size-element-s);
   --sbb-toggle-border-radius: var(--sbb-border-radius-infinity);
   --sbb-toggle-grid-template-columns: auto auto;
-  --_sbb-toggle-height: calc(
-    var(--sbb-toggle-height) - 2 * var(--sbb-toggle-selected-option-border-offset)
-  );
 
   @include sbb.if-forced-colors {
     --sbb-toggle-selected-option-border-color: Highlight;
@@ -52,9 +51,9 @@
   }
 }
 
-:host([size='m']) {
-  --sbb-toggle-padding-inline: var(--sbb-spacing-responsive-xs);
-  --sbb-toggle-height: var(--sbb-size-element-m);
+:host([size='s']) {
+  --sbb-toggle-padding-inline: var(--sbb-spacing-responsive-xxxs);
+  --sbb-toggle-height: var(--sbb-size-element-xxxs);
 }
 
 :host(:is(:not([data-initialized]), [data-disable-animation-on-resizing])) {
@@ -70,42 +69,41 @@
   align-items: center;
   min-width: var(--sbb-toggle-min-width);
   width: var(--sbb-toggle-width);
+  height: var(--sbb-toggle-height);
   max-width: 100%;
-  height: var(--_sbb-toggle-height);
   user-select: none;
   -webkit-tap-highlight-color: transparent;
-  background: var(--sbb-color-cloud);
   border-radius: var(--sbb-toggle-border-radius);
 
+  // White pill of selected toggle option
   &::before {
     content: '';
-    grid-area: start / start / end / end;
-    padding-inline: var(--sbb-toggle-padding-inline);
-    margin-inline: var(--sbb-toggle-option-left, 0) var(--sbb-toggle-option-right, 0);
     display: block;
+    grid-area: start / start / end / end;
+    margin-inline: var(--sbb-toggle-option-left, 0) var(--sbb-toggle-option-right, 0);
     background-color: var(--sbb-toggle-selected-option-background-color);
     border-radius: var(--sbb-toggle-border-radius);
     max-width: 100%;
     height: 100%;
-
-    // To break out of the grid box, we have to use a box shadow and an outline
-    // The outline is needed because in disabled we need a dashed style
-    // while the box shadow is needed to provide the white background.
-    box-shadow: 0 0 0 var(--sbb-toggle-selected-option-border-offset)
-      var(--sbb-toggle-selected-option-background-color);
-    outline: var(--sbb-toggle-selected-option-border-width)
+    border: var(--sbb-toggle-selected-option-border-width)
       var(--sbb-toggle-selected-option-border-style) var(--sbb-toggle-selected-option-border-color);
-    outline-offset: calc(
-      var(--sbb-toggle-selected-option-border-offset) - var(
-          --sbb-toggle-selected-option-border-width
-        )
-    );
 
     transition: {
       duration: var(--sbb-toggle-animation-duration);
       timing-function: ease;
       property: margin-inline-start, margin-inline-end;
     }
+  }
+
+  // Background
+  &::after {
+    content: '';
+    grid-area: start / start / end / end;
+    order: -1;
+    background: var(--sbb-color-cloud);
+    margin-inline: var(--sbb-toggle-background-inset);
+    height: calc(100% - 2 * var(--sbb-toggle-background-inset));
+    border-radius: var(--sbb-toggle-border-radius);
   }
 
   @include sbb.if-forced-colors {


### PR DESCRIPTION
BREAKING CHANGE: Before this change, the intrinsic size of the `sbb-toggle` was smaller than the element itself. Now the height and width of the element has increased to fit the real dimensions (plus 2px on all sides). Potential action needed: For some layouts the `sbb-toggle` needs a negative margin of 2px in order to nicely fit in existing layouts (align background track of `sbb-toggle` to the rest of the content).