### PR TITLE
fix(sbb-tab): fix height observer and animation

### DIFF
--- a/src/elements/tabs/tab-group/__snapshots__/tab-group.snapshot.spec.snap.js
+++ b/src/elements/tabs/tab-group/__snapshots__/tab-group.snapshot.spec.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["sbb-tab-group renders DOM"] =
+snapshots["sbb-tab-group renders DOM"] = 
 `<sbb-tab-group initial-selected-index="0">
   <sbb-tab-label
     active=""
@@ -65,7 +65,7 @@ snapshots["sbb-tab-group renders DOM"] =
 `;
 /* end snapshot sbb-tab-group renders DOM */
 
-snapshots["sbb-tab-group renders Shadow DOM"] =
+snapshots["sbb-tab-group renders Shadow DOM"] = 
 `<div
   class="sbb-tab-group"
   role="tablist"
@@ -80,7 +80,7 @@ snapshots["sbb-tab-group renders Shadow DOM"] =
 `;
 /* end snapshot sbb-tab-group renders Shadow DOM */
 
-snapshots["sbb-tab-group renders A11y tree Firefox"] =
+snapshots["sbb-tab-group renders A11y tree Firefox"] = 
 `<p>
   {
   "role": "document",
@@ -119,7 +119,7 @@ snapshots["sbb-tab-group renders A11y tree Firefox"] =
 `;
 /* end snapshot sbb-tab-group renders A11y tree Firefox */
 
-snapshots["sbb-tab-group renders A11y tree Chrome"] =
+snapshots["sbb-tab-group renders A11y tree Chrome"] = 
 `<p>
   {
   "role": "WebArea",

--- a/src/elements/tabs/tab-group/__snapshots__/tab-group.snapshot.spec.snap.js
+++ b/src/elements/tabs/tab-group/__snapshots__/tab-group.snapshot.spec.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["sbb-tab-group renders DOM"] = 
+snapshots["sbb-tab-group renders DOM"] =
 `<sbb-tab-group initial-selected-index="0">
   <sbb-tab-label
     active=""
@@ -13,7 +13,6 @@ snapshots["sbb-tab-group renders DOM"] =
     Test tab label 1
   </sbb-tab-label>
   <sbb-tab
-    data-active=""
     id="sbb-tab-0"
     tabindex="0"
   >
@@ -66,7 +65,7 @@ snapshots["sbb-tab-group renders DOM"] =
 `;
 /* end snapshot sbb-tab-group renders DOM */
 
-snapshots["sbb-tab-group renders Shadow DOM"] = 
+snapshots["sbb-tab-group renders Shadow DOM"] =
 `<div
   class="sbb-tab-group"
   role="tablist"
