### PR TITLE
feat(sbb-form-field): add support for custom controls

### DIFF
--- a/src/elements/form-field/form-field/form-field.component.ts
+++ b/src/elements/form-field/form-field/form-field.component.ts
@@ -33,6 +33,34 @@ let nextId = 0;
 const patchedInputs = new WeakMap<HTMLInputElement, PropertyDescriptor>();
 const nativeInputElements = ['input', 'textarea', 'select'];
 
+/** An interface which allows a control to work inside of a `SbbFormField`. */
+export interface SbbFormFieldElementControl {
+  /** The id of the form field. */
+  readonly id: string;
+  /** Whether the control is empty. */
+  readonly empty: boolean;
+  /** Whether the control is readonly. */
+  readonly readOnly?: boolean;
+  /** Whether the control is disabled. */
+  readonly disabled: boolean;
+
+  /** Handles a click on the control's container. */
+  onContainerClick(event: MouseEvent): void;
+}
+
+export class SbbFormFieldControlEvent extends Event {
+  private _control: SbbFormFieldElementControl | null;
+
+  public get control(): SbbFormFieldElementControl | null {
+    return this._control;
+  }
+
+  public constructor(control: SbbFormFieldElementControl | null) {
+    super('formfieldcontrol');
+    this._control = control;
+  }
+}
+
 /**
  * It wraps an input element adding label, errors, icon, etc.
  *
@@ -115,13 +143,14 @@ class SbbFormFieldElement extends SbbNegativeMixin(
   @state() private accessor _errorElements: Element[] = [];
 
   /** Reference to the slotted input element. */
-  @state() private accessor _input: HTMLInputElement | HTMLSelectElement | HTMLElement | undefined;
+  @state() private accessor _input: HTMLInputElement | HTMLSelectElement | HTMLElement | null =
+    null;
 
   /** Reference to the slotted label elements. */
   @state() private accessor _label!: HTMLLabelElement;
 
   /** Returns the input element. */
