### PR TITLE
fix(sbb-toggle-check, sbb-checkbox-panel): handle the 'data-checked' attribute synchronously

### DIFF
--- a/src/elements/checkbox/checkbox-panel/checkbox-panel.component.ts
+++ b/src/elements/checkbox/checkbox-panel/checkbox-panel.component.ts
@@ -3,6 +3,7 @@ import {
   html,
   LitElement,
   nothing,
+  type PropertyDeclaration,
   type PropertyValues,
   type TemplateResult,
 } from 'lit';
@@ -62,24 +63,23 @@ class SbbCheckboxPanelElement<T = string> extends SbbPanelMixin(
   @getOverride((i, v) => (i.group?.size ? (i.group.size === 'xs' ? 's' : i.group.size) : v))
   public accessor size: SbbPanelSize = isLean() ? 's' : 'm';
 
-  private _dispatchStateChange(detail: SbbCheckboxPanelStateChange): boolean {
-    /**
-     * @internal
-     * Internal event that emits whenever the state of the checkbox
-     * in relation to the parent selection panel changes.
-     */
-    return this.dispatchEvent(
-      new CustomEvent<SbbCheckboxPanelStateChange>('statechange', { detail, bubbles: true }),
-    );
+  public override requestUpdate(
+    name?: PropertyKey,
+    oldValue?: unknown,
+    options?: PropertyDeclaration,
+  ): void {
+    super.requestUpdate(name, oldValue, options);
+    if (name === 'checked') {
+      this.internals.ariaChecked = `${this.checked}`;
+      // As SbbFormAssociatedCheckboxMixin does not reflect checked property, we add a data-checked.
+      this.toggleAttribute('data-checked', this.checked);
+    }
   }
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     super.willUpdate(changedProperties);
 
     if (changedProperties.has('checked')) {
-      // As SbbFormAssociatedCheckboxMixin does not reflect checked property, we add a data-checked.
-      this.toggleAttribute('data-checked', this.checked);
-
       if (this.checked !== changedProperties.get('checked')!) {
         this._dispatchStateChange({ type: 'checked', checked: this.checked });
       }
@@ -89,6 +89,17 @@ class SbbCheckboxPanelElement<T = string> extends SbbPanelMixin(
         this._dispatchStateChange({ type: 'disabled', disabled: this.disabled });
       }
     }
+  }
+
+  private _dispatchStateChange(detail: SbbCheckboxPanelStateChange): boolean {
+    /**
+     * @internal
+     * Internal event that emits whenever the state of the checkbox
+     * in relation to the parent selection panel changes.
+     */
+    return this.dispatchEvent(
+      new CustomEvent<SbbCheckboxPanelStateChange>('statechange', { detail, bubbles: true }),
+    );
   }
 
   protected override render(): TemplateResult {

--- a/src/elements/toggle-check/toggle-check.component.ts
+++ b/src/elements/toggle-check/toggle-check.component.ts
@@ -1,4 +1,4 @@
-import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
+import type { CSSResultGroup, PropertyDeclaration, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
@@ -45,11 +45,15 @@ class SbbToggleCheckElement<T = string> extends SbbFormAssociatedCheckboxMixin(
   @property({ attribute: 'label-position', reflect: true })
   public accessor labelPosition: 'before' | 'after' = 'after';
 
-  protected override willUpdate(changedProperties: PropertyValues<this>): void {
-    super.willUpdate(changedProperties);
-
-    if (changedProperties.has('checked')) {
+  public override requestUpdate(
+    name?: PropertyKey,
+    oldValue?: unknown,
+    options?: PropertyDeclaration,
+  ): void {
+    super.requestUpdate(name, oldValue, options);
+    if (name === 'checked') {
       this.internals.ariaChecked = `${this.checked}`;
+      // As SbbFormAssociatedCheckboxMixin does not reflect checked property, we add a data-checked.
       this.toggleAttribute('data-checked', this.checked);
     }
   }


### PR DESCRIPTION
This fix ensures that the data-checked attribute is kept in sync with the checked property. The previous solution of handling it in willUpdate() was too late for some edge cases, especially in Angular during initial loading when using the Chrome browser.

BEGIN_COMMIT_OVERRIDE
fix(sbb-toggle-check, sbb-checkbox-panel): handle the 'data-checked' attribute synchronously

This fix ensures that the data-checked attribute is kept in sync with the checked property. The previous solution of handling it in willUpdate() was too late for some edge cases, especially in Angular during initial loading when using the Chrome browser.
END_COMMIT_OVERRIDE