### PR TITLE
style: reactivate "block-no-redundant-nested-style-rules"

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -50,7 +50,6 @@
     ],
     "number-max-precision": 12,
     "value-no-vendor-prefix": [true, { "ignoreValues": ["box"] }],
-    "no-duplicate-selectors": null,
-    "block-no-redundant-nested-style-rules": null
+    "no-duplicate-selectors": null
   }
 }

--- a/src/elements-experimental/pearl-chain/pearl-chain.scss
+++ b/src/elements-experimental/pearl-chain/pearl-chain.scss
@@ -45,13 +45,11 @@
   @include sbb.pearl-chain-bullet-start-end;
   @include sbb.pearl-chain-bullet;
 
-  & {
-    content: '';
-    position: absolute;
-    background-color: currentcolor;
-    inset-block-start: 0;
-    z-index: 3;
-  }
+  content: '';
+  position: absolute;
+  background-color: currentcolor;
+  inset-block-start: 0;
+  z-index: 3;
 }
 
 .sbb-pearl-chain__bullet:first-of-type {
@@ -92,10 +90,7 @@
   z-index: 2;
 
   @include sbb.pearl-chain-bullet;
-
-  & {
-    @include sbb.pearl-chain-bullet-stop;
-  }
+  @include sbb.pearl-chain-bullet-stop;
 }
 
 .sbb-pearl-chain__bullet--future {
@@ -202,14 +197,12 @@
 .sbb-pearl-chain__position {
   @include sbb.pearl-chain-bullet-position;
 
-  & {
-    position: absolute;
-    inset-block-start: -200%;
-    z-index: 4;
+  position: absolute;
+  inset-block-start: -200%;
+  z-index: 4;
 
-    // --sbb-pearl-chain-status-position: defined in .ts file
-    inset-inline-start: var(--sbb-pearl-chain-status-position);
-  }
+  // --sbb-pearl-chain-status-position: defined in .ts file
+  inset-inline-start: var(--sbb-pearl-chain-status-position);
 }
 
 .sbb-pearl-chain__position--no-animation {

--- a/src/elements-experimental/seat-reservation/seat-reservation/seat-reservation.scss
+++ b/src/elements-experimental/seat-reservation/seat-reservation/seat-reservation.scss
@@ -112,14 +112,12 @@
   // button outline-offset would be clipped otherwise because it's not calculated in the box-model
   padding-block-start: sbb-sr-functions.sr-px-to-rem(4);
 
-  & {
-    // Set sbb scrollbar transparent by default
-    --sbb-scrollbar-color: transparent;
+  // Set sbb scrollbar transparent by default
+  --sbb-scrollbar-color: transparent;
 
-    display: flex;
-    overflow: scroll hidden;
-    position: relative;
-  }
+  display: flex;
+  overflow: scroll hidden;
+  position: relative;
 }
 
 .sbb-sr-navigation__list-coaches {
@@ -159,15 +157,13 @@
 .sbb-sr__wrapper {
   @include sbb.scrollbar;
 
-  & {
-    overflow-x: scroll;
-    padding-block: sbb-sr-functions.sr-px-to-rem(8) sbb-sr-functions.sr-px-to-rem(16);
+  overflow-x: scroll;
+  padding-block: sbb-sr-functions.sr-px-to-rem(8) sbb-sr-functions.sr-px-to-rem(16);
 
-    .sbb-sr__parent {
-      display: flex;
-      flex-direction: column;
-      position: relative;
-    }
+  .sbb-sr__parent {
+    display: flex;
+    flex-direction: column;
+    position: relative;
   }
 }
 
@@ -340,11 +336,9 @@
         .sbb-sr__wrapper {
           @include sbb.scrollbar;
 
-          & {
-            overflow: hidden scroll;
-            height: 100%;
-            padding: 0;
-          }
+          overflow: hidden scroll;
+          height: 100%;
+          padding: 0;
         }
 
         .sbb-sr__parent {

--- a/src/elements/autocomplete/autocomplete-base-element.scss
+++ b/src/elements/autocomplete/autocomplete-base-element.scss
@@ -135,9 +135,7 @@
   @include sbb.optionsOverlay;
   @include sbb.scrollbar-rules;
 
-  & {
-    pointer-events: var(--sbb-options-pointer-events);
-  }
+  pointer-events: var(--sbb-options-pointer-events);
 
   @include sbb.if-forced-colors {
     border: var(--sbb-border-width-1x) solid CanvasText;

--- a/src/elements/breadcrumb/breadcrumb/breadcrumb.scss
+++ b/src/elements/breadcrumb/breadcrumb/breadcrumb.scss
@@ -22,15 +22,13 @@
   @include sbb.text-xs--regular;
   @include sbb.link-base;
 
-  & {
-    display: flex;
-    cursor: var(--sbb-cursor-pointer);
-    gap: var(--sbb-spacing-fixed-2x);
-    color: var(--sbb-breadcrumb-color);
-    align-items: center;
-    overflow: hidden;
-    outline: none;
-  }
+  display: flex;
+  cursor: var(--sbb-cursor-pointer);
+  gap: var(--sbb-spacing-fixed-2x);
+  color: var(--sbb-breadcrumb-color);
+  align-items: center;
+  overflow: hidden;
+  outline: none;
 
   @include sbb.if-forced-colors {
     --sbb-breadcrumb-color: ButtonText;

--- a/src/elements/chip-label/chip-label.scss
+++ b/src/elements/chip-label/chip-label.scss
@@ -30,9 +30,7 @@
 .sbb-chip-label {
   @include sbb.chip-label-rules;
 
-  & {
-    display: flex;
-  }
+  display: flex;
 }
 
 .sbb-chip__text-wrapper {

--- a/src/elements/core/styles/core.scss
+++ b/src/elements/core/styles/core.scss
@@ -269,15 +269,13 @@ html {
   :where(textarea) {
     @include scrollbar.scrollbar;
 
-    & {
-      position: relative;
-      resize: none;
+    position: relative;
+    resize: none;
 
-      // White-space break needed for Firefox
-      white-space: break-spaces;
-      overflow-y: auto;
-      min-height: calc((var(--sbb-typo-line-height-text) * 1em));
-    }
+    // White-space break needed for Firefox
+    white-space: break-spaces;
+    overflow-y: auto;
+    min-height: calc((var(--sbb-typo-line-height-text) * 1em));
   }
 
   &[size='l'] :where(textarea) {

--- a/src/elements/core/styles/mixins/link.scss
+++ b/src/elements/core/styles/mixins/link.scss
@@ -107,14 +107,11 @@
 @mixin link-consolidation {
   @include typo.text-inherit;
   @include link-base;
+  @include link-focus-visible;
+  @include link-hover;
 
-  & {
-    @include link-focus-visible;
-    @include link-hover;
-
-    // Active definitions have to be after :hover definitions
-    @include link-active;
-  }
+  // Active definitions have to be after :hover definitions
+  @include link-active;
 }
 
 @mixin link {

--- a/src/elements/core/styles/mixins/pearl-chain-bullet.scss
+++ b/src/elements/core/styles/mixins/pearl-chain-bullet.scss
@@ -107,10 +107,7 @@
 @mixin pearl-chain-bullet-position {
   @include pearl-chain-bullet-start-end;
   @include pearl-chain-bullet;
-
-  & {
-    @include pearl-chain-bullet-disruption;
-  }
+  @include pearl-chain-bullet-disruption;
 
   @keyframes pearl-chain-bullet-position-pulse {
     0% {
@@ -131,8 +128,6 @@
     }
   }
 
-  & {
-    animation: pearl-chain-bullet-position-pulse var(--sbb-pearl-chain-bullet-animation-duration)
-      var(--sbb-pearl-chain-bullet-animation-easing) infinite;
-  }
+  animation: pearl-chain-bullet-position-pulse var(--sbb-pearl-chain-bullet-animation-duration)
+    var(--sbb-pearl-chain-bullet-animation-easing) infinite;
 }

--- a/src/elements/core/styles/mixins/scrollbar.scss
+++ b/src/elements/core/styles/mixins/scrollbar.scss
@@ -40,6 +40,7 @@
   //  We have to use the `not` selector as Chrome supports both, the -webkit-* and the following properties.
   //  As long as possible we use the -webkit-* approach as we have more styling possibilities there.
   @supports not selector(::-webkit-scrollbar) {
+    // stylelint-disable-next-line block-no-redundant-nested-style-rules
     & {
       scrollbar-width: var(--sbb-scrollbar-width-firefox);
       scrollbar-color: var(--sbb-scrollbar-color, currentcolor)

--- a/src/elements/core/styles/mixins/table.scss
+++ b/src/elements/core/styles/mixins/table.scss
@@ -8,23 +8,21 @@
   @include table--m;
   @include table--striped;
 
-  & {
-    --sbb-table-border: var(--sbb-border-width-1x) solid var(--sbb-table-border-color);
-    --sbb-table-border-color: light-dark(var(--sbb-color-cloud), var(--sbb-color-anthracite));
-    --sbb-table-background-color: var(--sbb-background-color-1);
-    --sbb-table-row-striped-color: var(--sbb-background-color-3);
-    --sbb-table-color: var(--sbb-color-1);
-    --sbb-table-caption-color: light-dark(var(--sbb-color-granite), var(--sbb-color-cement));
-    --sbb-table-caption-margin-block-start: var(--sbb-spacing-fixed-4x);
-    --sbb-table-sticky-shadow-width: 3rem;
-    --sbb-table-sticky-shadow-transition-easing: var(--sbb-animation-easing);
-    --sbb-table-sticky-shadow-transition-duration: var(--sbb-animation-duration-6x);
+  --sbb-table-border: var(--sbb-border-width-1x) solid var(--sbb-table-border-color);
+  --sbb-table-border-color: light-dark(var(--sbb-color-cloud), var(--sbb-color-anthracite));
+  --sbb-table-background-color: var(--sbb-background-color-1);
+  --sbb-table-row-striped-color: var(--sbb-background-color-3);
+  --sbb-table-color: var(--sbb-color-1);
+  --sbb-table-caption-color: light-dark(var(--sbb-color-granite), var(--sbb-color-cement));
+  --sbb-table-caption-margin-block-start: var(--sbb-spacing-fixed-4x);
+  --sbb-table-sticky-shadow-width: 3rem;
+  --sbb-table-sticky-shadow-transition-easing: var(--sbb-animation-easing);
+  --sbb-table-sticky-shadow-transition-duration: var(--sbb-animation-duration-6x);
 
-    border-spacing: 0;
-    caption-side: bottom;
-    color: var(--sbb-table-color);
-    table-layout: auto;
-  }
+  border-spacing: 0;
+  caption-side: bottom;
+  color: var(--sbb-table-color);
+  table-layout: auto;
 
   thead {
     & > tr {

--- a/src/elements/link/common/link.scss
+++ b/src/elements/link/common/link.scss
@@ -15,14 +15,12 @@ $disabled: '[disabled], :disabled, [disabled-interactive]';
 .sbb-action-base {
   @include sbb.link-base;
 
-  & {
-    display: flex;
-    align-items: center;
-    width: 100%;
-    cursor: var(--sbb-cursor-pointer);
-    padding: var(--sbb-link-padding, 0);
-    outline: none;
-  }
+  display: flex;
+  align-items: center;
+  width: 100%;
+  cursor: var(--sbb-cursor-pointer);
+  padding: var(--sbb-link-padding, 0);
+  outline: none;
 
   :host(:is(#{$disabled})) & {
     pointer-events: none;

--- a/src/elements/map-container/map-container.scss
+++ b/src/elements/map-container/map-container.scss
@@ -75,24 +75,22 @@
 .sbb-map-container__sidebar {
   @include sbb.scrollbar($size: thick, $track-visible: true);
 
-  & {
-    grid-column: 1 / 3;
-    grid-row: 2 / 3;
-    width: 100%;
-    overflow: hidden auto;
-    position: relative;
-    border-start-end-radius: var(--sbb-map-container-border-radius);
-    border-start-start-radius: var(--sbb-map-container-border-radius);
-    margin-block-start: calc(var(--sbb-map-container-border-radius) * -1);
-    background-color: var(--sbb-map-container-sidebar-background-color);
+  grid-column: 1 / 3;
+  grid-row: 2 / 3;
+  width: 100%;
+  overflow: hidden auto;
+  position: relative;
+  border-start-end-radius: var(--sbb-map-container-border-radius);
+  border-start-start-radius: var(--sbb-map-container-border-radius);
+  margin-block-start: calc(var(--sbb-map-container-border-radius) * -1);
+  background-color: var(--sbb-map-container-sidebar-background-color);
 
-    @include sbb.mq($from: large) {
-      grid-column: 1 / 2;
-      grid-row: 1 / 3;
-      border-radius: 0;
-      margin-block-start: 0;
-      border-block-start: var(--sbb-border-width-1x) solid var(--sbb-border-color-4-inverted);
-    }
+  @include sbb.mq($from: large) {
+    grid-column: 1 / 2;
+    grid-row: 1 / 3;
+    border-radius: 0;
+    margin-block-start: 0;
+    border-block-start: var(--sbb-border-width-1x) solid var(--sbb-border-color-4-inverted);
   }
 }
 

--- a/src/elements/menu/menu/menu.scss
+++ b/src/elements/menu/menu/menu.scss
@@ -193,12 +193,10 @@ sbb-divider,
 .sbb-menu__content {
   @include sbb.scrollbar-rules;
 
-  & {
-    max-height: var(--sbb-menu-max-height);
-    padding-block: var(--sbb-spacing-fixed-1x);
-    overflow: auto;
-    outline: none;
-  }
+  max-height: var(--sbb-menu-max-height);
+  padding-block: var(--sbb-spacing-fixed-1x);
+  overflow: auto;
+  outline: none;
 
   // Margin bottom in mobile variant
   &::after {

--- a/src/elements/navigation/navigation-section/navigation-section.scss
+++ b/src/elements/navigation/navigation-section/navigation-section.scss
@@ -117,17 +117,15 @@
 .sbb-navigation-section__wrapper {
   @include sbb.scrollbar($negative: true);
 
-  & {
-    height: 100%;
-    padding-block: var(--sbb-navigation-section-padding-block);
-    outline: none;
-    overflow-y: auto;
+  height: 100%;
+  padding-block: var(--sbb-navigation-section-padding-block);
+  outline: none;
+  overflow-y: auto;
 
-    :host(:is(:state(state-opening), :state(state-closing))) & {
-      --sbb-scrollbar-color: transparent;
+  :host(:is(:state(state-opening), :state(state-closing))) & {
+    --sbb-scrollbar-color: transparent;
 
-      scrollbar-color: transparent transparent;
-    }
+    scrollbar-color: transparent transparent;
   }
 }
 

--- a/src/elements/navigation/navigation/navigation.scss
+++ b/src/elements/navigation/navigation/navigation.scss
@@ -196,17 +196,15 @@
   @include transition(translate);
   @include sbb.scrollbar($negative: true);
 
-  & {
-    display: flex;
-    flex-direction: column;
-    gap: var(--sbb-spacing-responsive-xxl);
-    position: relative;
-    height: var(--sbb-navigation-height);
-    padding-inline: var(--sbb-navigation-padding-inline);
-    padding-block: var(--sbb-navigation-padding-block-start) var(--sbb-navigation-padding-block-end);
-    overflow-y: auto;
-    translate: var(--sbb-navigation-content-translate);
-  }
+  display: flex;
+  flex-direction: column;
+  gap: var(--sbb-spacing-responsive-xxl);
+  position: relative;
+  height: var(--sbb-navigation-height);
+  padding-inline: var(--sbb-navigation-padding-inline);
+  padding-block: var(--sbb-navigation-padding-block-start) var(--sbb-navigation-padding-block-end);
+  overflow-y: auto;
+  translate: var(--sbb-navigation-content-translate);
 }
 
 ::slotted(:first-child) {

--- a/src/elements/overlay/overlay.scss
+++ b/src/elements/overlay/overlay.scss
@@ -125,11 +125,9 @@
 .sbb-overlay__content {
   @include sbb.scrollbar-rules;
 
-  & {
-    height: 100vh;
-    overflow: auto;
-    -webkit-overflow-scrolling: touch;
-  }
+  height: 100vh;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .sbb-overlay__content-container {

--- a/src/elements/sidebar/sidebar/sidebar.scss
+++ b/src/elements/sidebar/sidebar/sidebar.scss
@@ -102,19 +102,17 @@
 .sbb-sidebar-content-section {
   @include sbb.scrollbar;
 
-  & {
-    padding-block-start: var(--sbb-sidebar__padding-block-start);
-    padding-inline: var(--sbb-sidebar-padding) var(--sbb-sidebar__padding-inline-end);
-    overflow-y: auto;
-    flex-grow: 1;
+  padding-block-start: var(--sbb-sidebar__padding-block-start);
+  padding-inline: var(--sbb-sidebar-padding) var(--sbb-sidebar__padding-inline-end);
+  overflow-y: auto;
+  flex-grow: 1;
 
-    // If the element is scrollable and has no focusable content, it gets focused.
-    // To adapt to lyne styles we colorize it
-    outline-color: var(--sbb-focus-outline-color);
+  // If the element is scrollable and has no focusable content, it gets focused.
+  // To adapt to lyne styles we colorize it
+  outline-color: var(--sbb-focus-outline-color);
 
-    @supports (scrollbar-gutter: stable) {
-      scrollbar-gutter: stable;
-    }
+  @supports (scrollbar-gutter: stable) {
+    scrollbar-gutter: stable;
   }
 }
 

--- a/src/elements/teaser-hero/teaser-hero.scss
+++ b/src/elements/teaser-hero/teaser-hero.scss
@@ -35,10 +35,7 @@
   z-index: 1;
 
   @include sbb.panel;
-
-  & {
-    @include sbb.absolute-center-y;
-  }
+  @include sbb.absolute-center-y;
 
   // Hide panel when no content or link-content is provided.
   :host(:not(:state(slotted), :state(slotted-link-content), [link-content])) & {

--- a/src/elements/train/train-formation/train-formation.scss
+++ b/src/elements/train/train-formation/train-formation.scss
@@ -20,19 +20,17 @@
 .sbb-train-formation {
   @include sbb.scrollbar;
 
-  & {
-    display: grid;
-    grid-template:
-      'start sectors end' auto
-      'start trains end' auto / auto 1fr auto;
-    position: relative;
-    overflow-x: auto;
-    row-gap: calc(
-      var(--sbb-train-formation-show-sectors-gap, 0) * var(--sbb-train-formation-vertical-gap)
-    );
-    padding-block-end: var(--sbb-train-formation-vertical-gap);
-    color: var(--sbb-train-formation-text-color);
-  }
+  display: grid;
+  grid-template:
+    'start sectors end' auto
+    'start trains end' auto / auto 1fr auto;
+  position: relative;
+  overflow-x: auto;
+  row-gap: calc(
+    var(--sbb-train-formation-show-sectors-gap, 0) * var(--sbb-train-formation-vertical-gap)
+  );
+  padding-block-end: var(--sbb-train-formation-vertical-gap);
+  color: var(--sbb-train-formation-text-color);
 
   &:focus-visible {
     @include sbb.focus-outline;


### PR DESCRIPTION
Note:
on `scrollbar.scss` the `@supports` rule needs a selector as specified in the `no-invalid-position-declaration` rule https://stylelint.io/user-guide/rules/no-invalid-position-declaration/
but the rules needs to be applied on the same element, so the `$ {...}` can't be removed.