### PR TITLE
fix(sbb-calendar): avoid inconsistent label when aborting selection

### DIFF
--- a/src/elements/calendar/calendar.component.ts
+++ b/src/elements/calendar/calendar.component.ts
@@ -1248,6 +1248,7 @@ class SbbCalendarElement<T = Date> extends SbbHydrationMixin(SbbElementInternals
       this._dateAdapter.today();
     this._setChosenYear();
     this._chosenMonth = undefined;
+    this._init();
     this._nextCalendarView = this._calendarView = this.view;
 
     if (initTransition) {

--- a/src/elements/calendar/calendar.spec.ts
+++ b/src/elements/calendar/calendar.spec.ts
@@ -254,6 +254,49 @@ describe(`sbb-calendar`, () => {
 
       const dayCells = Array.from(element.shadowRoot!.querySelectorAll('.sbb-calendar__day'));
       expect(dayCells.length).to.be.equal(31);
+      expect((dayCells[0] as HTMLButtonElement).value).to.be.equal('2023-01-01');
+    });
+
+    it('reset view if day is not selected when year/month are changed', async () => {
+      // We move from Dec 2023 to Sep 2030
+      const yearSelectionButton: HTMLElement = element.shadowRoot!.querySelector(
+        '.sbb-calendar__date-selection',
+      )!;
+      expect(yearSelectionButton).not.to.be.null;
+      yearSelectionButton.click();
+      await waitForTransition();
+
+      const yearButton: HTMLButtonElement =
+        element.shadowRoot!.querySelector<HTMLButtonElement>('[data-year="2030"]')!;
+      expect(yearButton).not.to.be.null;
+      yearButton.click();
+      await waitForTransition();
+
+      const monthCells: HTMLElement[] = Array.from(
+        element.shadowRoot!.querySelectorAll('.sbb-calendar__table-month'),
+      );
+      expect(monthCells.length).to.be.equal(12);
+      monthCells[8].querySelector('button')!.click();
+      await waitForLitRender(element);
+      await waitForTransition();
+
+      const dayCells = Array.from(element.shadowRoot!.querySelectorAll('.sbb-calendar__day'));
+      expect(dayCells.length).to.be.equal(30);
+      expect((dayCells[0] as HTMLButtonElement).value).to.be.equal('2030-09-01');
+
+      // Without selecting a day, change to the year view
+      yearSelectionButton.click();
+      await waitForTransition();
+      // Go back to day view again by clicking once more
+      const monthSelection: HTMLElement = element.shadowRoot!.querySelector(
+        '#sbb-calendar__year-selection',
+      )!;
+      monthSelection.click();
+      await waitForTransition();
+      // We expect to be in the month of the selected day (Dec 2023)
+      const dayCells2 = Array.from(element.shadowRoot!.querySelectorAll('.sbb-calendar__day'));
+      expect(dayCells2.length).to.be.equal(31);
+      expect((dayCells2[0] as HTMLButtonElement).value).to.be.equal('2023-01-01');
     });
 
     it('opens year view', async () => {


### PR DESCRIPTION
Closes #4308

When the calendar is loaded, the day view shows a month (or two in wide) based on the currently calculated 'week' array, which is based on the activeDate.
On the other hand, the month label on top is calculated based again on the activeDate.

When the year / month is changed, the new day view is reloaded using a temporary activeDate, which is calculated based on the chosen values for year and month and the same day of the 'real' active date.

Since this date is temporary, the value is not saved; if users change again to year/month view and then exit as discussed in #4308, the month label is recalculated based on the 'real' active date (meaning: the selected, or today).

To fix this misalignment, the 'init' method is called when the view is reset, so the view always matches the active date.