### PR TITLE
fix(sbb-dialog, sbb-overlay): allow opening when shadow DOM not ready

### DIFF
--- a/src/elements/dialog/dialog/dialog.component.ts
+++ b/src/elements/dialog/dialog/dialog.component.ts
@@ -114,9 +114,9 @@ class SbbDialogElement extends SbbOverlayBaseElement {
     this.escapableOverlayController.connect();
     this.attachOpenOverlayEvents();
     this.focusTrapController.focusInitialElement();
+    this.focusTrapController.enabled = true;
     // Use timeout to read label after focused element
     setTimeout(() => this.announceTitle());
-    this.focusTrapController.enabled = true;
 
     const contentElement = this._contentElement();
     if (contentElement) {
@@ -127,6 +127,11 @@ class SbbDialogElement extends SbbOverlayBaseElement {
 
   protected override firstUpdated(changedProperties: PropertyValues<this>): void {
     super.firstUpdated(changedProperties);
+
+    // If the component is already open on firstUpdate, announce the title
+    if (this.isOpen) {
+      this.announceTitle();
+    }
 
     this._syncTitleNegative();
   }

--- a/src/elements/dialog/dialog/dialog.spec.ts
+++ b/src/elements/dialog/dialog/dialog.spec.ts
@@ -1,4 +1,4 @@
-import { assert, expect, fixture } from '@open-wc/testing';
+import { assert, aTimeout, expect, fixture } from '@open-wc/testing';
 import { sendKeys, setViewport } from '@web/test-runner-commands';
 import { html } from 'lit/static-html.js';
 
@@ -482,7 +482,8 @@ describe('sbb-dialog', () => {
 
     it('configures trigger', () => {
       expect(trigger.ariaHasPopup).to.be.equal('dialog');
-      expect(trigger.getAttribute('aria-controls')).to.be.equal('sbb-dialog-0');
+      const ariaControlsId = trigger.getAttribute('aria-controls');
+      expect(element.id).to.be.equal(ariaControlsId);
       expect(trigger.getAttribute('aria-expanded')).to.be.equal('false');
 
       trigger.click();
@@ -834,5 +835,29 @@ describe('sbb-dialog', () => {
     await closeSpy.calledOnce();
     expect(dialog).to.match(':state(state-closed)');
     expect(nestedDialog).to.match(':state(state-closed)');
+  });
+
+  it('handles opening without first rendering', async () => {
+    const button = document.createElement('button');
+    button.textContent = 'Button';
+    const content = document.createElement('sbb-dialog-content');
+    content.appendChild(button);
+    const element = document.createElement('sbb-dialog');
+    element.appendChild(content);
+    document.body.appendChild(element);
+
+    element.open();
+
+    await waitForLitRender(element);
+    expect(element.shadowRoot?.querySelector('sbb-screen-reader-only')).to.have.trimmed.text(
+      'Dialog',
+    );
+
+    // Wait until setTimeout of overlay base kicks in.
+    await aTimeout(0);
+
+    expect(document.activeElement).to.be.equal(button);
+
+    element.remove();
   });
 });

--- a/src/elements/overlay/overlay-base-element.ts
+++ b/src/elements/overlay/overlay-base-element.ts
@@ -58,7 +58,7 @@ export abstract class SbbOverlayBaseElement extends SbbNegativeMixin(SbbOpenClos
   protected escapableOverlayController = new SbbEscapableOverlayController(this);
 
   private _ariaLiveRefToggle = false;
-  private _ariaLiveRef!: SbbScreenReaderOnlyElement;
+  private _ariaLiveRef?: SbbScreenReaderOnlyElement;
   private _triggerElement: HTMLElement | null = null;
   private _triggerAbortController!: AbortController;
 
@@ -158,6 +158,15 @@ export abstract class SbbOverlayBaseElement extends SbbNegativeMixin(SbbOpenClos
     this._ariaLiveRef =
       this.shadowRoot!.querySelector<SbbScreenReaderOnlyElement>('sbb-screen-reader-only')!;
     this._configureTrigger();
+
+    // If the component is already open on firstUpdate, fix the focus
+    if (this.isOpen) {
+      // TODO: find better solution
+      // Problem: content's shadow DOM not yet ready, so focusing is impossible.
+      setTimeout(() => {
+        this.focusTrapController.focusInitialElement();
+      }, 0);
+    }
   }
 
   public override disconnectedCallback(): void {
@@ -230,10 +239,17 @@ export abstract class SbbOverlayBaseElement extends SbbNegativeMixin(SbbOpenClos
   }
 
   protected removeAriaLiveRefContent(): void {
+    if (!this._ariaLiveRef) {
+      return;
+    }
     this._ariaLiveRef.textContent = '';
   }
 
   protected setAriaLiveRefContent(label?: string): void {
+    if (!this._ariaLiveRef) {
+      return;
+    }
+
     this._ariaLiveRefToggle = !this._ariaLiveRefToggle;
 
     // If the text content remains the same, on VoiceOver the aria-live region is not announced a second time.

--- a/src/elements/overlay/overlay.component.ts
+++ b/src/elements/overlay/overlay.component.ts
@@ -1,4 +1,4 @@
-import type { CSSResultGroup, TemplateResult } from 'lit';
+import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { ref } from 'lit/directives/ref.js';
 import { html } from 'lit/static-html.js';
@@ -60,6 +60,15 @@ class SbbOverlayElement extends SbbOverlayBaseElement {
     this.id ||= `sbb-overlay-${nextId++}`;
 
     super.connectedCallback();
+  }
+
+  protected override firstUpdated(changedProperties: PropertyValues<this>): void {
+    super.firstUpdated(changedProperties);
+
+    // If the component is already open on firstUpdate, announce the title
+    if (this.isOpen) {
+      this.setAriaLiveRefContent();
+    }
   }
 
   protected isZeroAnimationDuration(): boolean {


### PR DESCRIPTION
Closes https://github.com/sbb-design-systems/lyne-angular/issues/243