-  public get inputElement(): HTMLInputElement | HTMLSelectElement | HTMLElement | undefined {
+  public get inputElement(): HTMLInputElement | HTMLSelectElement | HTMLElement | null {
     return this._input;
   }
 
@@ -141,6 +170,7 @@ class SbbFormFieldElement extends SbbNegativeMixin(
     : null;
 
   private _inputFormAbortController = new AbortController();
+  private _control: SbbFormFieldElementControl | null = null;
 
   public constructor() {
     super();
@@ -183,6 +213,14 @@ class SbbFormFieldElement extends SbbNegativeMixin(
     // This is duplicated from the form associated mixin for the native
     // input controls (e.g. <input> or <select>).
     this.addEventListener('invalid', (e) => e.preventDefault(), { capture: true });
+    this.addEventListener('formfieldcontrol', (e: SbbFormFieldControlEvent) => {
+      this._control = e.control;
+      if (this._connectInputElement() === 'unchanged') {
+        this._assignErrorMessageElements();
+        this._readInputState();
+        this._checkAndUpdateInputEmpty();
+      }
+    });
   }
 
   public override connectedCallback(): void {
@@ -213,12 +251,14 @@ class SbbFormFieldElement extends SbbNegativeMixin(
     }
   }
 
-  private _handleWrapperClick(event: Event): void {
+  private _handleWrapperClick(event: MouseEvent): void {
     if (this._isElementFocusExcluded(event)) {
       return;
     }
 
-    if ((event.target as Element).localName !== 'label') {
+    if (this._control?.onContainerClick) {
+      this._control?.onContainerClick(event);
+    } else if ((event.target as Element).localName !== 'label') {
       if (
         this._input?.localName === 'sbb-select' &&
         (event.target as HTMLElement).localName !== 'sbb-select'
@@ -266,15 +306,21 @@ class SbbFormFieldElement extends SbbNegativeMixin(
     );
   }
 
-  private _connectInputElement(): void {
-    // Find the slotted input element, even if it's nested (e.g. chip group)
-    const inputCandidates = Array.from(
-      this.querySelectorAll<HTMLElement>('*:not([slot],sbb-chip-group)'),
-    );
-    const newInput = inputCandidates.find((e) => this._isInputElement(e)) || inputCandidates[0];
+  private _connectInputElement(): 'changed' | 'no-input' | 'unchanged' {
+    let newInput: HTMLElement | null = null;
+    if (this._control?.id) {
+      newInput = (this.getRootNode() as Document | ShadowRoot).getElementById(this._control.id);
+    } else {
+      // Find the slotted input element, even if it's nested (e.g. chip group)
+      const inputCandidates = Array.from(
+        this.querySelectorAll<HTMLElement>('*:not([slot],sbb-chip-group)'),
+      );
+      newInput =
+        (inputCandidates.find((e) => this._isInputElement(e)) || inputCandidates[0]) ?? null;
+    }
 
     if (newInput === this._input) {
-      return;
+      return 'unchanged';
     } else if (this._input) {
       this.internals.states.delete(`input-type-${this._input.localName}`);
       if (this._input.localName === 'input') {
@@ -283,14 +329,14 @@ class SbbFormFieldElement extends SbbNegativeMixin(
     }
 
     if (!newInput) {
-      this._input = undefined;
-      return;
+      this._input = null;
+      return 'no-input';
     }
 
     this._input = newInput;
+    this._registerInputFormListener();
     this._assignErrorMessageElements();
     this._readInputState();
-    this._registerInputFormListener();
     this._checkAndUpdateInputEmpty();
 
     if (this._input.localName === 'textarea') {
@@ -313,6 +359,7 @@ class SbbFormFieldElement extends SbbNegativeMixin(
     });
     this.internals.states.add(`input-type-${this._input.localName}`);
     this._syncLabelInputReferences();
+    return 'changed';
   }
 
   private _syncLabelInputReferences(): void {
@@ -353,8 +400,8 @@ class SbbFormFieldElement extends SbbNegativeMixin(
   }
 
   private _readInputState(): void {
-    this.toggleState('readonly', this._input!.hasAttribute('readonly'));
-    this.toggleState('disabled', this._input!.hasAttribute('disabled'));
+    this.toggleState('readonly', this._control?.readOnly ?? this._input!.hasAttribute('readonly'));
+    this.toggleState('disabled', this._control?.disabled ?? this._input!.hasAttribute('disabled'));
     this.toggleState('has-popup-open', this._input!.hasAttribute('data-expanded'));
   }
 
@@ -416,8 +463,9 @@ class SbbFormFieldElement extends SbbNegativeMixin(
   private _checkAndUpdateInputEmpty(): void {
     this.toggleState(
       'empty',
-      this._floatingLabelSupportedInputElements.includes(this._input?.localName as string) &&
-        this._isInputEmpty(),
+      this._control?.empty ??
+        (this._floatingLabelSupportedInputElements.includes(this._input?.localName as string) &&
+          this._isInputEmpty()),
     );
   }
 
@@ -549,5 +597,9 @@ declare global {
   interface HTMLElementTagNameMap {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     'sbb-form-field': SbbFormFieldElement;
+  }
+
+  interface HTMLElementEventMap {
+    formfieldcontrol: SbbFormFieldControlEvent;
   }
 }

--- a/src/elements/form-field/form-field/readme.md
+++ b/src/elements/form-field/form-field/readme.md
@@ -122,6 +122,19 @@ it's possible to apply any desired width by setting just the `width` and `min-wi
 </sbb-form-field>
 ```
 
+### Reflected state from input
+
+The form field reflects certain states as custom states. This includes `focus`, `disabled`,
+`readonly`, `empty`, `has-error`, `has-popup-open` and `input-type-{tag name of the input}`.
+
+This can be targeted via CSS via the `:state()` pseudo-class:
+
+```css
+sbb-form-field:state(disabled) {
+  // Additional rules to apply when the input of the form field is disabled
+}
+```
+
 ### Error state
 
 The form field is displayed in an error state when an input element has been interacted with
@@ -134,6 +147,16 @@ to the input element.
 
 If you want to directly show the error state without having had an interaction, you can use the
 `sbb-show-errors` class on an ancestor (e.g. `<form>`).
+
+## Custom form control
+
+If you want to use a custom form control (e.g. Angular), that is not a native input element or a form
+associated custom element, you need to provide an integration layer, which is defined
+as the `SbbFormFieldElementControl` interface.
+
+To initially connect the custom form control and to update the state, whenever one of
+the property of the interface changes, the `SbbFormFieldControlEvent` needs to be dispatched
+on the `<sbb-form-field>` instance.
 
 ## Accessibility
 
@@ -159,17 +182,17 @@ to the form element's `ariaErrorMessageElements` property (or `aria-errormessage
 
 ## Properties
 
-| Name            | Attribute        | Privacy | Type                                                                | Default            | Description                                                                                                                                                           |
-| --------------- | ---------------- | ------- | ------------------------------------------------------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `borderless`    | `borderless`     | public  | `boolean`                                                           | `false`            | Whether to display the form field without a border.                                                                                                                   |
-| `errorSpace`    | `error-space`    | public  | `'none' \| 'reserve'`                                               | `'none'`           | Whether to reserve space for an error message. `none` does not reserve any space. `reserve` does reserve one row for an error message.                                |
-| `floatingLabel` | `floating-label` | public  | `boolean`                                                           | `false`            | Whether the label should float. If activated, the placeholder of the input is hidden.                                                                                 |
-| `hiddenLabel`   | `hidden-label`   | public  | `boolean`                                                           | `false`            | Whether to visually hide the label. If hidden, screen readers will still read it.                                                                                     |
-| `inputElement`  | -                | public  | `HTMLInputElement \| HTMLSelectElement \| HTMLElement \| undefined` |                    | Returns the input element.                                                                                                                                            |
-| `negative`      | `negative`       | public  | `boolean`                                                           | `false`            | Negative coloring variant flag.                                                                                                                                       |
-| `optional`      | `optional`       | public  | `boolean`                                                           | `false`            | Indicates whether the input is optional.                                                                                                                              |
-| `size`          | `size`           | public  | `'l' \| 'm' \| 's'`                                                 | `'m' / 's' (lean)` | Size variant, either l, m or s.                                                                                                                                       |
-| `width`         | `width`          | public  | `'default' \| 'collapse'`                                           | `'default'`        | Defines the width of the component: - `default`: the component has defined width and min-width; - `collapse`: the component adapts itself to its inner input content. |
+| Name            | Attribute        | Privacy | Type                                                           | Default            | Description                                                                                                                                                           |
+| --------------- | ---------------- | ------- | -------------------------------------------------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `borderless`    | `borderless`     | public  | `boolean`                                                      | `false`            | Whether to display the form field without a border.                                                                                                                   |
+| `errorSpace`    | `error-space`    | public  | `'none' \| 'reserve'`                                          | `'none'`           | Whether to reserve space for an error message. `none` does not reserve any space. `reserve` does reserve one row for an error message.                                |
+| `floatingLabel` | `floating-label` | public  | `boolean`                                                      | `false`            | Whether the label should float. If activated, the placeholder of the input is hidden.                                                                                 |
+| `hiddenLabel`   | `hidden-label`   | public  | `boolean`                                                      | `false`            | Whether to visually hide the label. If hidden, screen readers will still read it.                                                                                     |
+| `inputElement`  | -                | public  | `HTMLInputElement \| HTMLSelectElement \| HTMLElement \| null` |                    | Returns the input element.                                                                                                                                            |
+| `negative`      | `negative`       | public  | `boolean`                                                      | `false`            | Negative coloring variant flag.                                                                                                                                       |
+| `optional`      | `optional`       | public  | `boolean`                                                      | `false`            | Indicates whether the input is optional.                                                                                                                              |
+| `size`          | `size`           | public  | `'l' \| 'm' \| 's'`                                            | `'m' / 's' (lean)` | Size variant, either l, m or s.                                                                                                                                       |
+| `width`         | `width`          | public  | `'default' \| 'collapse'`                                      | `'default'`        | Defines the width of the component: - `default`: the component has defined width and min-width; - `collapse`: the component adapts itself to its inner input content. |
 
 ## Methods
 


### PR DESCRIPTION
This PR introduces the possibility of defining custom form controls for `<sbb-form-field>`.
The basic functionality is based on implementing the `SbbFormFieldElementControl` and dispatching the `SbbFormFieldControlEvent` on the related `<sbb-form-field>` instance.

This is the basis for supporting sbb-design-systems/lyne-angular#55