### PR TITLE
fix: set data-expanded to false on old element if trigger element changes

### DIFF
--- a/src/elements/autocomplete/autocomplete-base-element.ts
+++ b/src/elements/autocomplete/autocomplete-base-element.ts
@@ -382,6 +382,7 @@ export abstract class SbbAutocompleteBaseElement<T = string> extends SbbNegative
     }
 
     this._triggerAbortController?.abort();
+    this._triggerElement?.toggleAttribute('data-expanded', false);
     removeAriaComboBoxAttributes(this.triggerElement);
     this._triggerElement = triggerElement;
 


### PR DESCRIPTION
## Preflight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/sbb-design-systems/lyne-components/blob/main/docs/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/sbb-design-systems/lyne-components/blob/main/docs/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [pull request tracker](https://github.com/sbb-design-systems/lyne-components/pulls) for a Pull Request (PR) that matches the one I want to submit, without success.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

See [Review Guidelines](../docs/REVIEW.md) for more information on what is checked during the review process.

## Changes

Changes in this pull request:

- sets data-expaned attribute of old auto complete trigger element to false if auto complete trigger element changes

## Browsers

I tested the build on the following browsers:

- [ ] Firefox Desktop
- [x] Chrome Desktop
- [ ] Edge Desktop
- [ ] Safari Desktop
- [ ] Chrome Mobile
- [ ] Safari Mobile

## Screen readers

I tested the build on the following browsers:

- [ ] JAWS Firefox Desktop
- [ ] JAWS Chrome Desktop
- [ ] NVDA Firefox Desktop
- [ ] NVDA Chrome Desktop
- [ ] VoiceOver Safari Desktop
- [ ] VoiceOver Chrome Desktop
- [ ] VoiceOver Safari Mobile
- [ ] Android Accessibility Suite Chrome Mobile

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
