### PR TITLE
refactor(sbb-overlay): remove back button

### DIFF
--- a/src/elements/overlay/overlay.component.ts
+++ b/src/elements/overlay/overlay.component.ts
@@ -1,13 +1,12 @@
 import type { CSSResultGroup, TemplateResult } from 'lit';
-import { nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { ref } from 'lit/directives/ref.js';
 import { html, unsafeStatic } from 'lit/static-html.js';
 
 import { forceType } from '../core/decorators.js';
 import { isZeroAnimationDuration } from '../core/dom.js';
-import { EventEmitter, forwardEvent } from '../core/eventing.js';
-import { i18nCloseDialog, i18nGoBack } from '../core/i18n.js';
+import { forwardEvent } from '../core/eventing.js';
+import { i18nCloseDialog } from '../core/i18n.js';
 
 import { overlayRefs, SbbOverlayBaseElement } from './overlay-base-element.js';
 import style from './overlay.scss?lit&inline';
@@ -27,7 +26,6 @@ let nextId = 0;
  * @event {CustomEvent<void>} didOpen - Emits whenever the `sbb-overlay` is opened.
  * @event {CustomEvent<void>} willClose - Emits whenever the `sbb-overlay` begins the closing transition. Can be canceled.
  * @event {CustomEvent<SbbOverlayCloseEventDetails>} didClose - Emits whenever the `sbb-overlay` is closed.
- * @event {CustomEvent<void>} requestBackAction - Emits whenever the back button is clicked.
  * @cssprop [--sbb-overlay-z-index=var(--sbb-overlay-default-z-index)] - To specify a custom stack order,
  * the `z-index` can be overridden by defining this CSS variable. The default `z-index` of the
  * component is set to `var(--sbb-overlay-default-z-index)` with a value of `1000`.
@@ -43,7 +41,6 @@ class SbbOverlayElement extends SbbOverlayBaseElement {
     didOpen: 'didOpen',
     willClose: 'willClose',
     didClose: 'didClose',
-    backClick: 'requestBackAction',
   } as const;
 
   /**
@@ -54,25 +51,12 @@ class SbbOverlayElement extends SbbOverlayBaseElement {
   @property({ reflect: true, type: Boolean })
   public accessor expanded: boolean = false;
 
-  /** Whether a back button is displayed next to the title. */
-  @forceType()
-  @property({ attribute: 'back-button', type: Boolean })
-  public accessor backButton: boolean = false;
-
   /** This will be forwarded as aria-label to the close button element. */
   @forceType()
   @property({ attribute: 'accessibility-close-label' })
   public accessor accessibilityCloseLabel: string = '';
 
-  /** This will be forwarded as aria-label to the back button element. */
-  @forceType()
-  @property({ attribute: 'accessibility-back-label' })
-  public accessor accessibilityBackLabel: string = '';
-
   protected closeAttribute: string = 'sbb-overlay-close';
-
-  /** Emits whenever the back button is clicked. */
-  private _backClick: EventEmitter = new EventEmitter(this, SbbOverlayElement.events.backClick);
   private _overlayContentElement: HTMLElement | null = null;
 
   public override connectedCallback(): void {
@@ -135,18 +119,6 @@ class SbbOverlayElement extends SbbOverlayBaseElement {
         sbb-overlay-close
       ></${unsafeStatic(TAG_NAME)}>
     `;
-
-    const backButton = html`
-      <${unsafeStatic(TAG_NAME)}
-        class="sbb-overlay__back"
-        aria-label=${this.accessibilityBackLabel || i18nGoBack[this.language.current]}
-        ?negative=${this.negative}
-        size="m"
-        type="button"
-        icon-name="chevron-small-left-small"
-        @click=${() => this._backClick.emit()}
-      ></${unsafeStatic(TAG_NAME)}>
-    `;
     /* eslint-enable lit/binding-positions */
 
     return html`
@@ -156,9 +128,7 @@ class SbbOverlayElement extends SbbOverlayBaseElement {
             @click=${(event: Event) => this.closeOnSbbOverlayCloseClick(event)}
             class="sbb-overlay__wrapper"
           >
-            <div class="sbb-overlay__header">
-              ${this.backButton ? backButton : nothing} ${closeButton}
-            </div>
+            <div class="sbb-overlay__header">${closeButton}</div>
             <div
               class="sbb-overlay__content"
               ${ref((el?: Element) => (this._overlayContentElement = el as HTMLDivElement))}

--- a/src/elements/overlay/overlay.stories.ts
+++ b/src/elements/overlay/overlay.stories.ts
@@ -23,12 +23,6 @@ const expanded: InputType = {
   },
 };
 
-const backButton: InputType = {
-  control: {
-    type: 'boolean',
-  },
-};
-
 const negative: InputType = {
   control: {
     type: 'boolean',
@@ -53,29 +47,16 @@ const accessibilityCloseLabel: InputType = {
   },
 };
 
-const accessibilityBackLabel: InputType = {
-  control: {
-    type: 'text',
-  },
-  table: {
-    category: 'Accessibility',
-  },
-};
-
 const basicArgTypes: ArgTypes = {
   expanded,
-  'back-button': backButton,
   accessibilityCloseLabel,
-  accessibilityBackLabel,
   negative,
   'accessibility-label': accessibilityLabel,
 };
 
 const basicArgs: Args = {
   expanded: false,
-  'back-button': false,
   accessibilityCloseLabel: 'Close overlay',
-  accessibilityBackLabel: 'Go back',
   negative: false,
   'accessibility-label': undefined,
 };
@@ -238,15 +219,6 @@ export const Expanded: StoryObj = {
   },
 };
 
-export const WithBackButton: StoryObj = {
-  render: DefaultTemplate,
-  argTypes: basicArgTypes,
-  args: {
-    ...basicArgs,
-    'back-button': true,
-  },
-};
-
 export const Form: StoryObj = {
   render: FormTemplate,
   argTypes: basicArgTypes,
@@ -268,7 +240,6 @@ const meta: Meta = {
         SbbOverlayElement.events.didOpen,
         SbbOverlayElement.events.willClose,
         SbbOverlayElement.events.didClose,
-        SbbOverlayElement.events.backClick,
       ],
     },
     docs: {

--- a/src/elements/overlay/overlay.visual.spec.ts
+++ b/src/elements/overlay/overlay.visual.spec.ts
@@ -10,18 +10,16 @@ import type { SbbOverlayElement } from './overlay.component.js';
 describe(`sbb-overlay`, () => {
   const defaultArgs = {
     expanded: false,
-    backButton: false,
     negative: false,
     numberOfBlocks: 1,
   };
 
   const template = ({
     expanded,
-    backButton,
     negative,
     numberOfBlocks,
   }: typeof defaultArgs): TemplateResult => html`
-    <sbb-overlay ?negative=${negative} ?expanded=${expanded} ?back-button=${backButton}>
+    <sbb-overlay ?negative=${negative} ?expanded=${expanded}>
       ${repeat(
         new Array(numberOfBlocks),
         () => html`
@@ -48,14 +46,6 @@ describe(`sbb-overlay`, () => {
         `negative=${negative}`,
         visualDiffDefault.with(async (setup) => {
           await setup.withFixture(template({ ...defaultArgs, negative }));
-          openOverlay(setup);
-        }),
-      );
-
-      it(
-        `negative=${negative} backButton`,
-        visualDiffDefault.with(async (setup) => {
-          await setup.withFixture(template({ ...defaultArgs, negative, backButton: true }));
           openOverlay(setup);
         }),
       );

--- a/src/elements/overlay/readme.md
+++ b/src/elements/overlay/readme.md
@@ -5,7 +5,6 @@ It offers the following features:
 - disables scrolling of the page content while open;
 - manages focus properly by setting it on the first focusable element;
 - has a close button, which is always visible;
-- can display a back button;
 - adds the appropriate ARIA roles automatically.
 
 ```html
@@ -49,8 +48,6 @@ emit a close event with an optional result as a payload.
 The component can also be dismissed by clicking on the close button, clicking on the backdrop, pressing the `Esc` key,
 or, if an element within the `sbb-overlay` has the `sbb-overlay-close` attribute, by clicking on it.
 
-You can also set the property `backButton` on the `sbb-overlay` component to display the back button which will emit the event `requestBackAction` when clicked.
-
 ## Accessibility
 
 ### Controlling initial focus
@@ -72,10 +69,8 @@ an alternative element by listening to the `didClose` event.
 
 | Name                      | Attribute                   | Privacy | Type                  | Default | Description                                                                                                                                                                                                                                               |
 | ------------------------- | --------------------------- | ------- | --------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityBackLabel`  | `accessibility-back-label`  | public  | `string`              | `''`    | This will be forwarded as aria-label to the back button element.                                                                                                                                                                                          |
 | `accessibilityCloseLabel` | `accessibility-close-label` | public  | `string`              | `''`    | This will be forwarded as aria-label to the close button element.                                                                                                                                                                                         |
 | `accessibilityLabel`      | `accessibility-label`       | public  | `string`              | `''`    | This will be forwarded as aria-label to the relevant nested element to describe the purpose of the overlay.                                                                                                                                               |
-| `backButton`              | `back-button`               | public  | `boolean`             | `false` | Whether a back button is displayed next to the title.                                                                                                                                                                                                     |
 | `expanded`                | `expanded`                  | public  | `boolean`             | `false` | Whether to allow the overlay content to stretch to full width. By default, the content has the appropriate page size.                                                                                                                                     |
 | `isOpen`                  | -                           | public  | `boolean`             |         | Whether the element is open.                                                                                                                                                                                                                              |
 | `negative`                | `negative`                  | public  | `boolean`             | `false` | Negative coloring variant flag.                                                                                                                                                                                                                           |
@@ -91,13 +86,12 @@ an alternative element by listening to the `didClose` event.
 
 ## Events
 
-| Name                | Type                                       | Description                                                                      | Inherited From          |
-| ------------------- | ------------------------------------------ | -------------------------------------------------------------------------------- | ----------------------- |
-| `didClose`          | `CustomEvent<SbbOverlayCloseEventDetails>` | Emits whenever the `sbb-overlay` is closed.                                      | SbbOpenCloseBaseElement |
-| `didOpen`           | `CustomEvent<void>`                        | Emits whenever the `sbb-overlay` is opened.                                      | SbbOpenCloseBaseElement |
-| `requestBackAction` | `CustomEvent<void>`                        | Emits whenever the back button is clicked.                                       |                         |
-| `willClose`         | `CustomEvent<void>`                        | Emits whenever the `sbb-overlay` begins the closing transition. Can be canceled. | SbbOpenCloseBaseElement |
-| `willOpen`          | `CustomEvent<void>`                        | Emits whenever the `sbb-overlay` starts the opening transition. Can be canceled. | SbbOpenCloseBaseElement |
+| Name        | Type                                       | Description                                                                      | Inherited From          |
+| ----------- | ------------------------------------------ | -------------------------------------------------------------------------------- | ----------------------- |
+| `didClose`  | `CustomEvent<SbbOverlayCloseEventDetails>` | Emits whenever the `sbb-overlay` is closed.                                      | SbbOpenCloseBaseElement |
+| `didOpen`   | `CustomEvent<void>`                        | Emits whenever the `sbb-overlay` is opened.                                      | SbbOpenCloseBaseElement |
+| `willClose` | `CustomEvent<void>`                        | Emits whenever the `sbb-overlay` begins the closing transition. Can be canceled. | SbbOpenCloseBaseElement |
+| `willOpen`  | `CustomEvent<void>`                        | Emits whenever the `sbb-overlay` starts the opening transition. Can be canceled. | SbbOpenCloseBaseElement |
 
 ## CSS Properties
 


### PR DESCRIPTION
BREAKING CHANGE: removed back button from `sbb-overlay` as it was never intended to be used. Therefore properties `backButton` and `accessibilityBackLabel` were removed.