@@ -81,7 +80,7 @@ snapshots["sbb-tab-group renders Shadow DOM"] =
 `;
 /* end snapshot sbb-tab-group renders Shadow DOM */
 
-snapshots["sbb-tab-group renders A11y tree Firefox"] = 
+snapshots["sbb-tab-group renders A11y tree Firefox"] =
 `<p>
   {
   "role": "document",
@@ -120,7 +119,7 @@ snapshots["sbb-tab-group renders A11y tree Firefox"] =
 `;
 /* end snapshot sbb-tab-group renders A11y tree Firefox */
 
-snapshots["sbb-tab-group renders A11y tree Chrome"] = 
+snapshots["sbb-tab-group renders A11y tree Chrome"] =
 `<p>
   {
   "role": "WebArea",

--- a/src/elements/tabs/tab-group/readme.md
+++ b/src/elements/tabs/tab-group/readme.md
@@ -62,6 +62,7 @@ type SbbTabChangedEventDetails = {
 | `initialSelectedIndex` | `initial-selected-index` | public  | `number`               | `0`                | Sets the initial tab. If it matches a disabled tab or exceeds the length of the tab group, the first enabled tab will be selected. |
 | `labels`               | -                        | public  | `SbbTabLabelElement[]` |                    | Gets the slotted `sbb-tab-label`s.                                                                                                 |
 | `size`                 | `size`                   | public  | `'s' \| 'l' \| 'xl'`   | `'l' / 's' (lean)` | Size variant, either s, l or xl.                                                                                                   |
+| `tabs`                 | -                        | public  | `SbbTabElement[]`      |                    | Gets the slotted `sbb-tab`s.                                                                                                       |
 
 ## Methods
 

--- a/src/elements/tabs/tab-group/tab-group.component.ts
+++ b/src/elements/tabs/tab-group/tab-group.component.ts
@@ -122,6 +122,8 @@ class SbbTabGroupElement extends SbbElementInternalsMixin(SbbHydrationMixin(LitE
 
     this.labels.forEach((tabLabel) => tabLabel['linkToTab']());
     this._initSelection();
+
+    // To avoid animations on initialization, we have to mark the component as initialized and wait a tick.
     Promise.resolve().then(() => this.toggleState('initialized', true));
     this._tabGroupResizeObserver.observe(this._tabGroupElement);
   }
@@ -232,7 +234,7 @@ class SbbTabGroupElement extends SbbElementInternalsMixin(SbbHydrationMixin(LitE
   /**
    * @internal
    */
-  protected setHeightResizeTab(contentHeight: number): void {
+  protected setTabContentHeight(contentHeight: number): void {
     this._tabContentElement.style.height = `${contentHeight}px`;
   }
 

--- a/src/elements/tabs/tab-group/tab-group.component.ts
+++ b/src/elements/tabs/tab-group/tab-group.component.ts
@@ -8,7 +8,7 @@ import { getNextElementIndex, isArrowKeyPressed } from '../../core/a11y.js';
 import { forceType } from '../../core/decorators.js';
 import { isLean } from '../../core/dom.js';
 import { throttle } from '../../core/eventing.js';
-import { SbbHydrationMixin } from '../../core/mixins.js';
+import { SbbElementInternalsMixin, SbbHydrationMixin } from '../../core/mixins.js';
 import type { SbbTabLabelElement } from '../tab-label.js';
 import type { SbbTabElement } from '../tab.js';
 
@@ -54,7 +54,7 @@ export interface InterfaceSbbTabGroupTab extends SbbTabLabelElement {
  */
 export
 @customElement('sbb-tab-group')
-class SbbTabGroupElement extends SbbHydrationMixin(LitElement) {
+class SbbTabGroupElement extends SbbElementInternalsMixin(SbbHydrationMixin(LitElement)) {
   public static override styles: CSSResultGroup = style;
   public static readonly events = {
     tabchange: 'tabchange',
@@ -122,6 +122,7 @@ class SbbTabGroupElement extends SbbHydrationMixin(LitElement) {
 
     this.labels.forEach((tabLabel) => tabLabel['linkToTab']());
     this._initSelection();
+    Promise.resolve().then(() => this.toggleState('initialized', true));
     this._tabGroupResizeObserver.observe(this._tabGroupElement);
   }
 

--- a/src/elements/tabs/tab-group/tab-group.component.ts
+++ b/src/elements/tabs/tab-group/tab-group.component.ts
@@ -67,11 +67,6 @@ class SbbTabGroupElement extends SbbHydrationMixin(LitElement) {
     skipInitial: true,
     callback: (entries) => this._onTabGroupElementResize(entries),
   });
-  private _tabContentResizeObserver = new ResizeController(this, {
-    target: null,
-    skipInitial: true,
-    callback: (entries) => this._onTabContentElementResize(entries),
-  });
 
   /**
    * Size variant, either s, l or xl.
@@ -174,7 +169,6 @@ class SbbTabGroupElement extends SbbHydrationMixin(LitElement) {
   private _onContentSlotChange = (): void => {
     this.labels.forEach((tabLabel) => tabLabel['linkToTab']());
     this.labels.find((tabLabel) => tabLabel.active)?.activate();
-    this.tabs.forEach((tab) => this._tabContentResizeObserver.observe(tab));
   };
 
   private _onLabelSlotChange = (): void => {
@@ -214,18 +208,6 @@ class SbbTabGroupElement extends SbbHydrationMixin(LitElement) {
     }
   }
 
-  private _onTabContentElementResize(entries: ResizeObserverEntry[]): void {
-    if (!this._tabContentElement) {
-      return;
-    }
-    // The `entries` array contains the previous tab and the clicked one, which is the active one
-    const activeTab = entries.find((e) => (e.target as SbbTabElement).hasAttribute('data-active'));
-    if (activeTab) {
-      const contentHeight = Math.floor(activeTab.contentRect.height);
-      this._tabContentElement.style.height = `${contentHeight}px`;
-    }
-  }
-
   private _handleKeyDown(evt: KeyboardEvent): void {
     const enabledTabs: SbbTabLabelElement[] = this._enabledTabs();
 
@@ -244,6 +226,13 @@ class SbbTabGroupElement extends SbbHydrationMixin(LitElement) {
       enabledTabs[nextIndex]?.focus();
       evt.preventDefault();
     }
+  }
+
+  /**
+   * @internal
+   */
+  protected setHeightResizeTab(contentHeight: number): void {
+    this._tabContentElement.style.height = `${contentHeight}px`;
   }
 
   protected override render(): TemplateResult {

--- a/src/elements/tabs/tab-group/tab-group.component.ts
+++ b/src/elements/tabs/tab-group/tab-group.component.ts
@@ -124,7 +124,6 @@ class SbbTabGroupElement extends SbbHydrationMixin(LitElement) {
     this.labels.forEach((tabLabel) => tabLabel['linkToTab']());
     this._initSelection();
     this._tabGroupResizeObserver.observe(this._tabGroupElement);
-    this._tabContentResizeObserver.observe(this._tabContentElement);
   }
 
   /**

--- a/src/elements/tabs/tab-group/tab-group.component.ts
+++ b/src/elements/tabs/tab-group/tab-group.component.ts
@@ -108,6 +108,10 @@ class SbbTabGroupElement extends SbbHydrationMixin(LitElement) {
 
   /** Gets the slotted `sbb-tab`s. */
   public get tabs(): SbbTabElement[] {
+    /**
+     * The querySelector API is not used because when nested tabs are used,
+     * the returned array contains the inner tabs too, and this breaks the keyboard navigation.
+     */
     return Array.from(this.children ?? []).filter((child) =>
       /^sbb-tab$/u.test(child.localName),
     ) as SbbTabElement[];
@@ -214,11 +218,10 @@ class SbbTabGroupElement extends SbbHydrationMixin(LitElement) {
     if (!this._tabContentElement) {
       return;
     }
-    for (const entry of entries.filter((e) =>
-      (e.target as SbbTabElement).hasAttribute('data-active'),
-    )) {
-      const contentHeight = Math.floor(entry.contentRect.height);
-
+    // The `entries` array contains the previous tab and the clicked one, which is the active one
+    const activeTab = entries.find((e) => (e.target as SbbTabElement).hasAttribute('data-active'));
+    if (activeTab) {
+      const contentHeight = Math.floor(activeTab.contentRect.height);
       this._tabContentElement.style.height = `${contentHeight}px`;
     }
   }

--- a/src/elements/tabs/tab-group/tab-group.component.ts
+++ b/src/elements/tabs/tab-group/tab-group.component.ts
@@ -106,6 +106,13 @@ class SbbTabGroupElement extends SbbHydrationMixin(LitElement) {
     ) as SbbTabLabelElement[];
   }
 
+  /** Gets the slotted `sbb-tab`s. */
+  public get tabs(): SbbTabElement[] {
+    return Array.from(this.children ?? []).filter((child) =>
+      /^sbb-tab$/u.test(child.localName),
+    ) as SbbTabElement[];
+  }
+
   public constructor() {
     super();
     this.addEventListener?.('keydown', (e) => this._handleKeyDown(e));
@@ -164,6 +171,7 @@ class SbbTabGroupElement extends SbbHydrationMixin(LitElement) {
   private _onContentSlotChange = (): void => {
     this.labels.forEach((tabLabel) => tabLabel['linkToTab']());
     this.labels.find((tabLabel) => tabLabel.active)?.activate();
+    this.tabs.forEach((tab) => this._tabContentResizeObserver.observe(tab));
   };
 
   private _onLabelSlotChange = (): void => {
@@ -207,7 +215,9 @@ class SbbTabGroupElement extends SbbHydrationMixin(LitElement) {
     if (!this._tabContentElement) {
       return;
     }
-    for (const entry of entries) {
+    for (const entry of entries.filter((e) =>
+      (e.target as SbbTabElement).hasAttribute('data-active'),
+    )) {
       const contentHeight = Math.floor(entry.contentRect.height);
 
       this._tabContentElement.style.height = `${contentHeight}px`;

--- a/src/elements/tabs/tab-group/tab-group.scss
+++ b/src/elements/tabs/tab-group/tab-group.scss
@@ -4,12 +4,16 @@
 @include sbb.box-sizing;
 
 :host {
+  display: block;
+
+  --sbb-tab-group-animation-duration: 0s;
+}
+
+:host(:state(initialized)) {
   --sbb-tab-group-animation-duration: var(
     --sbb-disable-animation-duration,
     var(--sbb-animation-duration-4x)
   );
-
-  display: block;
 }
 
 .sbb-tab-group {
@@ -20,28 +24,4 @@
 .sbb-tab-group-content {
   margin-block-start: var(--sbb-spacing-responsive-m);
   transition: height var(--sbb-tab-group-animation-duration) var(--sbb-animation-easing);
-
-  ::slotted(sbb-tab) {
-    visibility: hidden;
-    opacity: 0;
-    height: 0;
-    overflow: hidden;
-  }
-
-  ::slotted(sbb-tab[data-active]) {
-    visibility: visible;
-    opacity: 1;
-    height: fit-content;
-    overflow: unset;
-    transition: {
-      duration: var(--sbb-tab-group-animation-duration);
-      delay: var(--sbb-tab-group-animation-duration);
-      timing-function: var(--sbb-animation-easing);
-      property: opacity, visibility;
-    }
-  }
-
-  ::slotted(sbb-tab:focus-visible) {
-    @include sbb.focus-outline;
-  }
 }

--- a/src/elements/tabs/tab-group/tab-group.spec.ts
+++ b/src/elements/tabs/tab-group/tab-group.spec.ts
@@ -216,14 +216,14 @@ describe(`sbb-tab-group`, () => {
     let firstTabLabel = element.querySelector('sbb-tab-label') as SbbTabLabelElement;
     expect(firstTabLabel).to.have.attribute('active');
     expect(firstTabLabel['internals'].ariaSelected).to.be.equal('true');
-    expect(element.querySelector('sbb-tab')).to.have.attribute('data-active');
+    expect(element.querySelector('sbb-tab')).to.match(':state(active)');
 
     let secondTabLabel = element.querySelector(
       'sbb-tab-label:nth-of-type(2)',
     ) as SbbTabLabelElement;
     expect(secondTabLabel).not.to.have.attribute('active');
     expect(secondTabLabel['internals'].ariaSelected).to.be.equal('false');
-    expect(element.querySelector('sbb-tab:nth-of-type(2)')).not.to.have.attribute('data-active');
+    expect(element.querySelector('sbb-tab:nth-of-type(2)')).not.to.match(':state(active)');
 
     newLabelActive.click();
     await waitForLitRender(element);
@@ -233,11 +233,11 @@ describe(`sbb-tab-group`, () => {
     firstTabLabel = element.querySelector('sbb-tab-label') as SbbTabLabelElement;
     expect(firstTabLabel).not.to.have.attribute('active');
     expect(firstTabLabel['internals'].ariaSelected).to.be.equal('false');
-    expect(element.querySelector('sbb-tab')).not.to.have.attribute('data-active');
+    expect(element.querySelector('sbb-tab')).not.to.match(':state(active)');
 
     secondTabLabel = element.querySelector('sbb-tab-label:nth-of-type(2)') as SbbTabLabelElement;
     expect(secondTabLabel).to.have.attribute('active');
     expect(secondTabLabel['internals'].ariaSelected).to.be.equal('true');
-    expect(element.querySelector('sbb-tab:nth-of-type(2)')).to.have.attribute('data-active');
+    expect(element.querySelector('sbb-tab:nth-of-type(2)')).to.match(':state(active)');
   });
 });

--- a/src/elements/tabs/tab-group/tab-group.stories.ts
+++ b/src/elements/tabs/tab-group/tab-group.stories.ts
@@ -45,12 +45,16 @@ const tabPanelOne = (): TemplateResult => html`
 
 const tabPanelTwo = (): TemplateResult => html`
   <sbb-tab>
-    <section>
-      Diam maecenas ultricies mi eget mauris pharetra et ultrices neque ornare aenean euismod
-      elementum nisi quis eleifend quam adipiscing vitae proin sagittis nisl rhoncus mattis rhoncus
-      urna neque viverra justo nec.
-      <sbb-block-link target="_blank" href="https://www.sbb.ch">Visit sbb.ch</sbb-block-link>
-    </section>
+    ${new Array(5).fill(null).map(
+      () => html`
+        <section>
+          Diam maecenas ultricies mi eget mauris pharetra et ultrices neque ornare aenean euismod
+          elementum nisi quis eleifend quam adipiscing vitae proin sagittis nisl rhoncus mattis
+          rhoncus urna neque viverra justo nec.
+          <sbb-block-link target="_blank" href="https://www.sbb.ch">Visit sbb.ch</sbb-block-link>
+        </section>
+      `,
+    )}
   </sbb-tab>
 `;
 
@@ -85,6 +89,9 @@ const DefaultTemplate = ({ size, label, ...args }: Args): TemplateResult => html
     <sbb-tab-label>Tab title four</sbb-tab-label>
     ${tabPanelFour()}
   </sbb-tab-group>
+  <sbb-card color="milk" style="margin-block-start: var(--sbb-spacing-fixed-8x)"
+    >Some content used to check the tabs height</sbb-card
+  >
 `;
 
 const IconsAndNumbersTemplate = ({ size, label, ...args }: Args): TemplateResult => html`
@@ -165,6 +172,9 @@ const DynamicTemplate = ({ size, label, ...args }: Args): TemplateResult => html
     <sbb-tab-label>Tab title four</sbb-tab-label>
     ${tabPanelFour()}
   </sbb-tab-group>
+  <sbb-card color="milk" style="margin-block-start: var(--sbb-spacing-fixed-8x)"
+    >Some content used to check the tabs height</sbb-card
+  >
 `;
 
 const label: InputType = {

--- a/src/elements/tabs/tab-label/tab-label.component.ts
+++ b/src/elements/tabs/tab-label/tab-label.component.ts
@@ -76,7 +76,6 @@ class SbbTabLabelElement extends SbbDisabledMixin(
 
     if (changedProperties.has('active')) {
       this.internals.ariaSelected = `${this.active}`;
-      this.tab?.toggleAttribute('data-active', this.active);
 
       if (this.active && !this.disabled) {
         this.activate();
@@ -97,6 +96,7 @@ class SbbTabLabelElement extends SbbDisabledMixin(
   /** Deactivate the tab. */
   public deactivate(): void {
     this.active = false;
+    this.tab?.['deactivate']();
     this._selected = false;
     this.tabIndex = -1;
   }
@@ -115,6 +115,7 @@ class SbbTabLabelElement extends SbbDisabledMixin(
     if (prevActiveTabLabel !== this) {
       prevActiveTabLabel?.deactivate();
       this.active = true;
+      this.tab?.['activate']();
       this._selected = true;
       this.tabIndex = 0;
       this.tab?.dispatchEvent(new Event('active', { bubbles: true, composed: true }));

--- a/src/elements/tabs/tab-label/tab-label.scss
+++ b/src/elements/tabs/tab-label/tab-label.scss
@@ -71,7 +71,7 @@
 }
 
 // Pressed/active state
-:host(:is([data-active], :active)) {
+:host(:active) {
   --sbb-tab-label-color: var(--sbb-color-3);
 }
 

--- a/src/elements/tabs/tab/__snapshots__/tab.snapshot.spec.snap.js
+++ b/src/elements/tabs/tab/__snapshots__/tab.snapshot.spec.snap.js
@@ -12,10 +12,8 @@ snapshots["sbb-tab renders DOM"] =
 /* end snapshot sbb-tab renders DOM */
 
 snapshots["sbb-tab renders Shadow DOM"] = 
-`<div class="sbb-tab">
-  <slot>
-  </slot>
-</div>
+`<slot>
+</slot>
 `;
 /* end snapshot sbb-tab renders Shadow DOM */
 
@@ -23,19 +21,7 @@ snapshots["sbb-tab renders A11y tree Chrome"] =
 `<p>
   {
   "role": "WebArea",
-  "name": "",
-  "children": [
-    {
-      "role": "tabpanel",
-      "name": "",
-      "children": [
-        {
-          "role": "text",
-          "name": "Content"
-        }
-      ]
-    }
-  ]
+  "name": ""
 }
 </p>
 `;
@@ -45,19 +31,7 @@ snapshots["sbb-tab renders A11y tree Firefox"] =
 `<p>
   {
   "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "tabpanel",
-      "name": "",
-      "children": [
-        {
-          "role": "text leaf",
-          "name": "Content"
-        }
-      ]
-    }
-  ]
+  "name": ""
 }
 </p>
 `;

--- a/src/elements/tabs/tab/readme.md
+++ b/src/elements/tabs/tab/readme.md
@@ -31,6 +31,7 @@ The role and the id for the `aria-controls` attribute is managed directly by the
 
 | Name    | Attribute | Privacy | Type                         | Default | Description                                  |
 | ------- | --------- | ------- | ---------------------------- | ------- | -------------------------------------------- |
+| `group` | -         | public  | `SbbTabGroupElement \| null` |         | Get the parent `sbb-tab-group`.              |
 | `label` | -         | public  | `SbbTabLabelElement \| null` |         | The `sbb-tab-label` associated with the tab. |
 
 ## Events

--- a/src/elements/tabs/tab/tab.component.ts
+++ b/src/elements/tabs/tab/tab.component.ts
@@ -1,8 +1,11 @@
+import { MutationController } from '@lit-labs/observers/mutation-controller.js';
+import { ResizeController } from '@lit-labs/observers/resize-controller.js';
 import type { CSSResultGroup, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 import { SbbElementInternalsMixin } from '../../core/mixins.js';
+import type { SbbTabGroupElement } from '../tab-group/tab-group.component.js';
 import type { SbbTabLabelElement } from '../tab-label.js';
 
 import style from './tab.scss?lit&inline';
@@ -24,11 +27,43 @@ class SbbTabElement extends SbbElementInternalsMixin(LitElement) {
     active: 'active',
   } as const;
 
+  private _tabContentResizeObserver = new ResizeController(this, {
+    target: null,
+    skipInitial: true,
+    callback: () => this._onTabContentElementResize(),
+  });
+
   /** The `sbb-tab-label` associated with the tab. */
   public get label(): SbbTabLabelElement | null {
     return this.previousElementSibling?.localName === 'sbb-tab-label'
       ? (this.previousElementSibling as SbbTabLabelElement)
       : null;
+  }
+
+  /** Get the parent `sbb-tab-group`. */
+  public get group(): SbbTabGroupElement | null {
+    return this.closest('sbb-tab-group');
+  }
+
+  public constructor() {
+    super();
+
+    this.addController(
+      new MutationController(this, {
+        config: { attributeFilter: ['data-active'] },
+        callback: (mutationsList) => {
+          for (const mutation of mutationsList) {
+            if (mutation.attributeName === 'data-active') {
+              if (this.hasAttribute('data-active')) {
+                this._tabContentResizeObserver.observe(this);
+              } else {
+                this._tabContentResizeObserver.unobserve(this);
+              }
+            }
+          }
+        },
+      }),
+    );
   }
 
   /**
@@ -42,6 +77,12 @@ class SbbTabElement extends SbbElementInternalsMixin(LitElement) {
 
     this.id ||= `sbb-tab-${nextId++}`;
     this.tabIndex = 0;
+  }
+
+  private _onTabContentElementResize(): void {
+    if (this.hasAttribute('data-active')) {
+      this.group?.['setHeightResizeTab'](Math.floor(this.getBoundingClientRect().height));
+    }
   }
 
   protected override render(): TemplateResult {

--- a/src/elements/tabs/tab/tab.component.ts
+++ b/src/elements/tabs/tab/tab.component.ts
@@ -74,11 +74,7 @@ class SbbTabElement extends SbbElementInternalsMixin(LitElement) {
   }
 
   protected override render(): TemplateResult {
-    return html`
-      <div class="sbb-tab">
-        <slot></slot>
-      </div>
-    `;
+    return html`<slot></slot>`;
   }
 }
 

--- a/src/elements/tabs/tab/tab.component.ts
+++ b/src/elements/tabs/tab/tab.component.ts
@@ -1,4 +1,3 @@
-import { MutationController } from '@lit-labs/observers/mutation-controller.js';
 import { ResizeController } from '@lit-labs/observers/resize-controller.js';
 import type { CSSResultGroup, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
@@ -45,27 +44,6 @@ class SbbTabElement extends SbbElementInternalsMixin(LitElement) {
     return this.closest('sbb-tab-group');
   }
 
-  public constructor() {
-    super();
-
-    this.addController(
-      new MutationController(this, {
-        config: { attributeFilter: ['data-active'] },
-        callback: (mutationsList) => {
-          for (const mutation of mutationsList) {
-            if (mutation.attributeName === 'data-active') {
-              if (this.hasAttribute('data-active')) {
-                this._tabContentResizeObserver.observe(this);
-              } else {
-                this._tabContentResizeObserver.unobserve(this);
-              }
-            }
-          }
-        },
-      }),
-    );
-  }
-
   /**
    * @internal
    * @deprecated
@@ -79,10 +57,20 @@ class SbbTabElement extends SbbElementInternalsMixin(LitElement) {
     this.tabIndex = 0;
   }
 
+  /** @internal */
+  protected activate(): void {
+    this.toggleState('active', true);
+    this._tabContentResizeObserver.observe(this);
+  }
+
+  /** @internal */
+  protected deactivate(): void {
+    this._tabContentResizeObserver.unobserve(this);
+    this.toggleState('active', false);
+  }
+
   private _onTabContentElementResize(): void {
-    if (this.hasAttribute('data-active')) {
-      this.group?.['setHeightResizeTab'](Math.floor(this.getBoundingClientRect().height));
-    }
+    this.group?.['setHeightResizeTab'](Math.floor(this.getBoundingClientRect().height));
   }
 
   protected override render(): TemplateResult {

--- a/src/elements/tabs/tab/tab.component.ts
+++ b/src/elements/tabs/tab/tab.component.ts
@@ -70,7 +70,7 @@ class SbbTabElement extends SbbElementInternalsMixin(LitElement) {
   }
 
   private _onTabContentElementResize(): void {
-    this.group?.['setHeightResizeTab'](Math.floor(this.getBoundingClientRect().height));
+    this.group?.['setTabContentHeight'](Math.floor(this.getBoundingClientRect().height));
   }
 
   protected override render(): TemplateResult {

--- a/src/elements/tabs/tab/tab.scss
+++ b/src/elements/tabs/tab/tab.scss
@@ -4,7 +4,29 @@
 @include sbb.box-sizing;
 
 :host {
-  display: block;
+  display: none;
 
   @include sbb.ignore-children-margin;
+}
+
+:host(:focus-visible) {
+  @include sbb.focus-outline;
+}
+
+:host(:state(active)) {
+  display: block;
+  opacity: 1;
+  transition: {
+    duration: var(--sbb-tab-group-animation-duration);
+    delay: var(--sbb-tab-group-animation-duration);
+    timing-function: var(--sbb-animation-easing);
+  }
+
+  // Experimental property, but supported in every major browser.
+  transition-behavior: allow-discrete;
+
+  // Experimental property, currently supported in every major browser except Firefox.
+  @starting-style {
+    opacity: 0;
+  }
 }

--- a/src/elements/tabs/tab/tab.stories.ts
+++ b/src/elements/tabs/tab/tab.stories.ts
@@ -3,9 +3,14 @@ import type { TemplateResult } from 'lit';
 import { html } from 'lit';
 
 import readme from './readme.md?raw';
-import './tab.component.js';
+import '../../card.js';
 
-const Template = (): TemplateResult => html` <sbb-tab> Content </sbb-tab> `;
+const Template = (): TemplateResult => html`
+  <sbb-card color="milk">
+    'sbb-tab' must be only used together with 'sbb-tab-label' in a 'sbb-tab-group'. See
+    'sbb-tab-group' examples to see it in action.
+  </sbb-card>
+`;
 
 export const Default: StoryObj = {
   render: Template,


### PR DESCRIPTION
In previous implementation, the `tab` reference in the `tabLabel` was observed by the `_tabContentResizeObserver` when the tab was activated (unobserving the previous selected one).

This logic has been lost moving the select/activate method from the tab-group to the tab-label; a possible solution is the logic added in the current PR.

Other options:
- move the observer in the tab-label and restore the .observe/.unobserve methods in the `activate` method (drawback: the height must be changed on the tab wrapper in the group, so querying it from the tab-label requires something like: `this.group?.shadowRoot.querySelector('.sbb-tab-group-content)?.style.height = ...`, which I don't really like);
- listen to the `active` event emitted by the tab to connect the observer
- listen to the `tabchange` event, which has also the information about the prevTab, to connect/disconnect the observer