### PR TITLE
fix(sbb-autocomplete): fix border radius gap in Safari

### DIFF
--- a/src/elements-experimental/autocomplete-grid/autocomplete-grid/autocomplete-grid.visual.spec.ts
+++ b/src/elements-experimental/autocomplete-grid/autocomplete-grid/autocomplete-grid.visual.spec.ts
@@ -359,5 +359,15 @@ describe('sbb-autocomplete-grid', () => {
         setup.withPostSetupAction(() => openAutocomplete(setup));
       }),
     );
+
+    it(
+      'custom background gap fix',
+      visualDiffFocus.with(async (setup) => {
+        await setup.withFixture(template(defaultArgs));
+        setup.snapshotElement.style.backgroundColor = 'red';
+
+        setup.withPostSetupAction(() => openAutocomplete(setup));
+      }),
+    );
   });
 });

--- a/src/elements/autocomplete/autocomplete.visual.spec.ts
+++ b/src/elements/autocomplete/autocomplete.visual.spec.ts
@@ -336,5 +336,15 @@ describe('sbb-autocomplete', () => {
         setup.withPostSetupAction(() => openAutocomplete(setup));
       }),
     );
+
+    it(
+      'custom background gap fix',
+      visualDiffFocus.with(async (setup) => {
+        await setup.withFixture(template(defaultArgs));
+        setup.snapshotElement.style.backgroundColor = 'red';
+
+        setup.withPostSetupAction(() => openAutocomplete(setup));
+      }),
+    );
   });
 });

--- a/src/elements/core/styles/mixins/overlay.scss
+++ b/src/elements/core/styles/mixins/overlay.scss
@@ -128,6 +128,13 @@
   .sbb-gap-fix-wrapper {
     position: relative;
     overflow: hidden;
+
+    // In Safari there is a bug where overflow: hidden doesn't have the required effect.
+    // Overflow: auto helps here.
+    @supports (font: -apple-system-body) {
+      overflow: auto;
+    }
+
     width: $radius;
     height: $radius;
     background-color: transparent;


### PR DESCRIPTION
Related to #4318 