### PR TITLE
fix(lists): display icon with forced colors

### DIFF
--- a/src/elements/core/styles/mixins/lists.scss
+++ b/src/elements/core/styles/mixins/lists.scss
@@ -152,6 +152,7 @@
 
       // If consumers override the `--sbb-icon-list-marker-icon-color` variable to set a custom color via inline style,
       // it would have higher specificity over any rule, included the forced-colors one.
+      // This can be avoided forcing `background-color: CanvasText` in high-contrast mode.
       @include a11y.if-forced-colors {
         background-color: CanvasText;
       }


### PR DESCRIPTION
Two different cases:
1. for the default icon case, it would be enough to set the `--sbb-icon-list-marker-icon-color` to `CanvasText` in high contrast mode; however,
2. this would not cover the case when consumers override the variable to set a custom color via inline style, due to its higher specificity; so, instead than overriding the variable, it is necessary to override the background rule.