### PR TITLE
fix(sbb-autocomplete, sbb-autocomplete-grid): remove Enter as opening criteria

### DIFF
--- a/src/elements/autocomplete/autocomplete-base-element.ts
+++ b/src/elements/autocomplete/autocomplete-base-element.ts
@@ -591,7 +591,6 @@ export abstract class SbbAutocompleteBaseElement<T = string> extends SbbNegative
     }
 
     switch (event.key) {
-      case 'Enter':
       case 'ArrowDown':
       case 'ArrowUp':
         this.open();


### PR DESCRIPTION
Using `Enter` as an opening criteria interferes with the native functionality of submitting the form. Due to this, we remove it as a trigger.