### PR TITLE
perf(sbb-datepicker): delay rendering of calendar

### DIFF
--- a/src/elements/datepicker/datepicker/datepicker.component.ts
+++ b/src/elements/datepicker/datepicker/datepicker.component.ts
@@ -4,6 +4,7 @@ import {
   isServer,
   nothing,
   type PropertyDeclaration,
+  type PropertyValues,
   type TemplateResult,
 } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
@@ -14,6 +15,7 @@ import { SbbLanguageController } from '../../core/controllers.js';
 import { type DateAdapter, defaultDateAdapter } from '../../core/datetime.js';
 import { forceType, idReference } from '../../core/decorators.js';
 import { i18nDateChangedTo } from '../../core/i18n.js';
+import { SbbUpdateSchedulerMixin } from '../../core/mixins.js';
 import { SbbDateInputElement, type SbbDateInputAssociated } from '../../date-input.js';
 import { SbbPopoverBaseElement } from '../../popover.js';
 import type { SbbDatepickerToggleElement } from '../datepicker-toggle.js';
@@ -31,7 +33,7 @@ let nextId = 0;
 export
 @customElement('sbb-datepicker')
 class SbbDatepickerElement<T = Date>
-  extends SbbPopoverBaseElement
+  extends SbbUpdateSchedulerMixin(SbbPopoverBaseElement)
   implements SbbDateInputAssociated<T>
 {
   public static override styles: CSSResultGroup = [SbbPopoverBaseElement.styles, style];
@@ -57,9 +59,11 @@ class SbbDatepickerElement<T = Date>
   private _inputAbortController?: AbortController;
   private _dateAdapter: DateAdapter<T> = readConfig().datetime?.dateAdapter ?? defaultDateAdapter;
   private _language = new SbbLanguageController(this);
+  private _ready = false;
 
   public constructor() {
     super();
+    this.startUpdate();
     this.addEventListener(SbbPopoverBaseElement.events.beforeopen, () => {
       this.shadowRoot?.querySelector('sbb-calendar')?.resetPosition?.();
     });
@@ -103,6 +107,17 @@ class SbbDatepickerElement<T = Date>
         );
       }
     }
+  }
+
+  protected override firstUpdated(changedProperties: PropertyValues<this>): void {
+    super.firstUpdated(changedProperties);
+    setTimeout(() => {
+      // We want to delay the rendering of the calendar to avoid a slow initial render.
+      // The slow render can be a problem if a large amount of datepickers are rendered at once.
+      this._ready = true;
+      this.requestUpdate();
+      this.completeUpdate();
+    });
   }
 
   private _updateStatus(): void {
@@ -149,7 +164,7 @@ class SbbDatepickerElement<T = Date>
   }
 
   protected override render(): TemplateResult {
-    return isServer || this.hydrationRequired ? html`${nothing}` : super.render();
+    return isServer || this.hydrationRequired || !this._ready ? html`${nothing}` : super.render();
   }
 }
 


### PR DESCRIPTION
Currently the `<sbb-calendar>` is rendered synchronously inside the `<sbb-datepicker>`. As the calendar is only needed once the datepicker needs to be opened, we can safely delay the rendering of the calendar.

Closes sbb-design-systems/lyne-angular#138