### PR TITLE
test: allow dark theme

### DIFF
--- a/web-test-runner.config.ts
+++ b/web-test-runner.config.ts
@@ -122,6 +122,10 @@ const testRunnerHtml = (
   }
     <link rel="modulepreload" href="/src/elements/core/testing/private/test-setup.ts" />
     <style type="text/css">
+      /* TODO: Remove once we globally activated dark mode */
+      :root {
+        color-scheme: light dark;
+      }
       ${renderStyles()}
     </style>
     <script type="module">


### PR DESCRIPTION
Allowing `color-scheme: light dark` in tests. As the forced colors test change for Safari, we merge this in a single commit to generate new baselines.