### PR TITLE
refactor: remove now parameter of date adapter parse method

### DIFF
--- a/src/elements/core/datetime/date-adapter.ts
+++ b/src/elements/core/datetime/date-adapter.ts
@@ -139,7 +139,7 @@ export abstract class DateAdapter<T = any> {
    * @param value The date in the format DD.MM.YYYY.
    * @param now The current date as Date.
    */
-  public abstract parse(value: string | null | undefined, now?: T): T | null;
+  public abstract parse(value: string | null | undefined): T | null;
 
   /**
    * Format the given date as string.

--- a/src/elements/core/datetime/native-date-adapter.spec.ts
+++ b/src/elements/core/datetime/native-date-adapter.spec.ts
@@ -181,13 +181,12 @@ describe('NativeDateAdapter', () => {
   });
 
   it('parse should return the correct value', function () {
-    const now = new Date(2023, 8, 15, 0, 0, 0, 0);
-    expect(nativeDateAdapter.parse(null, now)).to.be.null;
-    expect(nativeDateAdapter.parse('Test', now)).to.be.null;
-    expect(nativeDateAdapter.parse('1.1', now)).to.be.null;
-    expect(nativeDateAdapter.parse('2000.0.1', now)).to.be.null;
+    expect(nativeDateAdapter.parse(null)).to.be.null;
+    expect(nativeDateAdapter.parse('Test')).to.be.null;
+    expect(nativeDateAdapter.parse('1.1')).to.be.null;
+    expect(nativeDateAdapter.parse('2000.0.1')).to.be.null;
     for (const dateString of ['1/1/2000', '1.1.2000', '2000-01-01']) {
-      const date = nativeDateAdapter.parse(dateString, now)!;
+      const date = nativeDateAdapter.parse(dateString)!;
       expect(date.getFullYear()).to.be.equal(2000);
       expect(date.getMonth()).to.be.equal(0);
       expect(date.getDate()).to.be.equal(1);

--- a/src/elements/core/datetime/native-date-adapter.ts
+++ b/src/elements/core/datetime/native-date-adapter.ts
@@ -167,7 +167,7 @@ export class NativeDateAdapter extends DateAdapter<Date> {
   }
 
   /** Returns the right format for the `valueAsDate` property. */
-  public parse(value: string | null | undefined, now: Date = this.today()): Date | null {
+  public parse(value: string | null | undefined): Date | null {
     if (!value) {
       return null;
     }
@@ -199,7 +199,7 @@ export class NativeDateAdapter extends DateAdapter<Date> {
     let year = +match[3];
 
     if (typeof year === 'number' && year < 100 && year >= 0) {
-      const shift = now.getFullYear() - 2000 + this._cutoffYearOffset;
+      const shift = this.today().getFullYear() - 2000 + this._cutoffYearOffset;
       year = year <= shift ? 2000 + year : 1900 + year;
     }
 


### PR DESCRIPTION
BREAKING CHANGE: The `now` parameter of the `parse` method from the `DateAdapter` has been removed.