### PR TITLE
fix(sbb-dialog, sbb-overlay): prevent throwing if nested overlay gets removed from DOM

### DIFF
--- a/src/elements/dialog/dialog/dialog.spec.ts
+++ b/src/elements/dialog/dialog/dialog.spec.ts
@@ -831,6 +831,9 @@ describe('sbb-dialog', () => {
     expect(dialog).to.match(':state(state-opened)');
     expect(nestedDialog).to.match(':state(state-closed)');
 
+    // Should not throw when dialog was removed from DOM before closing
+    nestedDialog.remove();
+
     closeButton.click();
     await closeSpy.calledOnce();
     expect(dialog).to.match(':state(state-closed)');

--- a/src/elements/overlay/overlay-base-element.ts
+++ b/src/elements/overlay/overlay-base-element.ts
@@ -208,7 +208,10 @@ export abstract class SbbOverlayBaseElement extends SbbNegativeMixin(SbbOpenClos
   }
 
   protected removeInstanceFromGlobalCollection(): void {
-    overlayRefs.splice(overlayRefs.indexOf(this as SbbOverlayBaseElement), 1);
+    const indexInOverlayRefs = overlayRefs.indexOf(this as SbbOverlayBaseElement);
+    if (indexInOverlayRefs > -1) {
+      overlayRefs.splice(indexInOverlayRefs, 1);
+    }
   }
 
   // Close the component on click of any element that has the `closeAttribute` attribute.
@@ -235,7 +238,9 @@ export abstract class SbbOverlayBaseElement extends SbbNegativeMixin(SbbOpenClos
       overlayCloseElement.getAttribute('type') === 'submit'
         ? ((overlayCloseElement as HTMLButtonElement | SbbButtonBaseElement).form ?? null)
         : null;
-    overlayRefs[overlayRefs.length - 1].close(closestForm, overlayCloseElement);
+    if (overlayRefs.length) {
+      overlayRefs[overlayRefs.length - 1].close(closestForm, overlayCloseElement);
+    }
   }
 
   protected removeAriaLiveRefContent(): void {


### PR DESCRIPTION
Previously, in a nested dialog context, if closing the inner dialog and removing it from DOM, closing the second dialog would result in an exception. This is due to the splice method was called with `-1` during disconnection of the inner dialog. Therefore the second dialog was already removed from the overlayRefs. Closing it then throws.
This situation happens with the Angular Services where every dialog is removed from DOM after closing.