### PR TITLE
fix: fix disabled state handling

### DIFF
--- a/src/elements/core/mixins/form-associated-mixin.ts
+++ b/src/elements/core/mixins/form-associated-mixin.ts
@@ -225,18 +225,24 @@ export const SbbFormAssociatedMixin = <
     public formAssociatedCallback?(form: HTMLFormElement | null): void;
 
     /**
-     * Is called whenever a surrounding form / fieldset changes disabled state.
-     * @param disabled
+     * Is called whenever a surrounding fieldset changes disabled state.
      *
      * @internal
      */
-    public formDisabledCallback(disabled: boolean): void {
-      // This callback is triggered if the disabled property changes or the disabled attribute of a fieldset or form changes.
-      // We need to postpone the assignment, otherwise it interferes with disabled status setting
-      // and leads to a wrong state (e.g. embedded sbb-visual-checkbox).
-      Promise.resolve().then(() => {
-        this.formDisabled = disabled;
-      });
+    public formDisabledCallback(_disabled: boolean): void {
+      this.formDisabled = this._hasDisabledAncestor();
+    }
+
+    private _hasDisabledAncestor(): boolean {
+      // Check if any of the fieldset ancestors has the disabled attribute set.
+      let element: HTMLElement | null = this.parentElement;
+      while (element) {
+        if (element.localName === 'fieldset' && element.hasAttribute('disabled')) {
+          return true;
+        }
+        element = element.parentElement;
+      }
+      return false;
     }
 
     /**

--- a/src/elements/date-input/date-input.spec.ts
+++ b/src/elements/date-input/date-input.spec.ts
@@ -333,6 +333,99 @@ describe('sbb-date-input', () => {
     });
   });
 
+  describe('should handle disabled state', () => {
+    let fieldset: HTMLFieldSetElement;
+
+    beforeEach(async () => {
+      fieldset = await fixture(
+        html`<fieldset>
+          <sbb-form-field><sbb-date-input></sbb-date-input></sbb-form-field>
+        </fieldset>`,
+      );
+      element = fieldset.querySelector('sbb-date-input')!;
+    });
+
+    it('should handle disabled by attribute', async () => {
+      expect(element.disabled).to.be.false;
+      expect(element).not.to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+
+      element.toggleAttribute('disabled', true);
+      await waitForLitRender(element);
+
+      expect(element.disabled).to.be.true;
+      expect(element).to.match(':disabled');
+      expect(element).to.have.attribute('disabled');
+
+      element.removeAttribute('disabled');
+      await waitForLitRender(element);
+
+      expect(element.disabled).to.be.false;
+      expect(element).not.to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+    });
+
+    it('should handle disabled by property', async () => {
+      expect(element.disabled).to.be.false;
+      expect(element).not.to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+
+      element.disabled = true;
+      await waitForLitRender(element);
+
+      expect(element.disabled).to.be.true;
+      expect(element).to.match(':disabled');
+      expect(element).to.have.attribute('disabled');
+
+      element.disabled = false;
+      await waitForLitRender(element);
+
+      expect(element.disabled).to.be.false;
+      expect(element).not.to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+    });
+
+    it('should handle disabled fieldset by property', async () => {
+      expect(element.disabled).to.be.false;
+      expect(element).not.to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+
+      fieldset.disabled = true;
+      await waitForLitRender(element);
+
+      expect(element.disabled).to.be.true;
+      expect(element).to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+
+      fieldset.disabled = false;
+      await waitForLitRender(element);
+
+      expect(element.disabled).to.be.false;
+      expect(element).not.to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+    });
+
+    it('should handle disabled fieldset by attribute', async () => {
+      expect(element.disabled).to.be.false;
+      expect(element).not.to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+
+      fieldset.toggleAttribute('disabled', true);
+      await waitForLitRender(element);
+
+      expect(element.disabled).to.be.true;
+      expect(element).to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+
+      fieldset.removeAttribute('disabled');
+      await waitForLitRender(element);
+
+      expect(element.disabled).to.be.false;
+      expect(element).not.to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+    });
+  });
+
   describe('paste', () => {
     const pasteEvent = (value: string): Event => {
       // Firefox does not support mutating the DataTransfer instance.

--- a/src/elements/time-input/time-input.spec.ts
+++ b/src/elements/time-input/time-input.spec.ts
@@ -251,6 +251,99 @@ describe(`sbb-time-input`, () => {
     });
   });
 
+  describe('should handle disabled state', () => {
+    let fieldset: HTMLFieldSetElement;
+
+    beforeEach(async () => {
+      fieldset = await fixture(
+        html`<fieldset>
+          <sbb-form-field><sbb-time-input></sbb-time-input></sbb-form-field>
+        </fieldset>`,
+      );
+      element = fieldset.querySelector('sbb-time-input')!;
+    });
+
+    it('should handle disabled by attribute', async () => {
+      expect(element.disabled).to.be.false;
+      expect(element).not.to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+
+      element.toggleAttribute('disabled', true);
+      await waitForLitRender(element);
+
+      expect(element.disabled).to.be.true;
+      expect(element).to.match(':disabled');
+      expect(element).to.have.attribute('disabled');
+
+      element.removeAttribute('disabled');
+      await waitForLitRender(element);
+
+      expect(element.disabled).to.be.false;
+      expect(element).not.to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+    });
+
+    it('should handle disabled by property', async () => {
+      expect(element.disabled).to.be.false;
+      expect(element).not.to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+
+      element.disabled = true;
+      await waitForLitRender(element);
+
+      expect(element.disabled).to.be.true;
+      expect(element).to.match(':disabled');
+      expect(element).to.have.attribute('disabled');
+
+      element.disabled = false;
+      await waitForLitRender(element);
+
+      expect(element.disabled).to.be.false;
+      expect(element).not.to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+    });
+
+    it('should handle disabled fieldset by property', async () => {
+      expect(element.disabled).to.be.false;
+      expect(element).not.to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+
+      fieldset.disabled = true;
+      await waitForLitRender(element);
+
+      expect(element.disabled).to.be.true;
+      expect(element).to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+
+      fieldset.disabled = false;
+      await waitForLitRender(element);
+
+      expect(element.disabled).to.be.false;
+      expect(element).not.to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+    });
+
+    it('should handle disabled fieldset by attribute', async () => {
+      expect(element.disabled).to.be.false;
+      expect(element).not.to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+
+      fieldset.toggleAttribute('disabled', true);
+      await waitForLitRender(element);
+
+      expect(element.disabled).to.be.true;
+      expect(element).to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+
+      fieldset.removeAttribute('disabled');
+      await waitForLitRender(element);
+
+      expect(element.disabled).to.be.false;
+      expect(element).not.to.match(':disabled');
+      expect(element).not.to.have.attribute('disabled');
+    });
+  });
+
   it('should support asynchronously adding input by element reference', async () => {
     const root = await fixture(html`
       <div>


### PR DESCRIPTION
Previously, setting a custom form element into disabled state and re-enable it, failed. This fix changes the check for disabled ancestors by explicitly looking for them, instead of handling only the disabled value.

Closes [#lyne-angular/161](https://github.com/sbb-design-systems/lyne-angular/issues/161)