### PR TITLE
docs: support dark mode for collapsed doc sections

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -57,6 +57,10 @@
     color: var(--sbb-color-charcoal);
   }
 
+  .docs-story {
+    background-color: var(--sbb-background-color-1);
+  }
+
   .sb-show-main.sb-main-padded {
     padding: 2rem;
   }


### PR DESCRIPTION
This PR Closes #4282

The problem only happens in Chrome with the dark theme enabled

Co-author: @OkanBostan 