### PR TITLE
fix(sbb-navigation): fix inert state for large breakpoint

### DIFF
--- a/src/elements/navigation/navigation-section/navigation-section.component.ts
+++ b/src/elements/navigation/navigation-section/navigation-section.component.ts
@@ -18,7 +18,7 @@ import { SbbOpenCloseBaseElement } from '../../core/base-elements/open-close-bas
 import {
   SbbLanguageController,
   SbbMediaMatcherController,
-  SbbMediaQueryBreakpointLargeAndBelow,
+  SbbMediaQueryBreakpointSmallAndBelow,
 } from '../../core/controllers.ts';
 import { forceType, idReference, omitEmptyConverter } from '../../core/decorators.ts';
 import { isZeroAnimationDuration } from '../../core/dom.ts';
@@ -98,7 +98,7 @@ class SbbNavigationSectionElement extends SbbUpdateSchedulerMixin(SbbOpenCloseBa
   private _focusTrapController = new SbbFocusTrapController(this);
   private _lastKeydownEvent: KeyboardEvent | null = null;
   private _mediaMatcherController = new SbbMediaMatcherController(this, {
-    [SbbMediaQueryBreakpointLargeAndBelow]: (matches) => {
+    [SbbMediaQueryBreakpointSmallAndBelow]: (matches) => {
       if (this.state !== 'closed') {
         this._setNavigationInert(matches);
       }
@@ -304,7 +304,7 @@ class SbbNavigationSectionElement extends SbbUpdateSchedulerMixin(SbbOpenCloseBa
   }
 
   private _isBelowLarge(): boolean {
-    return this._mediaMatcherController.matches(SbbMediaQueryBreakpointLargeAndBelow) ?? false;
+    return this._mediaMatcherController.matches(SbbMediaQueryBreakpointSmallAndBelow) ?? false;
   }
 
   // Closes the navigation on "Esc" key pressed.

--- a/src/elements/navigation/navigation-section/navigation-section.spec.ts
+++ b/src/elements/navigation/navigation-section/navigation-section.spec.ts
@@ -5,6 +5,7 @@ import type { Context } from 'mocha';
 
 import {
   fixture,
+  sbbBreakpointLargeMinPx,
   sbbBreakpointSmallMinPx,
   sbbBreakpointUltraMinPx,
   tabKey,
@@ -135,6 +136,31 @@ describe(`sbb-navigation-section`, () => {
     element.trigger = null;
     await waitForLitRender(element);
     expect(trigger.ariaHasPopup).to.be.null;
+  });
+
+  it('add and remove inert on navigation content when switching breakpoints', async function () {
+    // Flaky on Webkit
+    this.retries(3);
+
+    element.open();
+    await waitForLitRender(element);
+
+    await waitForCondition(() => element.matches(':state(state-opened)'));
+    expect(element).to.match(':state(state-opened)');
+
+    await setViewport({ width: sbbBreakpointLargeMinPx, height: 600 });
+    await aTimeout(30);
+    expect(
+      root.shadowRoot!.querySelector<HTMLElement>('.sbb-navigation__content')!.inert,
+      'large viewport',
+    ).to.be.false;
+
+    await setViewport({ width: sbbBreakpointSmallMinPx, height: 600 });
+    await aTimeout(30);
+    expect(
+      root.shadowRoot!.querySelector<HTMLElement>('.sbb-navigation__content')!.inert,
+      'small viewport',
+    ).to.be.true;
   });
 
   describe('on desktop viewport', () => {


### PR DESCRIPTION
Currently the navigation buttons are not clickable when on large breakpoint and the navigation has sections.
This is due to inert being mistakenly set for large breakpoints, which this PR fixes.