### PR TITLE
refactor: remove SbbValidationChangeEvent interface

### DIFF
--- a/src/elements/core/interfaces.ts
+++ b/src/elements/core/interfaces.ts
@@ -4,4 +4,3 @@
 export * from './interfaces/overlay-close-details.js';
 export * from './interfaces/paginator-page.js';
 export * from './interfaces/types.js';
-export * from './interfaces/validation-change.js';

--- a/src/elements/core/interfaces/validation-change.ts
+++ b/src/elements/core/interfaces/validation-change.ts
@@ -1,3 +1,0 @@
-export interface SbbValidationChangeEvent {
-  valid: boolean;
-}

--- a/tools/vite/generate-react-wrappers.ts
+++ b/tools/vite/generate-react-wrappers.ts
@@ -154,7 +154,6 @@ function renderTemplate(
   const interfaces = new Map<string, string>()
     .set('SbbOverlayCloseEventDetails', 'core/interfaces.js')
     .set('SbbPaginatorPageEventDetails', 'core/interfaces.js')
-    .set('SbbValidationChangeEvent', 'core/interfaces.js')
     .set('SeatReservationPlaceSelection', 'seat-reservation/common.js')
     .set('SeatReservationCoachSelection', 'seat-reservation/common.js')
     .set('PlaceSelection', 'seat-reservation/common.js');


### PR DESCRIPTION
This PR removes the obsolete `SbbValidationChangeEvent`. The functionality is now handled by native from validation.