### PR TITLE
build: migrate accessibility testing to CDPSession usage

### DIFF
--- a/src/elements-experimental/autocomplete-grid/autocomplete-grid-button/__snapshots__/autocomplete-grid-button.snapshot.spec.snap.js
+++ b/src/elements-experimental/autocomplete-grid/autocomplete-grid-button/__snapshots__/autocomplete-grid-button.snapshot.spec.snap.js
@@ -60,8 +60,8 @@ snapshots["sbb-autocomplete-grid-button renders negative without icon Shadow DOM
 snapshots["sbb-autocomplete-grid-button A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
@@ -72,20 +72,4 @@ snapshots["sbb-autocomplete-grid-button A11y tree Chrome"] =
 </p>
 `;
 /* end snapshot sbb-autocomplete-grid-button A11y tree Chrome */
-
-snapshots["sbb-autocomplete-grid-button A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": ""
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-autocomplete-grid-button A11y tree Firefox */
 

--- a/src/elements-experimental/autocomplete-grid/autocomplete-grid-cell/__snapshots__/autocomplete-grid-cell.snapshot.spec.snap.js
+++ b/src/elements-experimental/autocomplete-grid/autocomplete-grid-cell/__snapshots__/autocomplete-grid-cell.snapshot.spec.snap.js
@@ -23,32 +23,18 @@ snapshots["sbb-autocomplete-grid-cell renders Shadow DOM"] =
 snapshots["sbb-autocomplete-grid-cell A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": ""
+      "role": "gridcell",
+      "name": "",
+      "readonly": false,
+      "required": false
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-autocomplete-grid-cell A11y tree Chrome */
-
-snapshots["sbb-autocomplete-grid-cell A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": ""
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-autocomplete-grid-cell A11y tree Firefox */
 

--- a/src/elements-experimental/autocomplete-grid/autocomplete-grid-optgroup/__snapshots__/autocomplete-grid-optgroup.snapshot.spec.snap.js
+++ b/src/elements-experimental/autocomplete-grid/autocomplete-grid-optgroup/__snapshots__/autocomplete-grid-optgroup.snapshot.spec.snap.js
@@ -79,31 +79,17 @@ snapshots["sbb-autocomplete-grid-optgroup renders Chrome-Firefox Shadow DOM"] =
 `;
 /* end snapshot sbb-autocomplete-grid-optgroup renders Chrome-Firefox Shadow DOM */
 
-snapshots["sbb-autocomplete-grid-optgroup A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Option 1"
-    },
-    {
-      "role": "text leaf",
-      "name": "Option 2"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-autocomplete-grid-optgroup A11y tree Firefox */
-
 snapshots["sbb-autocomplete-grid-optgroup A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "role": "group",
+      "name": "Group"
+    }
+  ]
 }
 </p>
 `;

--- a/src/elements-experimental/autocomplete-grid/autocomplete-grid-option/__snapshots__/autocomplete-grid-option.snapshot.spec.snap.js
+++ b/src/elements-experimental/autocomplete-grid/autocomplete-grid-option/__snapshots__/autocomplete-grid-option.snapshot.spec.snap.js
@@ -63,26 +63,19 @@ snapshots["sbb-autocomplete-grid-option renders disabled Shadow DOM"] =
 snapshots["sbb-autocomplete-grid-option A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-autocomplete-grid-option A11y tree Chrome */
-
-snapshots["sbb-autocomplete-grid-option A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text leaf",
-      "name": "Option 1"
+      "role": "gridcell",
+      "name": "Option 1",
+      "readonly": false,
+      "required": false,
+      "selected": false
     }
   ]
 }
 </p>
 `;
-/* end snapshot sbb-autocomplete-grid-option A11y tree Firefox */
+/* end snapshot sbb-autocomplete-grid-option A11y tree Chrome */
 

--- a/src/elements-experimental/autocomplete-grid/autocomplete-grid-row/__snapshots__/autocomplete-grid-row.snapshot.spec.snap.js
+++ b/src/elements-experimental/autocomplete-grid/autocomplete-grid-row/__snapshots__/autocomplete-grid-row.snapshot.spec.snap.js
@@ -28,34 +28,14 @@ snapshots["sbb-autocomplete-grid-row renders Shadow DOM"] =
 `;
 /* end snapshot sbb-autocomplete-grid-row renders Shadow DOM */
 
-snapshots["sbb-autocomplete-grid-row A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Option 1"
-    },
-    {
-      "role": "button",
-      "name": ""
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-autocomplete-grid-row A11y tree Firefox */
-
 snapshots["sbb-autocomplete-grid-row A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
+      "role": "row",
       "name": ""
     }
   ]

--- a/src/elements-experimental/autocomplete-grid/autocomplete-grid/__snapshots__/autocomplete-grid.snapshot.spec.snap.js
+++ b/src/elements-experimental/autocomplete-grid/autocomplete-grid/__snapshots__/autocomplete-grid.snapshot.spec.snap.js
@@ -127,43 +127,29 @@ snapshots["sbb-autocomplete-grid Safari Shadow DOM"] =
 `;
 /* end snapshot sbb-autocomplete-grid Safari Shadow DOM */
 
-snapshots["sbb-autocomplete-grid Chrome-Firefox A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "statictext",
-      "name": "​"
-    },
-    {
-      "role": "combobox",
-      "name": "",
-      "autocomplete": "list",
-      "haspopup": "grid"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-autocomplete-grid Chrome-Firefox A11y tree Firefox */
-
 snapshots["sbb-autocomplete-grid Chrome-Firefox A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "​"
-    },
-    {
-      "role": "combobox",
-      "name": "",
-      "autocomplete": "list",
-      "haspopup": "grid"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "generic",
+          "name": ""
+        },
+        {
+          "role": "generic",
+          "name": ""
+        },
+        {
+          "ignored": true,
+          "role": "none"
+        }
+      ]
     }
   ]
 }

--- a/src/elements-experimental/pearl-chain-vertical-item/__snapshots__/pearl-chain-vertical-item.snapshot.spec.snap.js
+++ b/src/elements-experimental/pearl-chain-vertical-item/__snapshots__/pearl-chain-vertical-item.snapshot.spec.snap.js
@@ -225,20 +225,16 @@ snapshots["sbb-pearl-chain-vertical-item renders a crossed-bullet Shadow DOM"] =
 snapshots["sbb-pearl-chain-vertical-item renders component with charcoal standard line and bullet A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "role": "generic",
+      "name": ""
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-pearl-chain-vertical-item renders component with charcoal standard line and bullet A11y tree Chrome */
-
-snapshots["sbb-pearl-chain-vertical-item renders component with charcoal standard line and bullet A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-pearl-chain-vertical-item renders component with charcoal standard line and bullet A11y tree Firefox */
 

--- a/src/elements-experimental/pearl-chain-vertical/__snapshots__/pearl-chain-vertical.snapshot.spec.snap.js
+++ b/src/elements-experimental/pearl-chain-vertical/__snapshots__/pearl-chain-vertical.snapshot.spec.snap.js
@@ -18,20 +18,22 @@ snapshots["sbb-pearl-chain-vertical renders Shadow DOM"] =
 snapshots["sbb-pearl-chain-vertical renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "LayoutTable",
+          "name": ""
+        }
+      ]
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-pearl-chain-vertical renders A11y tree Chrome */
-
-snapshots["sbb-pearl-chain-vertical renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-pearl-chain-vertical renders A11y tree Firefox */
 

--- a/src/elements-experimental/seat-reservation/seat-reservation-navigation-coach/__snapshots__/seat-reservation-navigation-coach.snapshot.spec.snap.js
+++ b/src/elements-experimental/seat-reservation/seat-reservation-navigation-coach/__snapshots__/seat-reservation-navigation-coach.snapshot.spec.snap.js
@@ -44,50 +44,66 @@ snapshots["sbb-seat-reservation-navigation-coach renders a navigation coach Shad
 snapshots["sbb-seat-reservation-navigation-coach renders a navigation coach A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "Navigate to coach 85. 0 seats available. 0 available bicycle spaces.",
-      "description": "Available services: Bike area,Quiet zone"
-    },
-    {
-      "role": "text",
-      "name": "Available services: Bike area,Quiet zone"
-    },
-    {
-      "role": "text",
-      "name": "Available services:Bike area, Quiet zone"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "button",
+          "name": "Navigate to coach 85. 0 seats available. 0 available bicycle spaces.",
+          "description": "Available services: Bike area,Quiet zone",
+          "invalid": false,
+          "focusable": true,
+          "describedby": "nav-coach-service-descriptions-0"
+        },
+        {
+          "role": "generic",
+          "name": ""
+        },
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "role": "generic",
+                  "name": ""
+                },
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "ignored": true,
+                      "role": "none"
+                    }
+                  ]
+                },
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "ignored": true,
+                      "role": "none"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-seat-reservation-navigation-coach renders a navigation coach A11y tree Chrome */
-
-snapshots["sbb-seat-reservation-navigation-coach renders a navigation coach A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Navigate to coach 85. 0 seats available. 0 available bicycle spaces.",
-      "description": "Available services: Bike area,Quiet zone"
-    },
-    {
-      "role": "text leaf",
-      "name": "Available services: Bike area,Quiet zone"
-    },
-    {
-      "role": "text leaf",
-      "name": "Available services:Bike area, Quiet zone"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-seat-reservation-navigation-coach renders a navigation coach A11y tree Firefox */
 

--- a/src/elements-experimental/seat-reservation/seat-reservation-navigation-services/__snapshots__/seat-reservation-navigation-services.snapshot.spec.snap.js
+++ b/src/elements-experimental/seat-reservation/seat-reservation-navigation-services/__snapshots__/seat-reservation-navigation-services.snapshot.spec.snap.js
@@ -33,32 +33,42 @@ snapshots["sbb-seat-reservation-navigation-services renders Shadow DOM"] =
 snapshots["sbb-seat-reservation-navigation-services renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Available services:Bike area, Quiet zone"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "generic",
+          "name": ""
+        },
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none"
+            }
+          ]
+        },
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none"
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-seat-reservation-navigation-services renders A11y tree Chrome */
-
-snapshots["sbb-seat-reservation-navigation-services renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Available services:Bike area, Quiet zone"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-seat-reservation-navigation-services renders A11y tree Firefox */
 

--- a/src/elements-experimental/seat-reservation/seat-reservation/__snapshots__/seat-reservation.snapshot.spec.snap.js
+++ b/src/elements-experimental/seat-reservation/seat-reservation/__snapshots__/seat-reservation.snapshot.spec.snap.js
@@ -81,60 +81,49 @@ snapshots["sbb-seat-reservation renders Shadow DOM"] =
 snapshots["sbb-seat-reservation renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "Start Graphic Seat Reservation",
-      "disabled": true
-    },
-    {
-      "role": "list",
-      "name": "Seat reservation navigation"
-    },
-    {
-      "role": "button",
-      "name": "Exit Graphic Seat Reservation",
-      "disabled": true
-    },
-    {
-      "role": "generic",
-      "name": ""
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "role": "navigation",
+                  "name": ""
+                }
+              ]
+            },
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "ignored": true,
+                  "role": "none"
+                },
+                {
+                  "role": "generic",
+                  "name": "",
+                  "focusable": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-seat-reservation renders A11y tree Chrome */
-
-snapshots["sbb-seat-reservation renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Start Graphic Seat Reservation",
-      "disabled": true
-    },
-    {
-      "role": "list",
-      "name": "Seat reservation navigation"
-    },
-    {
-      "role": "button",
-      "name": "Exit Graphic Seat Reservation",
-      "disabled": true
-    },
-    {
-      "role": "section",
-      "name": ""
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-seat-reservation renders A11y tree Firefox */
 

--- a/src/elements-experimental/timetable-duration/__snapshots__/timetable-duration.snapshot.spec.snap.js
+++ b/src/elements-experimental/timetable-duration/__snapshots__/timetable-duration.snapshot.spec.snap.js
@@ -30,11 +30,11 @@ snapshots["sbb-timetable-duration renders Shadow DOM"] =
 snapshots["sbb-timetable-duration renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
+      "role": "paragraph",
       "name": "3 Hours 12 Minutes."
     }
   ]
@@ -42,20 +42,4 @@ snapshots["sbb-timetable-duration renders A11y tree Chrome"] =
 </p>
 `;
 /* end snapshot sbb-timetable-duration renders A11y tree Chrome */
-
-snapshots["sbb-timetable-duration renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "3 Hours 12 Minutes."
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-timetable-duration renders A11y tree Firefox */
 

--- a/src/elements-experimental/timetable-row/__snapshots__/timetable-row.snapshot.spec.snap.js
+++ b/src/elements-experimental/timetable-row/__snapshots__/timetable-row.snapshot.spec.snap.js
@@ -272,110 +272,18 @@ snapshots["sbb-timetable-row renders loading state Shadow DOM"] =
 snapshots["sbb-timetable-row renders defaultTrip A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "Departure: 11:08, Train, IR 37, Direction Basel SBB, Arrival: 12:13, Travel time 1 Hour 15 Minutes,"
-    },
-    {
-      "role": "text",
-      "name": "Train"
-    },
-    {
-      "role": "text",
-      "name": "  "
-    },
-    {
-      "role": "text",
-      "name": "Direction Basel SBB"
-    },
-    {
-      "role": "text",
-      "name": "Departure"
-    },
-    {
-      "role": "text",
-      "name": ": "
-    },
-    {
-      "role": "text",
-      "name": "11:08"
-    },
-    {
-      "role": "text",
-      "name": "Arrival"
-    },
-    {
-      "role": "text",
-      "name": ": "
-    },
-    {
-      "role": "text",
-      "name": "12:13"
-    },
-    {
-      "role": "text",
-      "name": "Travel time 1 Hour 15 Minutes"
+      "role": "rowgroup",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-timetable-row renders defaultTrip A11y tree Chrome */
-
-snapshots["sbb-timetable-row renders defaultTrip A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Departure: 11:08, Train, IR 37, Direction Basel SBB, Arrival: 12:13, Travel time 1 Hour 15 Minutes,"
-    },
-    {
-      "role": "text leaf",
-      "name": "Train"
-    },
-    {
-      "role": "text leaf",
-      "name": "Direction Basel SBB"
-    },
-    {
-      "role": "text leaf",
-      "name": "Departure"
-    },
-    {
-      "role": "text leaf",
-      "name": ": "
-    },
-    {
-      "role": "text leaf",
-      "name": "11:08"
-    },
-    {
-      "role": "text leaf",
-      "name": "Arrival"
-    },
-    {
-      "role": "text leaf",
-      "name": ": "
-    },
-    {
-      "role": "text leaf",
-      "name": "12:13"
-    },
-    {
-      "role": "text leaf",
-      "name": "Travel time 1 Hour 15 Minutes"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-timetable-row renders defaultTrip A11y tree Firefox */
 
 snapshots["sbb-timetable-row renders trip with access leg DOM"] = 
 `<sbb-timetable-row role="rowgroup">

--- a/src/elements/accordion/__snapshots__/accordion.snapshot.spec.snap.js
+++ b/src/elements/accordion/__snapshots__/accordion.snapshot.spec.snap.js
@@ -62,40 +62,106 @@ snapshots["sbb-accordion renders Shadow DOM"] =
 snapshots["sbb-accordion renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "Header 1"
-    },
-    {
-      "role": "button",
-      "name": "Header 2"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "ignored": true,
+                      "role": "none",
+                      "children": [
+                        {
+                          "role": "button",
+                          "name": "Header 1",
+                          "invalid": false,
+                          "focusable": true,
+                          "expanded": false
+                        }
+                      ]
+                    },
+                    {
+                      "ignored": true,
+                      "role": "none",
+                      "children": [
+                        {
+                          "ignored": true,
+                          "role": "none",
+                          "children": [
+                            {
+                              "ignored": true,
+                              "role": "none"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "ignored": true,
+                      "role": "none",
+                      "children": [
+                        {
+                          "role": "button",
+                          "name": "Header 2",
+                          "invalid": false,
+                          "focusable": true,
+                          "expanded": false
+                        }
+                      ]
+                    },
+                    {
+                      "ignored": true,
+                      "role": "none",
+                      "children": [
+                        {
+                          "ignored": true,
+                          "role": "none",
+                          "children": [
+                            {
+                              "ignored": true,
+                              "role": "none"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-accordion renders A11y tree Chrome */
-
-snapshots["sbb-accordion renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Header 1"
-    },
-    {
-      "role": "button",
-      "name": "Header 2"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-accordion renders A11y tree Firefox */
 

--- a/src/elements/action-group/__snapshots__/action-group.snapshot.spec.snap.js
+++ b/src/elements/action-group/__snapshots__/action-group.snapshot.spec.snap.js
@@ -33,40 +33,33 @@ snapshots["sbb-action-group renders Shadow DOM"] =
 `;
 /* end snapshot sbb-action-group renders Shadow DOM */
 
-snapshots["sbb-action-group renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Button"
-    },
-    {
-      "role": "link",
-      "name": "Link",
-      "value": "https://github.com/sbb-design-systems/lyne-components"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-action-group renders A11y tree Firefox */
-
 snapshots["sbb-action-group renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "Button"
-    },
-    {
-      "role": "link",
-      "name": "Link"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "role": "button",
+              "name": "Button",
+              "invalid": false,
+              "focusable": true
+            },
+            {
+              "role": "generic",
+              "name": ""
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/elements/alert/alert-group/__snapshots__/alert-group.snapshot.spec.snap.js
+++ b/src/elements/alert/alert-group/__snapshots__/alert-group.snapshot.spec.snap.js
@@ -79,60 +79,19 @@ snapshots["sbb-alert-group renders with slotted Shadow DOM"] =
 snapshots["sbb-alert-group renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "heading",
-      "name": "Disruptions",
-      "level": 3
-    },
-    {
-      "role": "heading",
-      "name": "Interruption between Genève and Lausanne",
-      "level": 3
-    },
-    {
-      "role": "text",
-      "name": "The rail traffic between Allaman and Morges is interrupted. All trains are cancelled."
-    },
-    {
-      "role": "button",
-      "name": "Close message"
+      "role": "status",
+      "name": "",
+      "live": "polite",
+      "atomic": true,
+      "relevant": "additions text"
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-alert-group renders A11y tree Chrome */
-
-snapshots["sbb-alert-group renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "Disruptions",
-      "level": 3
-    },
-    {
-      "role": "heading",
-      "name": "Interruption between Genève and Lausanne",
-      "level": 3
-    },
-    {
-      "role": "text leaf",
-      "name": "The rail traffic between Allaman and Morges is interrupted. All trains are cancelled. "
-    },
-    {
-      "role": "button",
-      "name": "Close message"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-alert-group renders A11y tree Firefox */
 

--- a/src/elements/alert/alert/__snapshots__/alert.snapshot.spec.snap.js
+++ b/src/elements/alert/alert/__snapshots__/alert.snapshot.spec.snap.js
@@ -156,92 +156,86 @@ snapshots["sbb-alert A11y tree Chrome"] =
 `;
 /* end snapshot sbb-alert A11y tree Chrome */
 
-snapshots["sbb-alert A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "Interruption",
-      "level": 3
-    },
-    {
-      "role": "text leaf",
-      "name": "Alert content "
-    },
-    {
-      "role": "link",
-      "name": "Find out more",
-      "value": "https://www.sbb.ch/"
-    },
-    {
-      "role": "button",
-      "name": "Close message"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-alert A11y tree Firefox */
-
 snapshots["sbb-alert should render customized properties A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "heading",
-      "name": "Interruption",
-      "level": 2
-    },
-    {
-      "role": "text",
-      "name": "Alert content Alert content "
-    },
-    {
-      "role": "link",
-      "name": "Find out more"
-    },
-    {
-      "role": "button",
-      "name": "Close message"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "ignored": true,
+                      "role": "none",
+                      "children": [
+                        {
+                          "ignored": true,
+                          "role": "none"
+                        }
+                      ]
+                    },
+                    {
+                      "ignored": true,
+                      "role": "none",
+                      "children": [
+                        {
+                          "role": "heading",
+                          "name": "Interruption",
+                          "level": 2
+                        },
+                        {
+                          "role": "StaticText",
+                          "name": "Alert content Alert content "
+                        },
+                        {
+                          "role": "generic",
+                          "name": ""
+                        }
+                      ]
+                    },
+                    {
+                      "ignored": true,
+                      "role": "none",
+                      "children": [
+                        {
+                          "role": "separator",
+                          "name": "",
+                          "settable": true,
+                          "orientation": "vertical"
+                        },
+                        {
+                          "role": "button",
+                          "name": "Close message",
+                          "invalid": false,
+                          "focusable": true
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-alert should render customized properties A11y tree Chrome */
-
-snapshots["sbb-alert should render customized properties A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "Interruption",
-      "level": 2
-    },
-    {
-      "role": "text leaf",
-      "name": "Alert content Alert content "
-    },
-    {
-      "role": "link",
-      "name": "Find out more",
-      "value": "https://www.sbb.ch/"
-    },
-    {
-      "role": "button",
-      "name": "Close message"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-alert should render customized properties A11y tree Firefox */
 

--- a/src/elements/autocomplete/__snapshots__/autocomplete.snapshot.spec.snap.js
+++ b/src/elements/autocomplete/__snapshots__/autocomplete.snapshot.spec.snap.js
@@ -256,44 +256,30 @@ snapshots["sbb-autocomplete renders in form field Chrome-Firefox Shadow DOM"] =
 snapshots["sbb-autocomplete renders in form field A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "​"
-    },
-    {
-      "role": "combobox",
-      "name": "",
-      "autocomplete": "list",
-      "haspopup": "listbox"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "generic",
+          "name": ""
+        },
+        {
+          "role": "generic",
+          "name": ""
+        },
+        {
+          "ignored": true,
+          "role": "none"
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-autocomplete renders in form field A11y tree Chrome */
-
-snapshots["sbb-autocomplete renders in form field A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "statictext",
-      "name": "​"
-    },
-    {
-      "role": "combobox",
-      "name": "",
-      "autocomplete": "list",
-      "haspopup": "listbox"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-autocomplete renders in form field A11y tree Firefox */
 

--- a/src/elements/breadcrumb/breadcrumb-group/__snapshots__/breadcrumb-group.snapshot.spec.snap.js
+++ b/src/elements/breadcrumb/breadcrumb-group/__snapshots__/breadcrumb-group.snapshot.spec.snap.js
@@ -61,51 +61,16 @@ snapshots["sbb-breadcrumb-group renders Shadow DOM"] =
 snapshots["sbb-breadcrumb-group renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "link",
+      "role": "navigation",
       "name": ""
-    },
-    {
-      "role": "link",
-      "name": "One"
-    },
-    {
-      "role": "link",
-      "name": "Two"
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-breadcrumb-group renders A11y tree Chrome */
-
-snapshots["sbb-breadcrumb-group renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "link",
-      "name": "",
-      "value": "https://example.com/"
-    },
-    {
-      "role": "link",
-      "name": "One",
-      "value": "https://example.com/one"
-    },
-    {
-      "role": "link",
-      "name": "Two",
-      "value": "https://example.com/one"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-breadcrumb-group renders A11y tree Firefox */
 

--- a/src/elements/breadcrumb/breadcrumb/__snapshots__/breadcrumb.snapshot.spec.snap.js
+++ b/src/elements/breadcrumb/breadcrumb/__snapshots__/breadcrumb.snapshot.spec.snap.js
@@ -96,33 +96,16 @@ snapshots["sbb-breadcrumb renders with icon and text Shadow DOM"] =
 snapshots["sbb-breadcrumb renders with text A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "link",
-      "name": "Breadcrumb . Link target opens in a new window."
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-breadcrumb renders with text A11y tree Chrome */
-
-snapshots["sbb-breadcrumb renders with text A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "link",
-      "name": "Breadcrumb . Link target opens in a new window.",
-      "value": "https://example.com/test"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-breadcrumb renders with text A11y tree Firefox */
 

--- a/src/elements/button/accent-button-link/__snapshots__/accent-button-link.snapshot.spec.snap.js
+++ b/src/elements/button/accent-button-link/__snapshots__/accent-button-link.snapshot.spec.snap.js
@@ -71,33 +71,16 @@ snapshots["sbb-accent-button-link renders a disabled sbb-accent-button-link with
 snapshots["sbb-accent-button-link renders a sbb-accent-button-link without icon A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "link",
-      "name": "Label Text . Link target opens in a new window."
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-accent-button-link renders a sbb-accent-button-link without icon A11y tree Chrome */
-
-snapshots["sbb-accent-button-link renders a sbb-accent-button-link without icon A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "link",
-      "name": "Label Text . Link target opens in a new window.",
-      "value": "https://www.sbb.ch/"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-accent-button-link renders a sbb-accent-button-link without icon A11y tree Firefox */
 

--- a/src/elements/button/accent-button-static/__snapshots__/accent-button-static.snapshot.spec.snap.js
+++ b/src/elements/button/accent-button-static/__snapshots__/accent-button-static.snapshot.spec.snap.js
@@ -51,32 +51,38 @@ snapshots["sbb-accent-button-static renders with slotted icon Shadow DOM"] =
 snapshots["sbb-accent-button-static renders with slotted icon A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Label Text"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none"
+            }
+          ]
+        },
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "role": "StaticText",
+              "name": "Label Text"
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-accent-button-static renders with slotted icon A11y tree Chrome */
-
-snapshots["sbb-accent-button-static renders with slotted icon A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Label Text "
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-accent-button-static renders with slotted icon A11y tree Firefox */
 

--- a/src/elements/button/accent-button/__snapshots__/accent-button.snapshot.spec.snap.js
+++ b/src/elements/button/accent-button/__snapshots__/accent-button.snapshot.spec.snap.js
@@ -58,32 +58,18 @@ snapshots["sbb-accent-button renders a sbb-accent-button with slotted icon Shado
 snapshots["sbb-accent-button renders a sbb-accent-button with slotted icon A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
-      "name": "Label Text"
+      "name": "Label Text",
+      "invalid": false,
+      "focusable": true
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-accent-button renders a sbb-accent-button with slotted icon A11y tree Chrome */
-
-snapshots["sbb-accent-button renders a sbb-accent-button with slotted icon A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Label Text"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-accent-button renders a sbb-accent-button with slotted icon A11y tree Firefox */
 

--- a/src/elements/button/button-link/__snapshots__/button-link.snapshot.spec.snap.js
+++ b/src/elements/button/button-link/__snapshots__/button-link.snapshot.spec.snap.js
@@ -71,33 +71,16 @@ snapshots["sbb-button-link renders a disabled sbb-button-link with slotted icon 
 snapshots["sbb-button-link renders a sbb-button-link without icon A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "link",
-      "name": "Label Text . Link target opens in a new window."
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-button-link renders a sbb-button-link without icon A11y tree Chrome */
-
-snapshots["sbb-button-link renders a sbb-button-link without icon A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "link",
-      "name": "Label Text . Link target opens in a new window.",
-      "value": "https://www.sbb.ch/"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-button-link renders a sbb-button-link without icon A11y tree Firefox */
 

--- a/src/elements/button/button-static/__snapshots__/button-static.snapshot.spec.snap.js
+++ b/src/elements/button/button-static/__snapshots__/button-static.snapshot.spec.snap.js
@@ -51,32 +51,38 @@ snapshots["sbb-button-static renders with slotted icon Shadow DOM"] =
 snapshots["sbb-button-static renders with slotted icon A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Label Text"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none"
+            }
+          ]
+        },
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "role": "StaticText",
+              "name": "Label Text"
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-button-static renders with slotted icon A11y tree Chrome */
-
-snapshots["sbb-button-static renders with slotted icon A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Label Text "
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-button-static renders with slotted icon A11y tree Firefox */
 

--- a/src/elements/button/button/__snapshots__/button.snapshot.spec.snap.js
+++ b/src/elements/button/button/__snapshots__/button.snapshot.spec.snap.js
@@ -87,12 +87,14 @@ snapshots["sbb-button renders a sbb-button in loading state Shadow DOM"] =
 snapshots["sbb-button renders a sbb-button with slotted icon A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
-      "name": "Label Text"
+      "name": "Label Text",
+      "invalid": false,
+      "focusable": true
     }
   ]
 }
@@ -100,53 +102,23 @@ snapshots["sbb-button renders a sbb-button with slotted icon A11y tree Chrome"] 
 `;
 /* end snapshot sbb-button renders a sbb-button with slotted icon A11y tree Chrome */
 
-snapshots["sbb-button renders a sbb-button with slotted icon A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Label Text"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-button renders a sbb-button with slotted icon A11y tree Firefox */
-
 snapshots["sbb-button renders a sbb-button in loading state A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
       "name": "Loading Button",
-      "disabled": true
+      "disabled": true,
+      "invalid": false,
+      "focusable": true,
+      "busy": 1
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-button renders a sbb-button in loading state A11y tree Chrome */
-
-snapshots["sbb-button renders a sbb-button in loading state A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Loading Button",
-      "disabled": true
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-button renders a sbb-button in loading state A11y tree Firefox */
 

--- a/src/elements/button/mini-button-group/__snapshots__/mini-button-group.snapshot.spec.snap.js
+++ b/src/elements/button/mini-button-group/__snapshots__/mini-button-group.snapshot.spec.snap.js
@@ -96,40 +96,26 @@ snapshots["sbb-mini-button-group renders negative Shadow DOM"] =
 snapshots["sbb-mini-button-group renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": ""
-    },
-    {
-      "role": "button",
-      "name": ""
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "list",
+          "name": "Group label"
+        },
+        {
+          "ignored": true,
+          "role": "none"
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-mini-button-group renders A11y tree Chrome */
-
-snapshots["sbb-mini-button-group renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": ""
-    },
-    {
-      "role": "button",
-      "name": ""
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-mini-button-group renders A11y tree Firefox */
 

--- a/src/elements/button/secondary-button-link/__snapshots__/secondary-button-link.snapshot.spec.snap.js
+++ b/src/elements/button/secondary-button-link/__snapshots__/secondary-button-link.snapshot.spec.snap.js
@@ -71,33 +71,16 @@ snapshots["sbb-secondary-button-link renders a disabled sbb-secondary-button-lin
 snapshots["sbb-secondary-button-link renders a sbb-secondary-button-link without icon A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "link",
-      "name": "Label Text . Link target opens in a new window."
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-secondary-button-link renders a sbb-secondary-button-link without icon A11y tree Chrome */
-
-snapshots["sbb-secondary-button-link renders a sbb-secondary-button-link without icon A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "link",
-      "name": "Label Text . Link target opens in a new window.",
-      "value": "https://www.sbb.ch/"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-secondary-button-link renders a sbb-secondary-button-link without icon A11y tree Firefox */
 

--- a/src/elements/button/secondary-button-static/__snapshots__/secondary-button-static.snapshot.spec.snap.js
+++ b/src/elements/button/secondary-button-static/__snapshots__/secondary-button-static.snapshot.spec.snap.js
@@ -51,32 +51,38 @@ snapshots["sbb-secondary-button-static renders with slotted icon Shadow DOM"] =
 snapshots["sbb-secondary-button-static renders with slotted icon A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Label Text"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none"
+            }
+          ]
+        },
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "role": "StaticText",
+              "name": "Label Text"
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-secondary-button-static renders with slotted icon A11y tree Chrome */
-
-snapshots["sbb-secondary-button-static renders with slotted icon A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Label Text "
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-secondary-button-static renders with slotted icon A11y tree Firefox */
 

--- a/src/elements/button/secondary-button/__snapshots__/secondary-button.snapshot.spec.snap.js
+++ b/src/elements/button/secondary-button/__snapshots__/secondary-button.snapshot.spec.snap.js
@@ -58,32 +58,18 @@ snapshots["sbb-secondary-button renders a sbb-secondary-button with slotted icon
 snapshots["sbb-secondary-button renders a sbb-secondary-button with slotted icon A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
-      "name": "Label Text"
+      "name": "Label Text",
+      "invalid": false,
+      "focusable": true
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-secondary-button renders a sbb-secondary-button with slotted icon A11y tree Chrome */
-
-snapshots["sbb-secondary-button renders a sbb-secondary-button with slotted icon A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Label Text"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-secondary-button renders a sbb-secondary-button with slotted icon A11y tree Firefox */
 

--- a/src/elements/button/transparent-button-link/__snapshots__/transparent-button-link.snapshot.spec.snap.js
+++ b/src/elements/button/transparent-button-link/__snapshots__/transparent-button-link.snapshot.spec.snap.js
@@ -71,33 +71,16 @@ snapshots["sbb-transparent-button-link renders a disabled sbb-transparent-button
 snapshots["sbb-transparent-button-link renders a sbb-transparent-button-link without icon A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "link",
-      "name": "Label Text . Link target opens in a new window."
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-transparent-button-link renders a sbb-transparent-button-link without icon A11y tree Chrome */
-
-snapshots["sbb-transparent-button-link renders a sbb-transparent-button-link without icon A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "link",
-      "name": "Label Text . Link target opens in a new window.",
-      "value": "https://www.sbb.ch/"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-transparent-button-link renders a sbb-transparent-button-link without icon A11y tree Firefox */
 

--- a/src/elements/button/transparent-button-static/__snapshots__/transparent-button-static.snapshot.spec.snap.js
+++ b/src/elements/button/transparent-button-static/__snapshots__/transparent-button-static.snapshot.spec.snap.js
@@ -51,32 +51,38 @@ snapshots["sbb-transparent-button-static renders with slotted icon Shadow DOM"] 
 snapshots["sbb-transparent-button-static renders with slotted icon A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Label Text"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none"
+            }
+          ]
+        },
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "role": "StaticText",
+              "name": "Label Text"
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-transparent-button-static renders with slotted icon A11y tree Chrome */
-
-snapshots["sbb-transparent-button-static renders with slotted icon A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Label Text "
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-transparent-button-static renders with slotted icon A11y tree Firefox */
 

--- a/src/elements/button/transparent-button/__snapshots__/transparent-button.snapshot.spec.snap.js
+++ b/src/elements/button/transparent-button/__snapshots__/transparent-button.snapshot.spec.snap.js
@@ -58,32 +58,18 @@ snapshots["sbb-transparent-button renders a sbb-transparent-button with slotted 
 snapshots["sbb-transparent-button renders a sbb-transparent-button with slotted icon A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
-      "name": "Label Text"
+      "name": "Label Text",
+      "invalid": false,
+      "focusable": true
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-transparent-button renders a sbb-transparent-button with slotted icon A11y tree Chrome */
-
-snapshots["sbb-transparent-button renders a sbb-transparent-button with slotted icon A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Label Text"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-transparent-button renders a sbb-transparent-button with slotted icon A11y tree Firefox */
 

--- a/src/elements/calendar/__snapshots__/calendar.snapshot.spec.snap.js
+++ b/src/elements/calendar/__snapshots__/calendar.snapshot.spec.snap.js
@@ -3967,392 +3967,44 @@ snapshots["sbb-calendar renders vertical wide with week numbers Shadow DOM"] =
 snapshots["sbb-calendar renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "Change to the previous month"
-    },
-    {
-      "role": "button",
-      "name": "Choose year and month January 2023"
-    },
-    {
-      "role": "text",
-      "name": "January 2023"
-    },
-    {
-      "role": "button",
-      "name": "Change to the next month"
-    },
-    {
-      "role": "text",
-      "name": "Monday"
-    },
-    {
-      "role": "text",
-      "name": "Tuesday"
-    },
-    {
-      "role": "text",
-      "name": "Wednesday"
-    },
-    {
-      "role": "text",
-      "name": "Thursday"
-    },
-    {
-      "role": "text",
-      "name": "Friday"
-    },
-    {
-      "role": "text",
-      "name": "Saturday"
-    },
-    {
-      "role": "text",
-      "name": "Sunday"
-    },
-    {
-      "role": "button",
-      "name": "January 1, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 2, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 3, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 4, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 5, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 6, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 7, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 8, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 9, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 10, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 11, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 12, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 13, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 14, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 15, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 16, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 17, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 18, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 19, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 20, 2023",
-      "pressed": true
-    },
-    {
-      "role": "button",
-      "name": "January 21, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 22, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 23, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 24, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 25, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 26, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 27, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 28, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 29, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 30, 2023",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "January 31, 2023",
-      "pressed": false
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "role": "generic",
+              "name": ""
+            },
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "role": "table",
+                      "name": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-calendar renders A11y tree Chrome */
-
-snapshots["sbb-calendar renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Change to the previous month"
-    },
-    {
-      "role": "button",
-      "name": "Choose year and month January 2023"
-    },
-    {
-      "role": "text leaf",
-      "name": "January 2023 "
-    },
-    {
-      "role": "button",
-      "name": "Change to the next month"
-    },
-    {
-      "role": "text leaf",
-      "name": "Monday"
-    },
-    {
-      "role": "text leaf",
-      "name": "Tuesday"
-    },
-    {
-      "role": "text leaf",
-      "name": "Wednesday"
-    },
-    {
-      "role": "text leaf",
-      "name": "Thursday"
-    },
-    {
-      "role": "text leaf",
-      "name": "Friday"
-    },
-    {
-      "role": "text leaf",
-      "name": "Saturday"
-    },
-    {
-      "role": "text leaf",
-      "name": "Sunday"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 1, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 2, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 3, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 4, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 5, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 6, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 7, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 8, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 9, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 10, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 11, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 12, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 13, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 14, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 15, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 16, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 17, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 18, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 19, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 20, 2023",
-      "pressed": true
-    },
-    {
-      "role": "toggle button",
-      "name": "January 21, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 22, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 23, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 24, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 25, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 26, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 27, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 28, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 29, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 30, 2023"
-    },
-    {
-      "role": "toggle button",
-      "name": "January 31, 2023"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-calendar renders A11y tree Firefox */
 

--- a/src/elements/card/card-badge/__snapshots__/card-badge.snapshot.spec.snap.js
+++ b/src/elements/card/card-badge/__snapshots__/card-badge.snapshot.spec.snap.js
@@ -27,32 +27,16 @@ snapshots["sbb-card-badge renders Shadow DOM"] =
 snapshots["sbb-card-badge renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Black Friday Special"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-card-badge renders A11y tree Chrome */
-
-snapshots["sbb-card-badge renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Black Friday Special"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-card-badge renders A11y tree Firefox */
 

--- a/src/elements/card/card-button/__snapshots__/card-button.snapshot.spec.snap.js
+++ b/src/elements/card/card-button/__snapshots__/card-button.snapshot.spec.snap.js
@@ -28,40 +28,16 @@ snapshots["sbb-card-button renders Shadow DOM"] =
 snapshots["sbb-card-button renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "Click me"
-    },
-    {
-      "role": "text",
-      "name": "Content"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-card-button renders A11y tree Chrome */
-
-snapshots["sbb-card-button renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Click me"
-    },
-    {
-      "role": "text leaf",
-      "name": "Content"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-card-button renders A11y tree Firefox */
 

--- a/src/elements/card/card-link/__snapshots__/card-link.snapshot.spec.snap.js
+++ b/src/elements/card/card-link/__snapshots__/card-link.snapshot.spec.snap.js
@@ -36,41 +36,16 @@ snapshots["sbb-card-link renders Shadow DOM"] =
 snapshots["sbb-card-link renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "link",
-      "name": "Follow me . Link target opens in a new window."
-    },
-    {
-      "role": "text",
-      "name": "Content text"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-card-link renders A11y tree Chrome */
-
-snapshots["sbb-card-link renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "link",
-      "name": "Follow me . Link target opens in a new window.",
-      "value": "https://github.com/sbb-design-systems/lyne-components"
-    },
-    {
-      "role": "text leaf",
-      "name": "Content text "
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-card-link renders A11y tree Firefox */
 

--- a/src/elements/card/card/__snapshots__/card.snapshot.spec.snap.js
+++ b/src/elements/card/card/__snapshots__/card.snapshot.spec.snap.js
@@ -42,66 +42,16 @@ snapshots["sbb-card should render with sbb-card-badge - Shadow DOM"] =
 snapshots["sbb-card A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "heading",
-      "name": "Title",
-      "level": 2
-    },
-    {
-      "role": "text",
-      "name": "Content text"
-    },
-    {
-      "role": "text",
-      "name": "%"
-    },
-    {
-      "role": "text",
-      "name": "from CHF"
-    },
-    {
-      "role": "text",
-      "name": "19.99"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-card A11y tree Chrome */
-
-snapshots["sbb-card A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "Title",
-      "level": 2
-    },
-    {
-      "role": "text leaf",
-      "name": "Content text "
-    },
-    {
-      "role": "text leaf",
-      "name": "%"
-    },
-    {
-      "role": "text leaf",
-      "name": "from CHF"
-    },
-    {
-      "role": "text leaf",
-      "name": "19.99"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-card A11y tree Firefox */
 

--- a/src/elements/carousel/carousel-item/__snapshots__/carousel-item.snapshot.spec.snap.js
+++ b/src/elements/carousel/carousel-item/__snapshots__/carousel-item.snapshot.spec.snap.js
@@ -31,31 +31,16 @@ snapshots["sbb-carousel-item renders with sbb-image Shadow DOM"] =
 `;
 /* end snapshot sbb-carousel-item renders with sbb-image Shadow DOM */
 
-snapshots["sbb-carousel-item renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "img",
-      "name": "SBB image"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-carousel-item renders A11y tree Firefox */
-
 snapshots["sbb-carousel-item renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "image",
-      "name": "SBB image"
+      "role": "group",
+      "name": "",
+      "roledescription": "slide"
     }
   ]
 }
@@ -63,31 +48,16 @@ snapshots["sbb-carousel-item renders A11y tree Chrome"] =
 `;
 /* end snapshot sbb-carousel-item renders A11y tree Chrome */
 
-snapshots["sbb-carousel-item renders with sbb-image A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "img",
-      "name": "SBB image"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-carousel-item renders with sbb-image A11y tree Firefox */
-
 snapshots["sbb-carousel-item renders with sbb-image A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "image",
-      "name": "SBB image"
+      "role": "group",
+      "name": "",
+      "roledescription": "slide"
     }
   ]
 }

--- a/src/elements/carousel/carousel-list/__snapshots__/carousel-list.snapshot.spec.snap.js
+++ b/src/elements/carousel/carousel-list/__snapshots__/carousel-list.snapshot.spec.snap.js
@@ -43,38 +43,19 @@ snapshots["sbb-carousel-list renders Shadow DOM"] =
 snapshots["sbb-carousel-list renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "image",
-      "name": "SBB image"
+      "role": "generic",
+      "name": "",
+      "live": "polite",
+      "atomic": true,
+      "relevant": "additions text"
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-carousel-list renders A11y tree Chrome */
-
-snapshots["sbb-carousel-list renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text container",
-      "name": "",
-      "children": [
-        {
-          "role": "img",
-          "name": "SBB image"
-        }
-      ]
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-carousel-list renders A11y tree Firefox */
 

--- a/src/elements/carousel/carousel/__snapshots__/carousel.snapshot.spec.snap.js
+++ b/src/elements/carousel/carousel/__snapshots__/carousel.snapshot.spec.snap.js
@@ -50,46 +50,17 @@ snapshots["sbb-carousel renders Shadow DOM"] =
 snapshots["sbb-carousel renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Carousel - Use the arrow keys in interaction mode to navigate through the slides"
-    },
-    {
-      "role": "image",
-      "name": "SBB image"
+      "role": "region",
+      "name": "carousel",
+      "description": "Carousel - Use the arrow keys in interaction mode to navigate through the slides"
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-carousel renders A11y tree Chrome */
-
-snapshots["sbb-carousel renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Carousel - Use the arrow keys in interaction mode to navigate through the slides"
-    },
-    {
-      "role": "text container",
-      "name": "",
-      "children": [
-        {
-          "role": "img",
-          "name": "SBB image"
-        }
-      ]
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-carousel renders A11y tree Firefox */
 

--- a/src/elements/checkbox/checkbox-group/__snapshots__/checkbox-group.snapshot.spec.snap.js
+++ b/src/elements/checkbox/checkbox-group/__snapshots__/checkbox-group.snapshot.spec.snap.js
@@ -44,53 +44,47 @@ snapshots["sbb-checkbox-group renders Shadow DOM"] =
 snapshots["sbb-checkbox-group renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "checkbox",
-      "name": "​ Label 1",
-      "checked": false
-    },
-    {
-      "role": "checkbox",
-      "name": "​ Label 2",
-      "checked": false
-    },
-    {
-      "role": "checkbox",
-      "name": "​ Label 3",
-      "checked": false
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "role": "checkbox",
+              "name": "​ Label 1",
+              "invalid": false,
+              "focusable": true,
+              "checked": false
+            },
+            {
+              "role": "checkbox",
+              "name": "​ Label 2",
+              "invalid": false,
+              "focusable": true,
+              "checked": false
+            },
+            {
+              "role": "checkbox",
+              "name": "​ Label 3",
+              "invalid": false,
+              "focusable": true,
+              "checked": false
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-checkbox-group renders A11y tree Chrome */
-
-snapshots["sbb-checkbox-group renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "checkbox",
-      "name": "​ Label 1"
-    },
-    {
-      "role": "checkbox",
-      "name": "​ Label 2"
-    },
-    {
-      "role": "checkbox",
-      "name": "​ Label 3"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-checkbox-group renders A11y tree Firefox */
 
 snapshots["sbb-checkbox-group renders with panel DOM"] = 
 `<sbb-checkbox-group orientation="horizontal">

--- a/src/elements/checkbox/checkbox-panel/__snapshots__/checkbox-panel.snapshot.spec.snap.js
+++ b/src/elements/checkbox/checkbox-panel/__snapshots__/checkbox-panel.snapshot.spec.snap.js
@@ -196,12 +196,14 @@ snapshots["sbb-checkbox-panel renders unchecked disabled Shadow DOM"] =
 snapshots["sbb-checkbox-panel Unchecked - A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "checkbox",
       "name": "​ Label",
+      "invalid": false,
+      "focusable": true,
       "checked": false
     }
   ]
@@ -213,12 +215,14 @@ snapshots["sbb-checkbox-panel Unchecked - A11y tree Chrome"] =
 snapshots["sbb-checkbox-panel Checked - A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "checkbox",
       "name": "​ Label",
+      "invalid": false,
+      "focusable": true,
       "checked": true
     }
   ]
@@ -226,37 +230,4 @@ snapshots["sbb-checkbox-panel Checked - A11y tree Chrome"] =
 </p>
 `;
 /* end snapshot sbb-checkbox-panel Checked - A11y tree Chrome */
-
-snapshots["sbb-checkbox-panel Unchecked - A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "checkbox",
-      "name": "​ Label"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-checkbox-panel Unchecked - A11y tree Firefox */
-
-snapshots["sbb-checkbox-panel Checked - A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "checkbox",
-      "name": "​ Label",
-      "checked": true
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-checkbox-panel Checked - A11y tree Firefox */
 

--- a/src/elements/checkbox/checkbox/__snapshots__/checkbox.snapshot.spec.snap.js
+++ b/src/elements/checkbox/checkbox/__snapshots__/checkbox.snapshot.spec.snap.js
@@ -148,12 +148,14 @@ snapshots["sbb-checkbox should render unchecked disabled Shadow DOM"] =
 snapshots["sbb-checkbox Unchecked - A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "checkbox",
       "name": "​ Label",
+      "invalid": false,
+      "focusable": true,
       "checked": false
     }
   ]
@@ -165,12 +167,14 @@ snapshots["sbb-checkbox Unchecked - A11y tree Chrome"] =
 snapshots["sbb-checkbox Checked - A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "checkbox",
       "name": "​ Label",
+      "invalid": false,
+      "focusable": true,
       "checked": true
     }
   ]
@@ -178,37 +182,4 @@ snapshots["sbb-checkbox Checked - A11y tree Chrome"] =
 </p>
 `;
 /* end snapshot sbb-checkbox Checked - A11y tree Chrome */
-
-snapshots["sbb-checkbox Unchecked - A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "checkbox",
-      "name": "​ Label"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-checkbox Unchecked - A11y tree Firefox */
-
-snapshots["sbb-checkbox Checked - A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "checkbox",
-      "name": "​ Label",
-      "checked": true
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-checkbox Checked - A11y tree Firefox */
 

--- a/src/elements/chip-label/__snapshots__/chip-label.snapshot.spec.snap.js
+++ b/src/elements/chip-label/__snapshots__/chip-label.snapshot.spec.snap.js
@@ -24,32 +24,28 @@ snapshots["sbb-chip-label renders Shadow DOM"] =
 snapshots["sbb-chip-label renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Label"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "role": "StaticText",
+              "name": "Label"
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-chip-label renders A11y tree Chrome */
-
-snapshots["sbb-chip-label renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Label"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-chip-label renders A11y tree Firefox */
 

--- a/src/elements/chip/chip-group/__snapshots__/chip-group.snapshot.spec.snap.js
+++ b/src/elements/chip/chip-group/__snapshots__/chip-group.snapshot.spec.snap.js
@@ -88,76 +88,27 @@ snapshots["sbb-chip-group renders with form-field Shadow DOM"] =
 `;
 /* end snapshot sbb-chip-group renders with form-field Shadow DOM */
 
-snapshots["sbb-chip-group renders with form-field A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "statictext",
-      "name": "​"
-    },
-    {
-      "role": "text leaf",
-      "name": "Field label"
-    },
-    {
-      "role": "listbox",
-      "name": "",
-      "children": [
-        {
-          "role": "option",
-          "name": "Value 1 , Press the Delete button to remove the chip"
-        },
-        {
-          "role": "option",
-          "name": "Value 2 , Press the Delete button to remove the chip"
-        },
-        {
-          "role": "textbox",
-          "name": "Field label",
-          "description": "Selected elements: 2"
-        }
-      ]
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-chip-group renders with form-field A11y tree Firefox */
-
 snapshots["sbb-chip-group renders with form-field A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "​"
-    },
-    {
-      "role": "text",
-      "name": "Field label"
-    },
-    {
-      "role": "listbox",
-      "name": "",
-      "orientation": "vertical",
+      "ignored": true,
+      "role": "none",
       "children": [
         {
-          "role": "option",
-          "name": "Value 1 , Press the Delete button to remove the chip"
+          "role": "generic",
+          "name": ""
         },
         {
-          "role": "option",
-          "name": "Value 2 , Press the Delete button to remove the chip"
+          "role": "generic",
+          "name": ""
         },
         {
-          "role": "textbox",
-          "name": "Field label",
-          "description": "Selected elements: 2"
+          "ignored": true,
+          "role": "none"
         }
       ]
     }

--- a/src/elements/chip/chip/__snapshots__/chip.snapshot.spec.snap.js
+++ b/src/elements/chip/chip/__snapshots__/chip.snapshot.spec.snap.js
@@ -68,12 +68,14 @@ snapshots["sbb-chip renders disabled Shadow DOM"] =
 snapshots["sbb-chip renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "option",
-      "name": "Value , Press the Delete button to remove the chip"
+      "name": "Value , Press the Delete button to remove the chip",
+      "focusable": true,
+      "selected": false
     }
   ]
 }
@@ -81,83 +83,22 @@ snapshots["sbb-chip renders A11y tree Chrome"] =
 `;
 /* end snapshot sbb-chip renders A11y tree Chrome */
 
-snapshots["sbb-chip renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text container",
-      "name": "",
-      "children": [
-        {
-          "role": "text leaf",
-          "name": "Value"
-        },
-        {
-          "role": "text leaf",
-          "name": ", "
-        },
-        {
-          "role": "text leaf",
-          "name": "Press the Delete button to remove the chip"
-        }
-      ]
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-chip renders A11y tree Firefox */
-
 snapshots["sbb-chip renders disabled A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Value"
-    },
-    {
-      "role": "text",
-      "name": ", "
-    },
-    {
-      "role": "text",
-      "name": "Press the Delete button to remove the chip"
+      "role": "option",
+      "name": "Value , Press the Delete button to remove the chip",
+      "selected": false
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-chip renders disabled A11y tree Chrome */
-
-snapshots["sbb-chip renders disabled A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Value"
-    },
-    {
-      "role": "text leaf",
-      "name": ", "
-    },
-    {
-      "role": "text leaf",
-      "name": "Press the Delete button to remove the chip"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-chip renders disabled A11y tree Firefox */
 
 snapshots["sbb-chip renders with label DOM"] = 
 `<sbb-chip
@@ -195,46 +136,18 @@ snapshots["sbb-chip renders with label Shadow DOM"] =
 snapshots["sbb-chip renders with label A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "option",
-      "name": "Value label , Press the Delete button to remove the chip"
+      "name": "Value label , Press the Delete button to remove the chip",
+      "focusable": true,
+      "selected": false
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-chip renders with label A11y tree Chrome */
-
-snapshots["sbb-chip renders with label A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text container",
-      "name": "",
-      "children": [
-        {
-          "role": "text leaf",
-          "name": "Value label"
-        },
-        {
-          "role": "text leaf",
-          "name": ", "
-        },
-        {
-          "role": "text leaf",
-          "name": "Press the Delete button to remove the chip"
-        }
-      ]
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-chip renders with label A11y tree Firefox */
 

--- a/src/elements/clock/__snapshots__/clock.snapshot.spec.snap.js
+++ b/src/elements/clock/__snapshots__/clock.snapshot.spec.snap.js
@@ -50,20 +50,22 @@ snapshots["sbb-clock renders with fixed time Shadow DOM"] =
 snapshots["sbb-clock renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "generic",
+          "name": ""
+        }
+      ]
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-clock renders A11y tree Chrome */
-
-snapshots["sbb-clock renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-clock renders A11y tree Firefox */
 

--- a/src/elements/container/container/__snapshots__/container.snapshot.spec.snap.js
+++ b/src/elements/container/container/__snapshots__/container.snapshot.spec.snap.js
@@ -24,20 +24,36 @@ snapshots["sbb-container renders Shadow DOM"] =
 snapshots["sbb-container renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none"
+            },
+            {
+              "ignored": true,
+              "role": "none"
+            },
+            {
+              "ignored": true,
+              "role": "none"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-container renders A11y tree Chrome */
-
-snapshots["sbb-container renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-container renders A11y tree Firefox */
 

--- a/src/elements/container/sticky-bar/__snapshots__/sticky-bar.snapshot.spec.snap.js
+++ b/src/elements/container/sticky-bar/__snapshots__/sticky-bar.snapshot.spec.snap.js
@@ -25,20 +25,20 @@ snapshots["sbb-sticky-bar renders Shadow DOM"] =
 snapshots["sbb-sticky-bar renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "role": "generic",
+      "name": ""
+    },
+    {
+      "role": "generic",
+      "name": ""
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-sticky-bar renders A11y tree Chrome */
-
-snapshots["sbb-sticky-bar renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-sticky-bar renders A11y tree Firefox */
 

--- a/src/elements/core/base-elements/button-base-element.spec.ts
+++ b/src/elements/core/base-elements/button-base-element.spec.ts
@@ -1,10 +1,11 @@
 import { assert, aTimeout, expect } from '@open-wc/testing';
-import { a11ySnapshot, sendKeys } from '@web/test-runner-commands';
+import { sendKeys } from '@web/test-runner-commands';
 import { html, type TemplateResult } from 'lit';
 
+import { isChromium } from '../dom.ts';
 import { SbbDisabledInteractiveMixin, SbbDisabledMixin } from '../mixins.ts';
 import { tabKey } from '../testing/private/keys.ts';
-import { fixture, typeInElement } from '../testing/private.ts';
+import { a11yTreeSnapshot, fixture, typeInElement } from '../testing/private.ts';
 import { EventSpy, waitForLitRender } from '../testing.ts';
 
 import { SbbButtonBaseElement } from './button-base-element.ts';
@@ -225,59 +226,58 @@ describe(`SbbButtonBaseElement`, () => {
             input = form.querySelector('input')!;
           });
 
-          it('should have role button', async () => {
-            const snapshot = (await a11ySnapshot({
-              selector: entry.selector,
-            })) as unknown as ButtonAccessibilitySnapshot;
+          if (isChromium) {
+            it('should have role button', async () => {
+              await aTimeout(1000);
+              const snapshot = await a11yTreeSnapshot({
+                selector: `${entry.selector}:first-of-type`,
+              });
 
-            expect(snapshot.role).to.be.equal('button');
-          });
+              expect(snapshot.role).to.be.equal('button');
+            });
 
-          it('should be focusable', async () => {
-            const snapshot = (await a11ySnapshot({
-              selector: entry.selector,
-            })) as unknown as ButtonAccessibilitySnapshot;
+            it('should be focusable', async () => {
+              const snapshot = await a11yTreeSnapshot({ selector: entry.selector });
 
-            expect(snapshot.disabled).to.be.undefined;
-            expect(submitButton).not.to.have.attribute('disabled');
-            expect(submitButton).not.to.match(':disabled');
+              expect(snapshot.disabled).to.be.undefined;
+              expect(submitButton).not.to.have.attribute('disabled');
+              expect(submitButton).not.to.match(':disabled');
 
-            await sendKeys({ press: tabKey });
-            await sendKeys({ press: tabKey });
-            expect(document.activeElement!).to.be.equal(submitButton);
-          });
+              await sendKeys({ press: tabKey });
+              await sendKeys({ press: tabKey });
+              expect(document.activeElement!).to.be.equal(submitButton);
+            });
 
-          it('should not be focusable if disabled', async () => {
-            submitButton.disabled = true;
-            await waitForLitRender(submitButton);
+            it('should not be focusable if disabled', async () => {
+              submitButton.disabled = true;
+              await waitForLitRender(submitButton);
 
-            const snapshot = (await a11ySnapshot({
-              selector: entry.selector,
-            })) as unknown as ButtonAccessibilitySnapshot;
+              const snapshot = await a11yTreeSnapshot({ selector: entry.selector });
 
-            expect(snapshot.disabled).to.be.true;
-            expect(submitButton).to.have.attribute('disabled');
-            expect(submitButton).to.match(':disabled');
+              expect(snapshot.disabled).to.be.true;
+              expect(submitButton).to.have.attribute('disabled');
+              expect(submitButton).to.match(':disabled');
 
-            await sendKeys({ press: tabKey });
-            await sendKeys({ press: tabKey });
-            expect(document.activeElement!).not.to.be.equal(submitButton);
-          });
+              await sendKeys({ press: tabKey });
+              await sendKeys({ press: tabKey });
+              expect(document.activeElement!).not.to.be.equal(submitButton);
+            });
 
-          it('should not be focusable if inside a disabled fieldset', async () => {
-            fieldSet.disabled = true;
-            await waitForLitRender(submitButton);
+            it('should not be focusable if inside a disabled fieldset', async () => {
+              fieldSet.disabled = true;
+              await waitForLitRender(submitButton);
 
-            const snapshot = (await a11ySnapshot({
-              selector: entry.selector,
-            })) as unknown as ButtonAccessibilitySnapshot;
+              const snapshot = (await a11yTreeSnapshot({
+                selector: entry.selector,
+              })) as unknown as ButtonAccessibilitySnapshot;
 
-            expect(snapshot.disabled).to.be.true;
-            expect(submitButton).to.match(':disabled');
+              expect(snapshot.disabled).to.be.true;
+              expect(submitButton).to.match(':disabled');
 
-            await sendKeys({ press: tabKey });
-            expect(document.activeElement!).not.to.be.equal(submitButton);
-          });
+              await sendKeys({ press: tabKey });
+              expect(document.activeElement!).not.to.be.equal(submitButton);
+            });
+          }
 
           it('should set default value', () => {
             expect(submitButton.value).to.be.equal('submit');

--- a/src/elements/core/mixins/disabled-mixin.spec.ts
+++ b/src/elements/core/mixins/disabled-mixin.spec.ts
@@ -1,11 +1,11 @@
 import { expect } from '@open-wc/testing';
-import { a11ySnapshot } from '@web/test-runner-commands';
 import type { TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { html } from 'lit/static-html.js';
 
 import { SbbButtonBaseElement } from '../base-elements.ts';
-import { fixture } from '../testing/private.ts';
+import { isChromium } from '../dom.ts';
+import { a11yTreeSnapshot, fixture, type A11yNode } from '../testing/private.ts';
 import { waitForLitRender } from '../testing.ts';
 
 import { SbbDisabledMixin, SbbDisabledTabIndexActionMixin } from './disabled-mixin.ts';
@@ -23,28 +23,32 @@ class SbbDisabledTestElement extends SbbDisabledTabIndexActionMixin(
 describe(`SbbDisabledMixin`, () => {
   let element: SbbDisabledTestElement;
 
-  async function getA11ySnapshot(): Promise<{ disabled: boolean }> {
-    return (await a11ySnapshot({ selector: 'sbb-disabled-test' })) as unknown as {
-      disabled: boolean;
-    };
+  async function getA11ySnapshot(): Promise<A11yNode> {
+    return await a11yTreeSnapshot({ selector: 'sbb-disabled-test' });
   }
 
   async function assertDisabled(element: SbbDisabledTestElement): Promise<void> {
     expect(element.tabIndex).to.be.equal(-1);
     expect(element).not.to.have.attribute('tabindex');
-    expect((await getA11ySnapshot()).disabled).to.be.true;
+    if (isChromium) {
+      expect((await getA11ySnapshot()).disabled).to.be.true;
+    }
   }
 
   async function assertEnabled(element: SbbDisabledTestElement): Promise<void> {
     expect(element.tabIndex).to.be.equal(0);
     expect(element).to.have.attribute('tabindex', '0');
-    expect((await getA11ySnapshot()).disabled).to.be.undefined;
+    if (isChromium) {
+      expect((await getA11ySnapshot()).disabled).to.be.undefined;
+    }
   }
 
   async function assertDisabledInteractive(element: SbbDisabledTestElement): Promise<void> {
     expect(element.tabIndex).to.be.equal(0);
     expect(element).to.have.attribute('tabindex', '0');
-    expect((await getA11ySnapshot()).disabled).to.be.true;
+    if (isChromium) {
+      expect((await getA11ySnapshot()).disabled).to.be.true;
+    }
   }
 
   describe('disabled initially', () => {

--- a/src/elements/core/testing/private/a11y-tree-snapshot.ts
+++ b/src/elements/core/testing/private/a11y-tree-snapshot.ts
@@ -1,13 +1,22 @@
 import { aTimeout, expect } from '@open-wc/testing';
-import { a11ySnapshot } from '@web/test-runner-commands';
+import { executeServerCommand } from '@web/test-runner-commands';
 import type { TemplateResult } from 'lit';
 import { html } from 'lit/static-html.js';
 
-import { isChromium, isFirefox } from '../../dom.ts';
+import type { A11yNode } from '../../../../../tools/web-test-runner/aria-tree-plugin.ts';
+import { isChromium } from '../../dom.ts';
 import { testIf } from '../mocha-extensions.ts';
 import { waitForLitRender } from '../wait-for-render.ts';
 
 import { fixture } from './fixture.ts';
+
+export type { A11yNode };
+
+export function a11yTreeSnapshot(options: { selector: string }): Promise<A11yNode> {
+  return executeServerCommand('a11y-tree', options);
+}
+
+let nextId = 0;
 
 /**
  * Get the a11y tree snapshot and tests its snapshot.
@@ -16,7 +25,15 @@ import { fixture } from './fixture.ts';
  */
 async function a11yTreeEqualSnapshot(): Promise<void> {
   await aTimeout(500);
-  const snapshot = await a11ySnapshot({});
+  const currentFixture = Array.from(document.body.children)
+    .filter((child) => child.localName === 'div' && child.classList.length === 0)
+    .at(-1)!;
+  currentFixture.id = `a11y-fixture-${nextId++}`;
+  currentFixture.ariaLabel = 'Fixture Container';
+
+  const snapshot = await a11yTreeSnapshot({ selector: `#${currentFixture.id}` });
+  currentFixture.removeAttribute('id');
+  currentFixture.removeAttribute('aria-label');
 
   const htmlWrapper = await fixture(html`<p>${JSON.stringify(snapshot, null, 2)}</p>`);
   await expect(htmlWrapper).to.be.equalSnapshot();
@@ -51,8 +68,9 @@ export function testA11yTreeSnapshot(
     //   await a11yTreeEqualSnapshot();
     // });
 
-    testIf(isFirefox && !exclude.firefox, 'Firefox', async () => {
-      await a11yTreeEqualSnapshot();
-    });
+    // Only Chromium is supported at the moment
+    // testIf(isFirefox && !exclude.firefox, 'Firefox', async () => {
+    //  await a11yTreeEqualSnapshot();
+    //});
   });
 }

--- a/src/elements/date-input/__snapshots__/date-input.snapshot.spec.snap.js
+++ b/src/elements/date-input/__snapshots__/date-input.snapshot.spec.snap.js
@@ -38,34 +38,24 @@ snapshots["sbb-date-input renders Firefox Shadow DOM"] =
 snapshots["sbb-date-input renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "textbox",
       "name": "DD.MM.YYYY",
-      "value": "We, 11.12.2024"
+      "value": "We, 11.12.2024",
+      "invalid": false,
+      "focusable": true,
+      "editable": "plaintext",
+      "settable": true,
+      "multiline": false,
+      "readonly": false,
+      "required": false
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-date-input renders A11y tree Chrome */
-
-snapshots["sbb-date-input renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "textbox",
-      "name": "",
-      "value": "We, 11.12.2024"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-date-input renders A11y tree Firefox */
 

--- a/src/elements/datepicker/datepicker-next-day/__snapshots__/datepicker-next-day.snapshot.spec.snap.js
+++ b/src/elements/datepicker/datepicker-next-day/__snapshots__/datepicker-next-day.snapshot.spec.snap.js
@@ -39,13 +39,14 @@ snapshots["sbb-datepicker-next-day renders with connected date input Shadow DOM"
 snapshots["sbb-datepicker-next-day renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
       "name": "",
-      "disabled": true
+      "disabled": true,
+      "invalid": false
     }
   ]
 }
@@ -53,62 +54,19 @@ snapshots["sbb-datepicker-next-day renders A11y tree Chrome"] =
 `;
 /* end snapshot sbb-datepicker-next-day renders A11y tree Chrome */
 
-snapshots["sbb-datepicker-next-day renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "",
-      "disabled": true
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-datepicker-next-day renders A11y tree Firefox */
-
 snapshots["sbb-datepicker-next-day renders with connected date input A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "textbox",
-      "name": "DD.MM.YYYY",
-      "value": "Sa, 31.12.2022"
-    },
-    {
-      "role": "button",
-      "name": "Change to the next day, currently selected December 31, 2022."
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-datepicker-next-day renders with connected date input A11y tree Chrome */
-
-snapshots["sbb-datepicker-next-day renders with connected date input A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "textbox",
-      "name": "",
-      "value": "Sa, 31.12.2022"
-    },
-    {
-      "role": "button",
-      "name": "Change to the next day, currently selected December 31, 2022."
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-datepicker-next-day renders with connected date input A11y tree Firefox */
 

--- a/src/elements/datepicker/datepicker-previous-day/__snapshots__/datepicker-previous-day.snapshot.spec.snap.js
+++ b/src/elements/datepicker/datepicker-previous-day/__snapshots__/datepicker-previous-day.snapshot.spec.snap.js
@@ -39,13 +39,14 @@ snapshots["sbb-datepicker-previous-day renders with connected date input Shadow 
 snapshots["sbb-datepicker-previous-day renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
       "name": "",
-      "disabled": true
+      "disabled": true,
+      "invalid": false
     }
   ]
 }
@@ -53,62 +54,19 @@ snapshots["sbb-datepicker-previous-day renders A11y tree Chrome"] =
 `;
 /* end snapshot sbb-datepicker-previous-day renders A11y tree Chrome */
 
-snapshots["sbb-datepicker-previous-day renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "",
-      "disabled": true
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-datepicker-previous-day renders A11y tree Firefox */
-
 snapshots["sbb-datepicker-previous-day renders with connected date input A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "Change to the previous day, currently selected December 31, 2022."
-    },
-    {
-      "role": "textbox",
-      "name": "DD.MM.YYYY",
-      "value": "Sa, 31.12.2022"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-datepicker-previous-day renders with connected date input A11y tree Chrome */
-
-snapshots["sbb-datepicker-previous-day renders with connected date input A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Change to the previous day, currently selected December 31, 2022."
-    },
-    {
-      "role": "textbox",
-      "name": "",
-      "value": "Sa, 31.12.2022"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-datepicker-previous-day renders with connected date input A11y tree Firefox */
 

--- a/src/elements/datepicker/datepicker-toggle/__snapshots__/datepicker-toggle.snapshot.spec.snap.js
+++ b/src/elements/datepicker/datepicker-toggle/__snapshots__/datepicker-toggle.snapshot.spec.snap.js
@@ -81,51 +81,30 @@ snapshots["sbb-datepicker-toggle in form-field with calendar parameters Shadow D
 snapshots["sbb-datepicker-toggle in form-field with calendar parameters A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "​"
-    },
-    {
-      "role": "textbox",
-      "name": "DD.MM.YYYY"
-    },
-    {
-      "role": "button",
-      "name": "Show calendar",
-      "haspopup": "dialog"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "generic",
+          "name": ""
+        },
+        {
+          "role": "generic",
+          "name": ""
+        },
+        {
+          "ignored": true,
+          "role": "none"
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-datepicker-toggle in form-field with calendar parameters A11y tree Chrome */
-
-snapshots["sbb-datepicker-toggle in form-field with calendar parameters A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "statictext",
-      "name": "​"
-    },
-    {
-      "role": "textbox",
-      "name": "",
-      "value": "DD.MM.YYYY"
-    },
-    {
-      "role": "button",
-      "name": "Show calendar",
-      "haspopup": "dialog"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-datepicker-toggle in form-field with calendar parameters A11y tree Firefox */
 

--- a/src/elements/datepicker/datepicker/__snapshots__/datepicker.snapshot.spec.snap.js
+++ b/src/elements/datepicker/datepicker/__snapshots__/datepicker.snapshot.spec.snap.js
@@ -81,68 +81,30 @@ snapshots["sbb-datepicker renders Shadow DOM"] =
 snapshots["sbb-datepicker renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "​"
-    },
-    {
-      "role": "button",
-      "name": "Change to the previous day, currently selected December 20, 2021."
-    },
-    {
-      "role": "textbox",
-      "name": "DD.MM.YYYY",
-      "value": "Mo, 20.12.2021"
-    },
-    {
-      "role": "button",
-      "name": "Show calendar",
-      "haspopup": "dialog"
-    },
-    {
-      "role": "button",
-      "name": "Change to the next day, currently selected December 20, 2021."
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "generic",
+          "name": ""
+        },
+        {
+          "role": "generic",
+          "name": ""
+        },
+        {
+          "ignored": true,
+          "role": "none"
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-datepicker renders A11y tree Chrome */
-
-snapshots["sbb-datepicker renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "statictext",
-      "name": "​"
-    },
-    {
-      "role": "button",
-      "name": "Change to the previous day, currently selected December 20, 2021."
-    },
-    {
-      "role": "textbox",
-      "name": "",
-      "value": "Mo, 20.12.2021"
-    },
-    {
-      "role": "button",
-      "name": "Show calendar",
-      "haspopup": "dialog"
-    },
-    {
-      "role": "button",
-      "name": "Change to the next day, currently selected December 20, 2021."
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-datepicker renders A11y tree Firefox */
 

--- a/src/elements/dialog/dialog-actions/__snapshots__/dialog-actions.snapshot.spec.snap.js
+++ b/src/elements/dialog/dialog-actions/__snapshots__/dialog-actions.snapshot.spec.snap.js
@@ -22,20 +22,16 @@ snapshots["sbb-dialog-actions renders Shadow DOM"] =
 snapshots["sbb-dialog-actions renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "ignored": true,
+      "role": "none"
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-dialog-actions renders A11y tree Chrome */
-
-snapshots["sbb-dialog-actions renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-dialog-actions renders A11y tree Firefox */
 

--- a/src/elements/dialog/dialog-close-button/__snapshots__/dialog-close-button.snapshot.spec.snap.js
+++ b/src/elements/dialog/dialog-close-button/__snapshots__/dialog-close-button.snapshot.spec.snap.js
@@ -20,31 +20,17 @@ snapshots["sbb-dialog-close-button renders Shadow DOM"] =
 `;
 /* end snapshot sbb-dialog-close-button renders Shadow DOM */
 
-snapshots["sbb-dialog-close-button renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Close secondary window"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-dialog-close-button renders A11y tree Firefox */
-
 snapshots["sbb-dialog-close-button renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
-      "name": "Close secondary window"
+      "name": "Close secondary window",
+      "invalid": false,
+      "focusable": true
     }
   ]
 }

--- a/src/elements/dialog/dialog-content/__snapshots__/dialog-content.snapshot.spec.snap.js
+++ b/src/elements/dialog/dialog-content/__snapshots__/dialog-content.snapshot.spec.snap.js
@@ -17,32 +17,16 @@ snapshots["sbb-dialog-content renders Shadow DOM"] =
 snapshots["sbb-dialog-content renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Content"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-dialog-content renders A11y tree Chrome */
-
-snapshots["sbb-dialog-content renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Content"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-dialog-content renders A11y tree Firefox */
 

--- a/src/elements/dialog/dialog-title/__snapshots__/dialog-title.snapshot.spec.snap.js
+++ b/src/elements/dialog/dialog-title/__snapshots__/dialog-title.snapshot.spec.snap.js
@@ -20,8 +20,8 @@ snapshots["sbb-dialog-title renders Shadow DOM"] =
 snapshots["sbb-dialog-title renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "heading",
@@ -33,21 +33,4 @@ snapshots["sbb-dialog-title renders A11y tree Chrome"] =
 </p>
 `;
 /* end snapshot sbb-dialog-title renders A11y tree Chrome */
-
-snapshots["sbb-dialog-title renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "Title",
-      "level": 2
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-dialog-title renders A11y tree Firefox */
 

--- a/src/elements/dialog/dialog/__snapshots__/dialog.snapshot.spec.snap.js
+++ b/src/elements/dialog/dialog/__snapshots__/dialog.snapshot.spec.snap.js
@@ -73,49 +73,15 @@ snapshots["sbb-dialog renders an open dialog with close button negative Shadow D
 `;
 /* end snapshot sbb-dialog renders an open dialog with close button negative Shadow DOM */
 
-snapshots["sbb-dialog renders an open dialog A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "Title",
-      "level": 2
-    },
-    {
-      "role": "text leaf",
-      "name": "Content"
-    },
-    {
-      "role": "text leaf",
-      "name": "Dialog, Title "
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-dialog renders an open dialog A11y tree Firefox */
-
 snapshots["sbb-dialog renders an open dialog A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "heading",
-      "name": "Title",
-      "level": 2
-    },
-    {
-      "role": "text",
-      "name": "Content"
-    },
-    {
-      "role": "text",
-      "name": "Dialog, Title "
+      "role": "group",
+      "name": ""
     }
   ]
 }
@@ -123,59 +89,15 @@ snapshots["sbb-dialog renders an open dialog A11y tree Chrome"] =
 `;
 /* end snapshot sbb-dialog renders an open dialog A11y tree Chrome */
 
-snapshots["sbb-dialog renders an open dialog with close button negative A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "Title",
-      "level": 2
-    },
-    {
-      "role": "button",
-      "name": "Close secondary window",
-      "focused": true
-    },
-    {
-      "role": "text leaf",
-      "name": "Content"
-    },
-    {
-      "role": "text leaf",
-      "name": "Dialog, Title "
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-dialog renders an open dialog with close button negative A11y tree Firefox */
-
 snapshots["sbb-dialog renders an open dialog with close button negative A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "heading",
-      "name": "Title",
-      "level": 2
-    },
-    {
-      "role": "button",
-      "name": "Close secondary window",
-      "focused": true
-    },
-    {
-      "role": "text",
-      "name": "Content"
-    },
-    {
-      "role": "text",
-      "name": "Dialog, Title "
+      "role": "group",
+      "name": ""
     }
   ]
 }

--- a/src/elements/divider/__snapshots__/divider.snapshot.spec.snap.js
+++ b/src/elements/divider/__snapshots__/divider.snapshot.spec.snap.js
@@ -22,22 +22,20 @@ snapshots["sbb-divider renders vertical DOM"] =
 snapshots["sbb-divider renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "role": "separator",
+      "name": "",
+      "settable": true,
+      "orientation": "horizontal"
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-divider renders A11y tree Chrome */
-
-snapshots["sbb-divider renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-divider renders A11y tree Firefox */
 
 snapshots["sbb-divider renders Shadow DOM"] = 
 `<div class="sbb-divider">

--- a/src/elements/expansion-panel/expansion-panel-content/__snapshots__/expansion-panel-content.snapshot.spec.snap.js
+++ b/src/elements/expansion-panel/expansion-panel-content/__snapshots__/expansion-panel-content.snapshot.spec.snap.js
@@ -19,32 +19,22 @@ snapshots["sbb-expansion-panel-content renders Shadow DOM"] =
 snapshots["sbb-expansion-panel-content renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Content"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "generic",
+          "name": ""
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-expansion-panel-content renders A11y tree Chrome */
-
-snapshots["sbb-expansion-panel-content renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Content"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-expansion-panel-content renders A11y tree Firefox */
 

--- a/src/elements/expansion-panel/expansion-panel-header/__snapshots__/expansion-panel-header.snapshot.spec.snap.js
+++ b/src/elements/expansion-panel/expansion-panel-header/__snapshots__/expansion-panel-header.snapshot.spec.snap.js
@@ -105,32 +105,18 @@ snapshots["sbb-expansion-panel-header renders with slotted icon Shadow DOM"] =
 snapshots["sbb-expansion-panel-header renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
-      "name": "Header"
+      "name": "Header",
+      "invalid": false,
+      "focusable": true
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-expansion-panel-header renders A11y tree Chrome */
-
-snapshots["sbb-expansion-panel-header renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Header"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-expansion-panel-header renders A11y tree Firefox */
 

--- a/src/elements/expansion-panel/expansion-panel/__snapshots__/expansion-panel.snapshot.spec.snap.js
+++ b/src/elements/expansion-panel/expansion-panel/__snapshots__/expansion-panel.snapshot.spec.snap.js
@@ -131,32 +131,45 @@ snapshots["sbb-expansion-panel renders with level set Shadow DOM"] =
 snapshots["sbb-expansion-panel renders with level set A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "Header"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "role": "heading",
+              "name": "Header",
+              "level": 4
+            },
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "ignored": true,
+                      "role": "none"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-expansion-panel renders with level set A11y tree Chrome */
-
-snapshots["sbb-expansion-panel renders with level set A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Header"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-expansion-panel renders with level set A11y tree Firefox */
 

--- a/src/elements/file-selector/file-selector-dropzone/__snapshots__/file-selector-dropzone.snapshot.spec.snap.js
+++ b/src/elements/file-selector/file-selector-dropzone/__snapshots__/file-selector-dropzone.snapshot.spec.snap.js
@@ -49,51 +49,43 @@ snapshots["sbb-file-selector-dropzone renders Shadow DOM"] =
 snapshots["sbb-file-selector-dropzone renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Drag & Drop your file here"
-    },
-    {
-      "role": "text",
-      "name": "Choose a file"
-    },
-    {
-      "role": "button",
-      "name": "Drag & Drop your file here Choose a file",
-      "value": "No file chosen"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "role": "LabelText",
+                  "name": ""
+                }
+              ]
+            },
+            {
+              "role": "status",
+              "name": "",
+              "live": "polite",
+              "atomic": true,
+              "relevant": "additions text"
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-file-selector-dropzone renders A11y tree Chrome */
-
-snapshots["sbb-file-selector-dropzone renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Drag & Drop your file here"
-    },
-    {
-      "role": "text leaf",
-      "name": "Choose a file"
-    },
-    {
-      "role": "button",
-      "name": "Drag & Drop your file here Choose a file Browse… …"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-file-selector-dropzone renders A11y tree Firefox */
 
 snapshots["sbb-file-selector-dropzone renders multiple DOM"] = 
 `<sbb-file-selector-dropzone
@@ -147,49 +139,41 @@ snapshots["sbb-file-selector-dropzone renders multiple Shadow DOM"] =
 snapshots["sbb-file-selector-dropzone renders multiple A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Drag & Drop your files here"
-    },
-    {
-      "role": "text",
-      "name": "Choose files"
-    },
-    {
-      "role": "button",
-      "name": "Drag & Drop your files here Choose files",
-      "value": "No file chosen"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "role": "LabelText",
+                  "name": ""
+                }
+              ]
+            },
+            {
+              "role": "status",
+              "name": "",
+              "live": "polite",
+              "atomic": true,
+              "relevant": "additions text"
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-file-selector-dropzone renders multiple A11y tree Chrome */
-
-snapshots["sbb-file-selector-dropzone renders multiple A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Drag & Drop your files here"
-    },
-    {
-      "role": "text leaf",
-      "name": "Choose files"
-    },
-    {
-      "role": "button",
-      "name": "Drag & Drop your files here Choose files Browse… …"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-file-selector-dropzone renders multiple A11y tree Firefox */
 

--- a/src/elements/file-selector/file-selector/__snapshots__/file-selector.snapshot.spec.snap.js
+++ b/src/elements/file-selector/file-selector/__snapshots__/file-selector.snapshot.spec.snap.js
@@ -39,41 +39,41 @@ snapshots["sbb-file-selector renders Shadow DOM"] =
 snapshots["sbb-file-selector renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Choose a file"
-    },
-    {
-      "role": "button",
-      "name": "Choose a file",
-      "value": "No file chosen"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "role": "LabelText",
+                  "name": ""
+                }
+              ]
+            },
+            {
+              "role": "status",
+              "name": "",
+              "live": "polite",
+              "atomic": true,
+              "relevant": "additions text"
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-file-selector renders A11y tree Chrome */
-
-snapshots["sbb-file-selector renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Choose a file"
-    },
-    {
-      "role": "button",
-      "name": "Choose a file Browse… …"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-file-selector renders A11y tree Firefox */
 

--- a/src/elements/flip-card/flip-card-details/__snapshots__/flip-card-details.snapshot.spec.snap.js
+++ b/src/elements/flip-card/flip-card-details/__snapshots__/flip-card-details.snapshot.spec.snap.js
@@ -37,32 +37,16 @@ snapshots["sbb-flip-card-details Shadow DOM"] =
 snapshots["sbb-flip-card-details A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Example text"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-flip-card-details A11y tree Chrome */
-
-snapshots["sbb-flip-card-details A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Example text"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-flip-card-details A11y tree Firefox */
 

--- a/src/elements/flip-card/flip-card-summary/__snapshots__/flip-card-summary.snapshot.spec.snap.js
+++ b/src/elements/flip-card/flip-card-summary/__snapshots__/flip-card-summary.snapshot.spec.snap.js
@@ -47,34 +47,39 @@ snapshots["sbb-flip-card-summary Shadow DOM"] =
 snapshots["sbb-flip-card-summary A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "heading",
-      "name": "Summary",
-      "level": 4
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "heading",
+          "name": "Summary",
+          "level": 4
+        },
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "role": "generic",
+                  "name": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-flip-card-summary A11y tree Chrome */
-
-snapshots["sbb-flip-card-summary A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "Summary",
-      "level": 4
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-flip-card-summary A11y tree Firefox */
 

--- a/src/elements/flip-card/flip-card/__snapshots__/flip-card.snapshot.spec.snap.js
+++ b/src/elements/flip-card/flip-card/__snapshots__/flip-card.snapshot.spec.snap.js
@@ -91,42 +91,16 @@ snapshots["sbb-flip-card Shadow DOM"] =
 snapshots["sbb-flip-card A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "Summary, Click on this card for details"
-    },
-    {
-      "role": "heading",
-      "name": "Summary",
-      "level": 4
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-flip-card A11y tree Chrome */
-
-snapshots["sbb-flip-card A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Summary, Click on this card for details"
-    },
-    {
-      "role": "heading",
-      "name": "Summary",
-      "level": 4
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-flip-card A11y tree Firefox */
 

--- a/src/elements/footer/__snapshots__/footer.snapshot.spec.snap.js
+++ b/src/elements/footer/__snapshots__/footer.snapshot.spec.snap.js
@@ -26,34 +26,22 @@ snapshots["sbb-footer renders Shadow DOM"] =
 snapshots["sbb-footer renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "heading",
-      "name": "Footer",
-      "level": 1
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "contentinfo",
+          "name": ""
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-footer renders A11y tree Chrome */
-
-snapshots["sbb-footer renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "Footer",
-      "level": 1
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-footer renders A11y tree Firefox */
 

--- a/src/elements/form-field/error/__snapshots__/error.snapshot.spec.snap.js
+++ b/src/elements/form-field/error/__snapshots__/error.snapshot.spec.snap.js
@@ -23,32 +23,16 @@ snapshots["sbb-error renders Shadow DOM"] =
 snapshots["sbb-error renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Required"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-error renders A11y tree Chrome */
-
-snapshots["sbb-error renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Required"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-error renders A11y tree Firefox */
 

--- a/src/elements/form-field/form-field-clear/__snapshots__/form-field-clear.snapshot.spec.snap.js
+++ b/src/elements/form-field/form-field-clear/__snapshots__/form-field-clear.snapshot.spec.snap.js
@@ -39,58 +39,30 @@ snapshots["sbb-form-field-clear renders form-field-clear Shadow DOM"] =
 snapshots["sbb-form-field-clear renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "​"
-    },
-    {
-      "role": "text",
-      "name": "Label"
-    },
-    {
-      "role": "textbox",
-      "name": "Label",
-      "value": "Input value"
-    },
-    {
-      "role": "button",
-      "name": "Clear input value"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "generic",
+          "name": ""
+        },
+        {
+          "role": "generic",
+          "name": ""
+        },
+        {
+          "ignored": true,
+          "role": "none"
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-form-field-clear renders A11y tree Chrome */
-
-snapshots["sbb-form-field-clear renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "statictext",
-      "name": "​"
-    },
-    {
-      "role": "text leaf",
-      "name": "Label"
-    },
-    {
-      "role": "textbox",
-      "name": "Label",
-      "value": "Input value"
-    },
-    {
-      "role": "button",
-      "name": "Clear input value"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-form-field-clear renders A11y tree Firefox */
 

--- a/src/elements/form-field/form-field/__snapshots__/form-field.snapshot.spec.snap.js
+++ b/src/elements/form-field/form-field/__snapshots__/form-field.snapshot.spec.snap.js
@@ -319,48 +319,30 @@ snapshots["sbb-form-field renders select with optional flag and borderless Shado
 snapshots["sbb-form-field A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "​"
-    },
-    {
-      "role": "text",
-      "name": "Fill input"
-    },
-    {
-      "role": "textbox",
-      "name": "Fill input"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "generic",
+          "name": ""
+        },
+        {
+          "role": "generic",
+          "name": ""
+        },
+        {
+          "ignored": true,
+          "role": "none"
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-form-field A11y tree Chrome */
-
-snapshots["sbb-form-field A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "statictext",
-      "name": "​"
-    },
-    {
-      "role": "text leaf",
-      "name": "Fill input"
-    },
-    {
-      "role": "textbox",
-      "name": "Fill input"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-form-field A11y tree Firefox */
 

--- a/src/elements/header/header-button/__snapshots__/header-button.snapshot.spec.snap.js
+++ b/src/elements/header/header-button/__snapshots__/header-button.snapshot.spec.snap.js
@@ -37,32 +37,18 @@ snapshots["sbb-header-button renders Shadow DOM"] =
 snapshots["sbb-header-button renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
-      "name": "a11y label"
+      "name": "a11y label",
+      "invalid": false,
+      "focusable": true
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-header-button renders A11y tree Chrome */
-
-snapshots["sbb-header-button renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "a11y label"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-header-button renders A11y tree Firefox */
 

--- a/src/elements/header/header-link/__snapshots__/header-link.snapshot.spec.snap.js
+++ b/src/elements/header/header-link/__snapshots__/header-link.snapshot.spec.snap.js
@@ -44,33 +44,16 @@ snapshots["sbb-header-link renders Shadow DOM"] =
 snapshots["sbb-header-link renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "link",
-      "name": "a11y label"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-header-link renders A11y tree Chrome */
-
-snapshots["sbb-header-link renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "link",
-      "name": "a11y label",
-      "value": "https://github.com/sbb-design-systems/lyne-components"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-header-link renders A11y tree Firefox */
 

--- a/src/elements/header/header/__snapshots__/header.snapshot.spec.snap.js
+++ b/src/elements/header/header/__snapshots__/header.snapshot.spec.snap.js
@@ -53,33 +53,16 @@ snapshots["sbb-header renders actions and logo Shadow DOM"] =
 snapshots["sbb-header renders actions and logo A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "link",
-      "name": "Menu"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-header renders actions and logo A11y tree Chrome */
-
-snapshots["sbb-header renders actions and logo A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "link",
-      "name": "Menu",
-      "value": "https://github.com/sbb-design-systems/lyne-components"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-header renders actions and logo A11y tree Firefox */
 

--- a/src/elements/icon-sidebar/icon-sidebar-button/__snapshots__/icon-sidebar-button.snapshot.spec.snap.js
+++ b/src/elements/icon-sidebar/icon-sidebar-button/__snapshots__/icon-sidebar-button.snapshot.spec.snap.js
@@ -24,32 +24,18 @@ snapshots["sbb-icon-sidebar-button renders Shadow DOM"] =
 snapshots["sbb-icon-sidebar-button renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
-      "name": "Go to the party"
+      "name": "Go to the party",
+      "invalid": false,
+      "focusable": true
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-icon-sidebar-button renders A11y tree Chrome */
-
-snapshots["sbb-icon-sidebar-button renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Go to the party"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-icon-sidebar-button renders A11y tree Firefox */
 

--- a/src/elements/icon-sidebar/icon-sidebar-container/__snapshots__/icon-sidebar-container.snapshot.spec.snap.js
+++ b/src/elements/icon-sidebar/icon-sidebar-container/__snapshots__/icon-sidebar-container.snapshot.spec.snap.js
@@ -16,20 +16,16 @@ snapshots["sbb-icon-sidebar-container renders Shadow DOM"] =
 snapshots["sbb-icon-sidebar-container renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "role": "generic",
+      "name": ""
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-icon-sidebar-container renders A11y tree Chrome */
-
-snapshots["sbb-icon-sidebar-container renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-icon-sidebar-container renders A11y tree Firefox */
 

--- a/src/elements/icon-sidebar/icon-sidebar-content/__snapshots__/icon-sidebar-content.snapshot.spec.snap.js
+++ b/src/elements/icon-sidebar/icon-sidebar-content/__snapshots__/icon-sidebar-content.snapshot.spec.snap.js
@@ -19,20 +19,16 @@ snapshots["sbb-icon-sidebar-content renders Shadow DOM"] =
 snapshots["sbb-icon-sidebar-content renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "role": "main",
+      "name": ""
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-icon-sidebar-content renders A11y tree Chrome */
-
-snapshots["sbb-icon-sidebar-content renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-icon-sidebar-content renders A11y tree Firefox */
 

--- a/src/elements/icon-sidebar/icon-sidebar-link/__snapshots__/icon-sidebar-link.snapshot.spec.snap.js
+++ b/src/elements/icon-sidebar/icon-sidebar-link/__snapshots__/icon-sidebar-link.snapshot.spec.snap.js
@@ -28,33 +28,16 @@ snapshots["sbb-icon-sidebar-link renders Shadow DOM"] =
 snapshots["sbb-icon-sidebar-link renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "link",
-      "name": "Go to the party"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-icon-sidebar-link renders A11y tree Chrome */
-
-snapshots["sbb-icon-sidebar-link renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "link",
-      "name": "Go to the party",
-      "value": "https://www.sbb.ch/"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-icon-sidebar-link renders A11y tree Firefox */
 

--- a/src/elements/icon-sidebar/icon-sidebar/__snapshots__/icon-sidebar.snapshot.spec.snap.js
+++ b/src/elements/icon-sidebar/icon-sidebar/__snapshots__/icon-sidebar.snapshot.spec.snap.js
@@ -19,20 +19,16 @@ snapshots["sbb-icon-sidebar renders Shadow DOM"] =
 snapshots["sbb-icon-sidebar renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "role": "navigation",
+      "name": ""
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-icon-sidebar renders A11y tree Chrome */
-
-snapshots["sbb-icon-sidebar renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-icon-sidebar renders A11y tree Firefox */
 

--- a/src/elements/icon/__snapshots__/icon.snapshot.spec.snap.js
+++ b/src/elements/icon/__snapshots__/icon.snapshot.spec.snap.js
@@ -93,20 +93,16 @@ snapshots["sbb-icon renders custom aria-label Shadow DOM"] =
 snapshots["sbb-icon A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "ignored": true,
+      "role": "none"
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-icon A11y tree Chrome */
-
-snapshots["sbb-icon A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-icon A11y tree Firefox */
 

--- a/src/elements/journey-header/__snapshots__/journey-header.snapshot.spec.snap.js
+++ b/src/elements/journey-header/__snapshots__/journey-header.snapshot.spec.snap.js
@@ -70,8 +70,8 @@ snapshots["sbb-journey-header renders H1 L-sized round-trip negative Shadow DOM"
 snapshots["sbb-journey-header renders H1 L-sized round-trip negative A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "heading",
@@ -83,21 +83,4 @@ snapshots["sbb-journey-header renders H1 L-sized round-trip negative A11y tree C
 </p>
 `;
 /* end snapshot sbb-journey-header renders H1 L-sized round-trip negative A11y tree Chrome */
-
-snapshots["sbb-journey-header renders H1 L-sized round-trip negative A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "Connection from B to C and back to B.",
-      "level": 1
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-journey-header renders H1 L-sized round-trip negative A11y tree Firefox */
 

--- a/src/elements/lead-container/__snapshots__/lead-container.snapshot.spec.snap.js
+++ b/src/elements/lead-container/__snapshots__/lead-container.snapshot.spec.snap.js
@@ -28,20 +28,50 @@ snapshots["sbb-lead-container Shadow DOM"] =
 snapshots["sbb-lead-container A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "role": "generic",
+                      "name": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "role": "generic",
+                  "name": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-lead-container A11y tree Chrome */
-
-snapshots["sbb-lead-container A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-lead-container A11y tree Firefox */
 

--- a/src/elements/link-list/link-list-anchor/__snapshots__/link-list-anchor.snapshot.spec.snap.js
+++ b/src/elements/link-list/link-list-anchor/__snapshots__/link-list-anchor.snapshot.spec.snap.js
@@ -74,61 +74,33 @@ snapshots["sbb-link-list-anchor renders Shadow DOM"] =
 snapshots["sbb-link-list-anchor renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "heading",
-      "name": "title",
-      "level": 2
-    },
-    {
-      "role": "link",
-      "name": "Link 0"
-    },
-    {
-      "role": "link",
-      "name": "Link 1"
-    },
-    {
-      "role": "link",
-      "name": "Link 2"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "role": "heading",
+              "name": "title",
+              "level": 2
+            },
+            {
+              "role": "list",
+              "name": "title"
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-link-list-anchor renders A11y tree Chrome */
-
-snapshots["sbb-link-list-anchor renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "title",
-      "level": 2
-    },
-    {
-      "role": "link",
-      "name": "Link 0",
-      "value": "https://www.sbb.ch/"
-    },
-    {
-      "role": "link",
-      "name": "Link 1",
-      "value": "https://www.sbb.ch/"
-    },
-    {
-      "role": "link",
-      "name": "Link 2",
-      "value": "https://www.sbb.ch/"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-link-list-anchor renders A11y tree Firefox */
 

--- a/src/elements/link-list/link-list/__snapshots__/link-list.snapshot.spec.snap.js
+++ b/src/elements/link-list/link-list/__snapshots__/link-list.snapshot.spec.snap.js
@@ -326,20 +326,10 @@ snapshots["sbb-link-list rendered without a title Shadow DOM"] =
 snapshots["sbb-link-list rendered with a slotted title A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "ignored": true,
+  "role": "none"
 }
 </p>
 `;
 /* end snapshot sbb-link-list rendered with a slotted title A11y tree Chrome */
-
-snapshots["sbb-link-list rendered with a slotted title A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-link-list rendered with a slotted title A11y tree Firefox */
 

--- a/src/elements/link/block-link-button/__snapshots__/block-link-button.snapshot.spec.snap.js
+++ b/src/elements/link/block-link-button/__snapshots__/block-link-button.snapshot.spec.snap.js
@@ -36,32 +36,18 @@ snapshots["sbb-block-link-button renders Shadow DOM"] =
 snapshots["sbb-block-link-button renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
-      "name": "Travelcards & tickets."
+      "name": "Travelcards & tickets.",
+      "invalid": false,
+      "focusable": true
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-block-link-button renders A11y tree Chrome */
-
-snapshots["sbb-block-link-button renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Travelcards & tickets."
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-block-link-button renders A11y tree Firefox */
 

--- a/src/elements/link/block-link-static/__snapshots__/block-link-static.snapshot.spec.snap.js
+++ b/src/elements/link/block-link-static/__snapshots__/block-link-static.snapshot.spec.snap.js
@@ -33,32 +33,44 @@ snapshots["sbb-block-link-static renders Shadow DOM"] =
 snapshots["sbb-block-link-static renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Travelcards & tickets."
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "ignored": true,
+                      "role": "none"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "role": "StaticText",
+              "name": "Travelcards & tickets."
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-block-link-static renders A11y tree Chrome */
-
-snapshots["sbb-block-link-static renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Travelcards & tickets. "
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-block-link-static renders A11y tree Firefox */
 

--- a/src/elements/link/block-link/__snapshots__/block-link.snapshot.spec.snap.js
+++ b/src/elements/link/block-link/__snapshots__/block-link.snapshot.spec.snap.js
@@ -34,33 +34,16 @@ snapshots["sbb-block-link renders Shadow DOM"] =
 snapshots["sbb-block-link renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "link",
-      "name": "Travelcards & tickets"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-block-link renders A11y tree Chrome */
-
-snapshots["sbb-block-link renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "link",
-      "name": "Travelcards & tickets",
-      "value": "https://github.com/sbb-design-systems/lyne-components"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-block-link renders A11y tree Firefox */
 

--- a/src/elements/link/link-button/__snapshots__/link-button.snapshot.spec.snap.js
+++ b/src/elements/link/link-button/__snapshots__/link-button.snapshot.spec.snap.js
@@ -27,32 +27,18 @@ snapshots["sbb-link-button renders Shadow DOM"] =
 snapshots["sbb-link-button renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
-      "name": "Travelcards & tickets"
+      "name": "Travelcards & tickets",
+      "invalid": false,
+      "focusable": true
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-link-button renders A11y tree Chrome */
-
-snapshots["sbb-link-button renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Travelcards & tickets"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-link-button renders A11y tree Firefox */
 

--- a/src/elements/link/link-static/__snapshots__/link-static.snapshot.spec.snap.js
+++ b/src/elements/link/link-static/__snapshots__/link-static.snapshot.spec.snap.js
@@ -19,32 +19,22 @@ snapshots["sbb-link-static renders Shadow DOM"] =
 snapshots["sbb-link-static renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Travelcards & tickets."
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "StaticText",
+          "name": "Travelcards & tickets."
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-link-static renders A11y tree Chrome */
-
-snapshots["sbb-link-static renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Travelcards & tickets. "
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-link-static renders A11y tree Firefox */
 

--- a/src/elements/link/link/__snapshots__/link.snapshot.spec.snap.js
+++ b/src/elements/link/link/__snapshots__/link.snapshot.spec.snap.js
@@ -31,35 +31,18 @@ snapshots["sbb-link renders Shadow DOM"] =
 snapshots["sbb-link renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "link",
-      "name": "Travelcards & tickets. . Link target opens in a new window."
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-link renders A11y tree Chrome */
-
-snapshots["sbb-link renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "link",
-      "name": "Travelcards & tickets. . Link target opens in a new window.",
-      "value": "https://sbb.ch/"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-link renders A11y tree Firefox */
 
 snapshots["sbb-link reflects properties DOM"] = 
 `<sbb-link
@@ -94,33 +77,16 @@ snapshots["sbb-link reflects properties Shadow DOM"] =
 snapshots["sbb-link reflects properties A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "link",
-      "name": "Travelcards & tickets. . Link target opens in a new window."
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-link reflects properties A11y tree Chrome */
-
-snapshots["sbb-link reflects properties A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "link",
-      "name": "Travelcards & tickets. . Link target opens in a new window.",
-      "value": "https://sbb.ch/"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-link reflects properties A11y tree Firefox */
 

--- a/src/elements/loading-indicator-circle/__snapshots__/loading-indicator-circle.snapshot.spec.snap.js
+++ b/src/elements/loading-indicator-circle/__snapshots__/loading-indicator-circle.snapshot.spec.snap.js
@@ -18,8 +18,18 @@ snapshots["sbb-loading-indicator-circle renders with variant `circle` Shadow DOM
 snapshots["sbb-loading-indicator-circle renders with variant `circle` A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "role": "progressbar",
+      "name": "",
+      "valuemin": 0,
+      "valuemax": 100,
+      "valuetext": "",
+      "busy": 1
+    }
+  ]
 }
 </p>
 `;

--- a/src/elements/loading-indicator/__snapshots__/loading-indicator.snapshot.spec.snap.js
+++ b/src/elements/loading-indicator/__snapshots__/loading-indicator.snapshot.spec.snap.js
@@ -55,8 +55,18 @@ snapshots["sbb-loading-indicator renders with variant `circle` Shadow DOM"] =
 snapshots["sbb-loading-indicator renders with variant `window` A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "role": "progressbar",
+      "name": "",
+      "valuemin": 0,
+      "valuemax": 100,
+      "valuetext": "",
+      "busy": 1
+    }
+  ]
 }
 </p>
 `;

--- a/src/elements/map-container/__snapshots__/map-container.snapshot.spec.snap.js
+++ b/src/elements/map-container/__snapshots__/map-container.snapshot.spec.snap.js
@@ -58,20 +58,32 @@ snapshots["sbb-map-container renders without scroll-up button Shadow DOM"] =
 snapshots["sbb-map-container renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "role": "generic",
+              "name": ""
+            },
+            {
+              "role": "generic",
+              "name": ""
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-map-container renders A11y tree Chrome */
-
-snapshots["sbb-map-container renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-map-container renders A11y tree Firefox */
 

--- a/src/elements/menu/menu-button/__snapshots__/menu-button.snapshot.spec.snap.js
+++ b/src/elements/menu/menu-button/__snapshots__/menu-button.snapshot.spec.snap.js
@@ -69,38 +69,18 @@ snapshots["sbb-menu-button renders component with icon Shadow DOM"] =
 snapshots["sbb-menu-button renders component with icon A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "menuitem",
-      "name": "Action"
+      "name": "Action",
+      "invalid": false,
+      "focusable": true
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-menu-button renders component with icon A11y tree Chrome */
-
-snapshots["sbb-menu-button renders component with icon A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text container",
-      "name": "",
-      "children": [
-        {
-          "role": "text leaf",
-          "name": "Action"
-        }
-      ]
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-menu-button renders component with icon A11y tree Firefox */
 

--- a/src/elements/menu/menu-link/__snapshots__/menu-link.snapshot.spec.snap.js
+++ b/src/elements/menu/menu-link/__snapshots__/menu-link.snapshot.spec.snap.js
@@ -89,32 +89,16 @@ snapshots["sbb-menu-link renders component with icon Shadow DOM"] =
 snapshots["sbb-menu-link renders component with icon A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "menuitem",
-      "name": "a11y label"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-menu-link renders component with icon A11y tree Chrome */
-
-snapshots["sbb-menu-link renders component with icon A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text container",
-      "name": "a11y label"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-menu-link renders component with icon A11y tree Firefox */
 

--- a/src/elements/menu/menu/__snapshots__/menu.snapshot.spec.snap.js
+++ b/src/elements/menu/menu/__snapshots__/menu.snapshot.spec.snap.js
@@ -138,82 +138,16 @@ snapshots["sbb-menu renders open Shadow DOM"] =
 snapshots["sbb-menu renders open A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "menu",
-      "name": "",
-      "orientation": "vertical",
-      "children": [
-        {
-          "role": "link",
-          "name": "Profile",
-          "focused": true
-        },
-        {
-          "role": "menuitem",
-          "name": "View"
-        },
-        {
-          "role": "menuitem",
-          "name": "Edit 1",
-          "disabled": true
-        },
-        {
-          "role": "menuitem",
-          "name": "Details 2"
-        },
-        {
-          "role": "menuitem",
-          "name": "Cancel"
-        }
-      ]
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-menu renders open A11y tree Chrome */
-
-snapshots["sbb-menu renders open A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "menu",
-      "name": "",
-      "children": [
-        {
-          "role": "link",
-          "name": "Profile",
-          "focused": true,
-          "value": "https://www.sbb.ch/en"
-        },
-        {
-          "role": "menuitem",
-          "name": "View"
-        },
-        {
-          "role": "menuitem",
-          "name": "Edit 1",
-          "disabled": true
-        },
-        {
-          "role": "menuitem",
-          "name": "Details 2"
-        },
-        {
-          "role": "menuitem",
-          "name": "Cancel"
-        }
-      ]
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-menu renders open A11y tree Firefox */
 

--- a/src/elements/message/__snapshots__/message.snapshot.spec.snap.js
+++ b/src/elements/message/__snapshots__/message.snapshot.spec.snap.js
@@ -80,58 +80,53 @@ snapshots["sbb-message renders without optional slots Shadow DOM"] =
 snapshots["sbb-message renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "heading",
-      "name": "Title.",
-      "level": 3
-    },
-    {
-      "role": "text",
-      "name": "Subtitle."
-    },
-    {
-      "role": "text",
-      "name": "Error code: 0001"
-    },
-    {
-      "role": "button",
-      "name": ""
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "role": "generic",
+                  "name": ""
+                }
+              ]
+            },
+            {
+              "role": "heading",
+              "name": "Title.",
+              "level": 3
+            },
+            {
+              "role": "paragraph",
+              "name": ""
+            },
+            {
+              "role": "paragraph",
+              "name": ""
+            },
+            {
+              "role": "button",
+              "name": "",
+              "invalid": false,
+              "focusable": true
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-message renders A11y tree Chrome */
-
-snapshots["sbb-message renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "Title.",
-      "level": 3
-    },
-    {
-      "role": "text leaf",
-      "name": "Subtitle."
-    },
-    {
-      "role": "text leaf",
-      "name": "Error code: 0001"
-    },
-    {
-      "role": "button",
-      "name": ""
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-message renders A11y tree Firefox */
 

--- a/src/elements/mini-calendar/mini-calendar-day/__snapshots__/mini-calendar-day.snapshot.spec.snap.js
+++ b/src/elements/mini-calendar/mini-calendar-day/__snapshots__/mini-calendar-day.snapshot.spec.snap.js
@@ -19,32 +19,18 @@ snapshots["sbb-mini-calendar-day renders Shadow DOM"] =
 snapshots["sbb-mini-calendar-day renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
-      "name": "January 1, 2025"
+      "name": "January 1, 2025",
+      "invalid": false,
+      "focusable": true
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-mini-calendar-day renders A11y tree Chrome */
-
-snapshots["sbb-mini-calendar-day renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "January 1, 2025"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-mini-calendar-day renders A11y tree Firefox */
 

--- a/src/elements/mini-calendar/mini-calendar-month/__snapshots__/mini-calendar-month.snapshot.spec.snap.js
+++ b/src/elements/mini-calendar/mini-calendar-month/__snapshots__/mini-calendar-month.snapshot.spec.snap.js
@@ -61,39 +61,33 @@ snapshots["sbb-mini-calendar-month renders June Shadow DOM"] =
 `;
 /* end snapshot sbb-mini-calendar-month renders June Shadow DOM */
 
-snapshots["sbb-mini-calendar-month renders January A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "January 1, 2025"
-    },
-    {
-      "role": "text leaf",
-      "name": "Jan."
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-mini-calendar-month renders January A11y tree Firefox */
-
 snapshots["sbb-mini-calendar-month renders January A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "January 1, 2025"
-    },
-    {
-      "role": "text",
-      "name": "Jan."
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "role": "button",
+              "name": "January 1, 2025",
+              "invalid": false,
+              "focusable": true
+            }
+          ]
+        },
+        {
+          "role": "generic",
+          "name": ""
+        }
+      ]
     }
   ]
 }

--- a/src/elements/mini-calendar/mini-calendar/__snapshots__/mini-calendar.snapshot.spec.snap.js
+++ b/src/elements/mini-calendar/mini-calendar/__snapshots__/mini-calendar.snapshot.spec.snap.js
@@ -23,47 +23,55 @@ snapshots["sbb-mini-calendar renders Shadow DOM"] =
 `;
 /* end snapshot sbb-mini-calendar renders Shadow DOM */
 
-snapshots["sbb-mini-calendar renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "2025"
-    },
-    {
-      "role": "button",
-      "name": "January 1, 2025"
-    },
-    {
-      "role": "text leaf",
-      "name": "Jan."
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-mini-calendar renders A11y tree Firefox */
-
 snapshots["sbb-mini-calendar renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "2025"
-    },
-    {
-      "role": "button",
-      "name": "January 1, 2025"
-    },
-    {
-      "role": "text",
-      "name": "Jan."
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "role": "generic",
+                      "name": ""
+                    },
+                    {
+                      "ignored": true,
+                      "role": "none",
+                      "children": [
+                        {
+                          "role": "button",
+                          "name": "January 1, 2025",
+                          "invalid": false,
+                          "focusable": true
+                        }
+                      ]
+                    },
+                    {
+                      "role": "generic",
+                      "name": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/elements/navigation/navigation-button/__snapshots__/navigation-button.snapshot.spec.snap.js
+++ b/src/elements/navigation/navigation-button/__snapshots__/navigation-button.snapshot.spec.snap.js
@@ -24,32 +24,18 @@ snapshots["sbb-navigation-button renders Shadow DOM"] =
 snapshots["sbb-navigation-button renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
-      "name": "Button"
+      "name": "Button",
+      "invalid": false,
+      "focusable": true
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-navigation-button renders A11y tree Chrome */
-
-snapshots["sbb-navigation-button renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Button"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-navigation-button renders A11y tree Firefox */
 

--- a/src/elements/navigation/navigation-link/__snapshots__/navigation-link.snapshot.spec.snap.js
+++ b/src/elements/navigation/navigation-link/__snapshots__/navigation-link.snapshot.spec.snap.js
@@ -35,33 +35,16 @@ snapshots["sbb-navigation-link renders Shadow DOM"] =
 snapshots["sbb-navigation-link renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "link",
-      "name": "a11y label"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-navigation-link renders A11y tree Chrome */
-
-snapshots["sbb-navigation-link renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "link",
-      "name": "a11y label",
-      "value": "https://www.sbb.ch/"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-navigation-link renders A11y tree Firefox */
 

--- a/src/elements/navigation/navigation-list/__snapshots__/navigation-list.snapshot.spec.snap.js
+++ b/src/elements/navigation/navigation-list/__snapshots__/navigation-list.snapshot.spec.snap.js
@@ -112,56 +112,36 @@ snapshots["sbb-navigation-list should render named slots if data-ssr-child-count
 snapshots["sbb-navigation-list renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "Tickets & Offers"
-    },
-    {
-      "role": "button",
-      "name": "Vacations & Recreation"
-    },
-    {
-      "role": "button",
-      "name": "Travel information"
-    },
-    {
-      "role": "button",
-      "name": "Help & Contact"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none"
+            }
+          ]
+        },
+        {
+          "role": "list",
+          "name": ""
+        },
+        {
+          "ignored": true,
+          "role": "none"
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-navigation-list renders A11y tree Chrome */
-
-snapshots["sbb-navigation-list renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Tickets & Offers"
-    },
-    {
-      "role": "button",
-      "name": "Vacations & Recreation"
-    },
-    {
-      "role": "button",
-      "name": "Travel information"
-    },
-    {
-      "role": "button",
-      "name": "Help & Contact"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-navigation-list renders A11y tree Firefox */
 

--- a/src/elements/notification/__snapshots__/notification.snapshot.spec.snap.js
+++ b/src/elements/notification/__snapshots__/notification.snapshot.spec.snap.js
@@ -261,50 +261,22 @@ snapshots["sbb-notification renders size s Shadow DOM"] =
 snapshots["sbb-notification A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "heading",
-      "name": "Test title",
-      "level": 3
-    },
-    {
-      "role": "text",
-      "name": "Lorem ipsum..."
-    },
-    {
-      "role": "button",
-      "name": "Close message"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "generic",
+          "name": ""
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-notification A11y tree Chrome */
-
-snapshots["sbb-notification A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "Test title",
-      "level": 3
-    },
-    {
-      "role": "text leaf",
-      "name": "Lorem ipsum... "
-    },
-    {
-      "role": "button",
-      "name": "Close message"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-notification A11y tree Firefox */
 

--- a/src/elements/option/optgroup/__snapshots__/optgroup.snapshot.spec.snap.js
+++ b/src/elements/option/optgroup/__snapshots__/optgroup.snapshot.spec.snap.js
@@ -115,21 +115,35 @@ snapshots["sbb-optgroup autocomplete renders Chrome-Firefox Shadow DOM"] =
 snapshots["sbb-optgroup autocomplete renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "combobox",
-      "name": "",
-      "expanded": true,
-      "focused": true,
-      "autocomplete": "list",
-      "haspopup": "listbox"
-    },
-    {
-      "role": "listbox",
-      "name": "",
-      "orientation": "vertical"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "combobox",
+          "name": "",
+          "invalid": false,
+          "focusable": true,
+          "focused": true,
+          "editable": "plaintext",
+          "settable": true,
+          "autocomplete": "list",
+          "hasPopup": "listbox",
+          "required": false,
+          "expanded": true
+        },
+        {
+          "role": "group",
+          "name": ""
+        },
+        {
+          "role": "generic",
+          "name": ""
+        }
+      ]
     }
   ]
 }
@@ -171,38 +185,4 @@ snapshots["sbb-optgroup autocomplete renders disabled Chrome-Firefox Shadow DOM"
 </slot>
 `;
 /* end snapshot sbb-optgroup autocomplete renders disabled Chrome-Firefox Shadow DOM */
-
-snapshots["sbb-optgroup autocomplete renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "combobox",
-      "name": "",
-      "expanded": true,
-      "focused": true,
-      "autocomplete": "list",
-      "haspopup": "listbox"
-    },
-    {
-      "role": "listbox",
-      "name": "",
-      "children": [
-        {
-          "role": "option",
-          "name": "1"
-        },
-        {
-          "role": "option",
-          "name": "2"
-        }
-      ]
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-optgroup autocomplete renders A11y tree Firefox */
 

--- a/src/elements/option/option-hint/__snapshots__/option-hint.snapshot.spec.snap.js
+++ b/src/elements/option/option-hint/__snapshots__/option-hint.snapshot.spec.snap.js
@@ -20,31 +20,33 @@ snapshots["sbb-option-hint renders Shadow DOM"] =
 `;
 /* end snapshot sbb-option-hint renders Shadow DOM */
 
-snapshots["sbb-option-hint renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Hint"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-option-hint renders A11y tree Firefox */
-
 snapshots["sbb-option-hint renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Hint"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "role": "StaticText",
+                  "name": "Hint"
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/elements/option/option/__snapshots__/option.snapshot.spec.snap.js
+++ b/src/elements/option/option/__snapshots__/option.snapshot.spec.snap.js
@@ -64,8 +64,15 @@ snapshots["sbb-option autocomplete renders disabled Shadow DOM"] =
 snapshots["sbb-option selected Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "role": "option",
+      "name": "",
+      "selected": true
+    }
+  ]
 }
 </p>
 `;
@@ -84,8 +91,16 @@ snapshots["sbb-option selected Firefox"] =
 snapshots["sbb-option disabled Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "role": "option",
+      "name": "",
+      "disabled": true,
+      "selected": false
+    }
+  ]
 }
 </p>
 `;

--- a/src/elements/overlay/__snapshots__/overlay.snapshot.spec.snap.js
+++ b/src/elements/overlay/__snapshots__/overlay.snapshot.spec.snap.js
@@ -46,42 +46,16 @@ snapshots["sbb-overlay renders Shadow DOM"] =
 snapshots["sbb-overlay renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "Close secondary window",
-      "focused": true
-    },
-    {
-      "role": "text",
-      "name": "Dialog "
+      "role": "group",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-overlay renders A11y tree Chrome */
-
-snapshots["sbb-overlay renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Close secondary window",
-      "focused": true
-    },
-    {
-      "role": "text leaf",
-      "name": "Dialog "
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-overlay renders A11y tree Firefox */
 

--- a/src/elements/paginator/compact-paginator/__snapshots__/compact-paginator.snapshot.spec.snap.js
+++ b/src/elements/paginator/compact-paginator/__snapshots__/compact-paginator.snapshot.spec.snap.js
@@ -63,57 +63,15 @@ snapshots["sbb-compact-paginator renders Shadow DOM"] =
 `;
 /* end snapshot sbb-compact-paginator renders Shadow DOM */
 
-snapshots["sbb-compact-paginator renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Previous page",
-      "disabled": true
-    },
-    {
-      "role": "button",
-      "name": "Next page"
-    },
-    {
-      "role": "text leaf",
-      "name": "Page 1 of 10"
-    },
-    {
-      "role": "text leaf",
-      "name": "Page 1 selected."
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-compact-paginator renders A11y tree Firefox */
-
 snapshots["sbb-compact-paginator renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "Previous page",
-      "disabled": true
-    },
-    {
-      "role": "button",
-      "name": "Next page"
-    },
-    {
-      "role": "text",
-      "name": "Page 1 of 10"
-    },
-    {
-      "role": "text",
-      "name": "Page 1 selected."
+      "role": "group",
+      "name": ""
     }
   ]
 }
@@ -189,58 +147,16 @@ snapshots["sbb-compact-paginator renders accessibility labels Shadow DOM"] =
 snapshots["sbb-compact-paginator renders accessibility labels A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "Previous slide",
-      "disabled": true
-    },
-    {
-      "role": "button",
-      "name": "Next slide"
-    },
-    {
-      "role": "text",
-      "name": "Slide 1 of 10"
-    },
-    {
-      "role": "text",
-      "name": "Slide 1 selected."
+      "role": "group",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-compact-paginator renders accessibility labels A11y tree Chrome */
-
-snapshots["sbb-compact-paginator renders accessibility labels A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Previous slide",
-      "disabled": true
-    },
-    {
-      "role": "button",
-      "name": "Next slide"
-    },
-    {
-      "role": "text leaf",
-      "name": "Slide 1 of 10"
-    },
-    {
-      "role": "text leaf",
-      "name": "Slide 1 selected."
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-compact-paginator renders accessibility labels A11y tree Firefox */
 

--- a/src/elements/paginator/paginator/__snapshots__/paginator.snapshot.spec.snap.js
+++ b/src/elements/paginator/paginator/__snapshots__/paginator.snapshot.spec.snap.js
@@ -721,120 +721,16 @@ snapshots["sbb-paginator renders with options and accessibility labels Safari Sh
 snapshots["sbb-paginator renders with options and accessibility labels A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "Previous slide"
-    },
-    {
-      "role": "button",
-      "name": "Next slide"
-    },
-    {
-      "role": "button",
-      "name": "Slide 1"
-    },
-    {
-      "role": "button",
-      "name": "Slide 2"
-    },
-    {
-      "role": "button",
-      "name": "Slide 3"
-    },
-    {
-      "role": "button",
-      "name": "Slide 4"
-    },
-    {
-      "role": "button",
-      "name": "Slide 5"
-    },
-    {
-      "role": "text",
-      "name": "Items per slide"
-    },
-    {
-      "role": "text",
-      "name": "​"
-    },
-    {
-      "role": "combobox",
-      "name": "Items per slide",
-      "haspopup": "listbox",
-      "value": "10"
-    },
-    {
-      "role": "text",
-      "name": "Slide 3 selected."
+      "role": "group",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-paginator renders with options and accessibility labels A11y tree Chrome */
-
-snapshots["sbb-paginator renders with options and accessibility labels A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Previous slide"
-    },
-    {
-      "role": "button",
-      "name": "Next slide"
-    },
-    {
-      "role": "button",
-      "name": "Slide 1"
-    },
-    {
-      "role": "button",
-      "name": "Slide 2"
-    },
-    {
-      "role": "button",
-      "name": "Slide 3"
-    },
-    {
-      "role": "button",
-      "name": "Slide 4"
-    },
-    {
-      "role": "button",
-      "name": "Slide 5"
-    },
-    {
-      "role": "text leaf",
-      "name": "Items per slide"
-    },
-    {
-      "role": "statictext",
-      "name": "​"
-    },
-    {
-      "role": "combobox",
-      "name": "Items per slide",
-      "haspopup": "listbox",
-      "value": "10"
-    },
-    {
-      "role": "text container",
-      "name": "Items per slide"
-    },
-    {
-      "role": "text leaf",
-      "name": "Slide 3 selected."
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-paginator renders with options and accessibility labels A11y tree Firefox */
 

--- a/src/elements/popover/__snapshots__/popover.snapshot.spec.snap.js
+++ b/src/elements/popover/__snapshots__/popover.snapshot.spec.snap.js
@@ -40,20 +40,28 @@ snapshots["sbb-popover renders Shadow DOM"] =
 snapshots["sbb-popover renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-popover renders A11y tree Chrome */
-
-snapshots["sbb-popover renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-popover renders A11y tree Firefox */
 

--- a/src/elements/radio-button/radio-button-group/__snapshots__/radio-button-group.snapshot.spec.snap.js
+++ b/src/elements/radio-button/radio-button-group/__snapshots__/radio-button-group.snapshot.spec.snap.js
@@ -122,52 +122,17 @@ snapshots["sbb-radio-button-group renders with selection-expansion-panel Shadow 
 snapshots["sbb-radio-button-group renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "radio",
-      "name": "1",
-      "checked": false
-    },
-    {
-      "role": "radio",
-      "name": "2",
-      "checked": true
-    },
-    {
-      "role": "radio",
-      "name": "3",
-      "checked": false
+      "role": "radiogroup",
+      "name": "",
+      "required": false
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-radio-button-group renders A11y tree Chrome */
-
-snapshots["sbb-radio-button-group renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "radio",
-      "name": "1"
-    },
-    {
-      "role": "radio",
-      "name": "2",
-      "checked": true
-    },
-    {
-      "role": "radio",
-      "name": "3"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-radio-button-group renders A11y tree Firefox */
 

--- a/src/elements/radio-button/radio-button-panel/__snapshots__/radio-button-panel.snapshot.spec.snap.js
+++ b/src/elements/radio-button/radio-button-panel/__snapshots__/radio-button-panel.snapshot.spec.snap.js
@@ -83,12 +83,14 @@ snapshots["sbb-radio-button-panel renders checked Shadow DOM"] =
 snapshots["sbb-radio-button-panel renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "radio",
       "name": "Label Suffix Subtext",
+      "invalid": false,
+      "focusable": true,
       "checked": false
     }
   ]
@@ -97,31 +99,17 @@ snapshots["sbb-radio-button-panel renders A11y tree Chrome"] =
 `;
 /* end snapshot sbb-radio-button-panel renders A11y tree Chrome */
 
-snapshots["sbb-radio-button-panel renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "radio",
-      "name": "Label Suffix Subtext"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-radio-button-panel renders A11y tree Firefox */
-
 snapshots["sbb-radio-button-panel renders checked A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "radio",
       "name": "Label Suffix Subtext",
+      "invalid": false,
+      "focusable": true,
       "checked": true
     }
   ]
@@ -130,33 +118,17 @@ snapshots["sbb-radio-button-panel renders checked A11y tree Chrome"] =
 `;
 /* end snapshot sbb-radio-button-panel renders checked A11y tree Chrome */
 
-snapshots["sbb-radio-button-panel renders checked A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "radio",
-      "name": "Label Suffix Subtext",
-      "checked": true
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-radio-button-panel renders checked A11y tree Firefox */
-
 snapshots["sbb-radio-button-panel renders disabled - A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "radio",
       "name": "Label",
       "disabled": true,
+      "invalid": false,
       "checked": false
     }
   ]
@@ -165,56 +137,22 @@ snapshots["sbb-radio-button-panel renders disabled - A11y tree Chrome"] =
 `;
 /* end snapshot sbb-radio-button-panel renders disabled - A11y tree Chrome */
 
-snapshots["sbb-radio-button-panel renders disabled - A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "radio",
-      "name": "Label",
-      "disabled": true
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-radio-button-panel renders disabled - A11y tree Firefox */
-
 snapshots["sbb-radio-button-panel renders required - A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "radio",
       "name": "",
-      "checked": false,
-      "invalid": "true"
+      "invalid": true,
+      "focusable": true,
+      "checked": false
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-radio-button-panel renders required - A11y tree Chrome */
-
-snapshots["sbb-radio-button-panel renders required - A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "radio",
-      "name": "",
-      "required": true,
-      "invalid": "true"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-radio-button-panel renders required - A11y tree Firefox */
 

--- a/src/elements/radio-button/radio-button/__snapshots__/radio-button.snapshot.spec.snap.js
+++ b/src/elements/radio-button/radio-button/__snapshots__/radio-button.snapshot.spec.snap.js
@@ -22,31 +22,17 @@ snapshots["sbb-radio-button renders Shadow DOM"] =
 `;
 /* end snapshot sbb-radio-button renders Shadow DOM */
 
-snapshots["sbb-radio-button renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "radio",
-      "name": ""
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-radio-button renders A11y tree Firefox */
-
 snapshots["sbb-radio-button renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "radio",
       "name": "",
+      "invalid": false,
+      "focusable": true,
       "checked": false
     }
   ]
@@ -55,32 +41,17 @@ snapshots["sbb-radio-button renders A11y tree Chrome"] =
 `;
 /* end snapshot sbb-radio-button renders A11y tree Chrome */
 
-snapshots["sbb-radio-button renders checked - A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "radio",
-      "name": "",
-      "checked": true
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-radio-button renders checked - A11y tree Firefox */
-
 snapshots["sbb-radio-button renders checked - A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "radio",
       "name": "",
+      "invalid": false,
+      "focusable": true,
       "checked": true
     }
   ]
@@ -92,13 +63,14 @@ snapshots["sbb-radio-button renders checked - A11y tree Chrome"] =
 snapshots["sbb-radio-button renders disabled - A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "radio",
       "name": "",
       "disabled": true,
+      "invalid": false,
       "checked": false
     }
   ]
@@ -107,56 +79,22 @@ snapshots["sbb-radio-button renders disabled - A11y tree Chrome"] =
 `;
 /* end snapshot sbb-radio-button renders disabled - A11y tree Chrome */
 
-snapshots["sbb-radio-button renders disabled - A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "radio",
-      "name": "",
-      "disabled": true
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-radio-button renders disabled - A11y tree Firefox */
-
 snapshots["sbb-radio-button renders required - A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "radio",
       "name": "",
-      "checked": false,
-      "invalid": "true"
+      "invalid": true,
+      "focusable": true,
+      "checked": false
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-radio-button renders required - A11y tree Chrome */
-
-snapshots["sbb-radio-button renders required - A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "radio",
-      "name": "",
-      "required": true,
-      "invalid": "true"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-radio-button renders required - A11y tree Firefox */
 

--- a/src/elements/screen-reader-only/__snapshots__/screen-reader-only.snapshot.spec.snap.js
+++ b/src/elements/screen-reader-only/__snapshots__/screen-reader-only.snapshot.spec.snap.js
@@ -16,20 +16,16 @@ snapshots["sbb-screen-reader-only renders Shadow DOM"] =
 snapshots["sbb-screen-reader-only renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "role": "generic",
+      "name": ""
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-screen-reader-only renders A11y tree Chrome */
-
-snapshots["sbb-screen-reader-only renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-screen-reader-only renders A11y tree Firefox */
 

--- a/src/elements/select/__snapshots__/select.snapshot.spec.snap.js
+++ b/src/elements/select/__snapshots__/select.snapshot.spec.snap.js
@@ -212,13 +212,21 @@ snapshots["sbb-select renders Chrome-Firefox Shadow DOM"] =
 snapshots["sbb-select renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "combobox",
       "name": "",
-      "haspopup": "listbox"
+      "focusable": true,
+      "hasPopup": "listbox",
+      "required": false,
+      "expanded": false
+    },
+    {
+      "role": "generic",
+      "name": "",
+      "invalid": false
     }
   ]
 }
@@ -260,17 +268,11 @@ snapshots["sbb-select renders multiple Chrome-Firefox Shadow DOM"] =
 >
   <div class="sbb-select__gap-fix">
     <div class="sbb-gap-fix-wrapper">
-      <div
-        class="sbb-gap-fix-corner"
-        id="left"
-      >
+      <div class="sbb-gap-fix-corner">
       </div>
     </div>
     <div class="sbb-gap-fix-wrapper">
-      <div
-        class="sbb-gap-fix-corner"
-        id="right"
-      >
+      <div class="sbb-gap-fix-corner">
       </div>
     </div>
   </div>
@@ -279,7 +281,6 @@ snapshots["sbb-select renders multiple Chrome-Firefox Shadow DOM"] =
       <div
         aria-multiselectable=""
         class="sbb-select__options"
-        id="sbb-select-5"
         role="listbox"
         tabindex="-1"
       >
@@ -295,51 +296,25 @@ snapshots["sbb-select renders multiple Chrome-Firefox Shadow DOM"] =
 snapshots["sbb-select renders multiple A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "combobox",
       "name": "",
-      "haspopup": "listbox"
+      "focusable": true,
+      "hasPopup": "listbox",
+      "required": false,
+      "expanded": false
+    },
+    {
+      "role": "generic",
+      "name": "",
+      "invalid": false
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-select renders multiple A11y tree Chrome */
-
-snapshots["sbb-select renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "combobox",
-      "name": "",
-      "haspopup": "listbox"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-select renders A11y tree Firefox */
-
-snapshots["sbb-select renders multiple A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "combobox",
-      "name": "",
-      "haspopup": "listbox"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-select renders multiple A11y tree Firefox */
 

--- a/src/elements/select/select.snapshot.spec.ts
+++ b/src/elements/select/select.snapshot.spec.ts
@@ -65,7 +65,7 @@ describe(`sbb-select`, () => {
       });
 
       it('Shadow DOM', async () => {
-        await expect(elem).shadowDom.to.be.equalSnapshot();
+        await expect(elem).shadowDom.to.be.equalSnapshot({ ignoreAttributes: ['id'] });
       });
     });
 

--- a/src/elements/selection-action-panel/__snapshots__/selection-action-panel.snapshot.spec.snap.js
+++ b/src/elements/selection-action-panel/__snapshots__/selection-action-panel.snapshot.spec.snap.js
@@ -44,20 +44,11 @@ snapshots["sbb-selection-action-panel renders Shadow DOM"] =
 snapshots["sbb-selection-action-panel renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "%"
-    },
-    {
-      "role": "checkbox",
-      "name": "​ Value one Subtext",
-      "checked": false
-    },
-    {
-      "role": "button",
+      "role": "generic",
       "name": ""
     }
   ]
@@ -65,28 +56,4 @@ snapshots["sbb-selection-action-panel renders A11y tree Chrome"] =
 </p>
 `;
 /* end snapshot sbb-selection-action-panel renders A11y tree Chrome */
-
-snapshots["sbb-selection-action-panel renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "%"
-    },
-    {
-      "role": "checkbox",
-      "name": "​ Value one Subtext"
-    },
-    {
-      "role": "button",
-      "name": ""
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-selection-action-panel renders A11y tree Firefox */
 

--- a/src/elements/selection-expansion-panel/__snapshots__/selection-expansion-panel.snapshot.spec.snap.js
+++ b/src/elements/selection-expansion-panel/__snapshots__/selection-expansion-panel.snapshot.spec.snap.js
@@ -51,33 +51,16 @@ snapshots["sbb-selection-expansion-panel renders Shadow DOM"] =
 snapshots["sbb-selection-expansion-panel renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "checkbox",
-      "name": "% ​ Value one Suffix Subtext , collapsed",
-      "checked": false
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-selection-expansion-panel renders A11y tree Chrome */
-
-snapshots["sbb-selection-expansion-panel renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "checkbox",
-      "name": "% ​ Value one Suffix Subtext , collapsed"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-selection-expansion-panel renders A11y tree Firefox */
 

--- a/src/elements/selection-expansion-panel/selection-expansion-panel.spec.ts
+++ b/src/elements/selection-expansion-panel/selection-expansion-panel.spec.ts
@@ -1,5 +1,5 @@
 import { assert, expect } from '@open-wc/testing';
-import { a11ySnapshot, sendKeys } from '@web/test-runner-commands';
+import { sendKeys } from '@web/test-runner-commands';
 import type { TemplateResult } from 'lit';
 import { html, unsafeStatic } from 'lit/static-html.js';
 
@@ -8,7 +8,8 @@ import {
   type SbbCheckboxGroupElement,
   SbbCheckboxPanelElement,
 } from '../checkbox.ts';
-import { fixture, tabKey } from '../core/testing/private.ts';
+import { isChromium } from '../core/dom.ts';
+import { a11yTreeSnapshot, fixture, tabKey } from '../core/testing/private.ts';
 import { EventSpy, waitForCondition, waitForLitRender } from '../core/testing.ts';
 import {
   type SbbRadioButtonElement,
@@ -381,14 +382,6 @@ describe(`sbb-selection-expansion-panel`, () => {
           "sbb-radio-button-panel[value='main2']",
         )!;
 
-      const mainRadioButton1Label = (await a11ySnapshot({
-        selector: 'sbb-radio-button-panel[value="main1"]',
-      })) as unknown as { name: string };
-
-      const mainRadioButton2Label = (await a11ySnapshot({
-        selector: 'sbb-radio-button-panel[value="main2"]',
-      })) as unknown as { name: string };
-
       // We assert that there was no fade in animation (skipped opening state).
       await waitForCondition(() => panel1.matches(':state(state-opening)'), 1, 100)
         .then(() => Promise.reject('accidentally passed'))
@@ -397,8 +390,17 @@ describe(`sbb-selection-expansion-panel`, () => {
       await openSpy.calledOnce();
       expect(beforeOpenSpy.count).to.be.equal(1);
       expect(openSpy.count).to.be.equal(1);
-      expect(mainRadioButton1Label.name.trim()).to.be.equal('Main Option 1 , expanded');
-      expect(mainRadioButton2Label.name.trim()).to.be.equal('Main Option 2 , collapsed');
+      if (isChromium) {
+        const mainRadioButton1Label = await a11yTreeSnapshot({
+          selector: 'sbb-radio-button-panel[value="main1"]',
+        });
+        const mainRadioButton2Label = await a11yTreeSnapshot({
+          selector: 'sbb-radio-button-panel[value="main2"]',
+        });
+
+        expect(mainRadioButton1Label.name?.trim()).to.be.equal('Main Option 1 , expanded');
+        expect(mainRadioButton2Label.name?.trim()).to.be.equal('Main Option 2 , collapsed');
+      }
       expect(panel1).to.match(':state(state-opened)');
       expect(panel2).to.match(':state(state-closed)');
 
@@ -408,22 +410,25 @@ describe(`sbb-selection-expansion-panel`, () => {
       await openSpy.calledTimes(2);
       await closeSpy.calledOnce();
 
-      const mainRadioButton1LabelSecondRender = (await a11ySnapshot({
-        selector: 'sbb-radio-button-panel[value="main1"]',
-      })) as unknown as { name: string };
-
-      const mainRadioButton2LabelSecondRender = (await a11ySnapshot({
-        selector: 'sbb-radio-button-panel[value="main2"]',
-      })) as unknown as { name: string };
-
       expect(beforeOpenSpy.count).to.be.equal(2);
       expect(openSpy.count).to.be.equal(2);
       expect(beforeCloseSpy.count).to.be.equal(1);
       expect(closeSpy.count).to.be.equal(1);
-      expect(mainRadioButton1LabelSecondRender.name.trim()).to.be.equal(
-        'Main Option 1 , collapsed',
-      );
-      expect(mainRadioButton2LabelSecondRender.name.trim()).to.be.equal('Main Option 2 , expanded');
+      if (isChromium) {
+        const mainRadioButton1LabelSecondRender = await a11yTreeSnapshot({
+          selector: 'sbb-radio-button-panel[value="main1"]',
+        });
+        const mainRadioButton2LabelSecondRender = await a11yTreeSnapshot({
+          selector: 'sbb-radio-button-panel[value="main2"]',
+        });
+
+        expect(mainRadioButton1LabelSecondRender.name?.trim()).to.be.equal(
+          'Main Option 1 , collapsed',
+        );
+        expect(mainRadioButton2LabelSecondRender.name?.trim()).to.be.equal(
+          'Main Option 2 , expanded',
+        );
+      }
 
       expect(panel1).to.match(':state(state-closed)');
       expect(panel2).to.match(':state(state-opened)');
@@ -788,16 +793,17 @@ describe(`sbb-selection-expansion-panel`, () => {
       const mainCheckbox2: SbbCheckboxPanelElement =
         nestedElement.querySelector<SbbCheckboxPanelElement>("sbb-checkbox-panel[value='main2']")!;
 
-      const mainCheckbox1Label = (await a11ySnapshot({
-        selector: 'sbb-checkbox-panel[value="main1"]',
-      })) as unknown as { name: string };
+      if (isChromium) {
+        const mainCheckbox1Label = await a11yTreeSnapshot({
+          selector: 'sbb-checkbox-panel[value="main1"]',
+        });
+        const mainCheckbox2Label = await a11yTreeSnapshot({
+          selector: 'sbb-checkbox-panel[value="main2"]',
+        });
 
-      const mainCheckbox2Label = (await a11ySnapshot({
-        selector: 'sbb-checkbox-panel[value="main2"]',
-      })) as unknown as { name: string };
-
-      expect(mainCheckbox1Label.name.trim()).to.be.equal('​ Main Option 1 , expanded');
-      expect(mainCheckbox2Label.name.trim()).to.be.equal('​ Main Option 2 , collapsed');
+        expect(mainCheckbox1Label.name?.trim()).to.be.equal('​ Main Option 1 , expanded');
+        expect(mainCheckbox2Label.name?.trim()).to.be.equal('​ Main Option 2 , collapsed');
+      }
 
       // Deactivate main option 1
       mainCheckbox1.click();
@@ -807,16 +813,21 @@ describe(`sbb-selection-expansion-panel`, () => {
 
       await waitForLitRender(nestedElement);
 
-      const mainCheckbox1LabelSecondRender = (await a11ySnapshot({
-        selector: 'sbb-checkbox-panel[value="main1"]',
-      })) as unknown as { name: string };
+      if (isChromium) {
+        const mainCheckbox1LabelSecondRender = await a11yTreeSnapshot({
+          selector: 'sbb-checkbox-panel[value="main1"]',
+        });
+        const mainCheckbox2LabelSecondRender = await a11yTreeSnapshot({
+          selector: 'sbb-checkbox-panel[value="main2"]',
+        });
 
-      const mainCheckbox2LabelSecondRender = (await a11ySnapshot({
-        selector: 'sbb-checkbox-panel[value="main2"]',
-      })) as unknown as { name: string };
-
-      expect(mainCheckbox1LabelSecondRender.name.trim()).to.be.equal('​ Main Option 1 , collapsed');
-      expect(mainCheckbox2LabelSecondRender.name.trim()).to.be.equal('​ Main Option 2 , expanded');
+        expect(mainCheckbox1LabelSecondRender.name?.trim()).to.be.equal(
+          '​ Main Option 1 , collapsed',
+        );
+        expect(mainCheckbox2LabelSecondRender.name?.trim()).to.be.equal(
+          '​ Main Option 2 , expanded',
+        );
+      }
     });
 
     it('should mark only outer group children as disabled', async () => {

--- a/src/elements/sidebar/sidebar-close-button/__snapshots__/sidebar-close-button.snapshot.spec.snap.js
+++ b/src/elements/sidebar/sidebar-close-button/__snapshots__/sidebar-close-button.snapshot.spec.snap.js
@@ -21,31 +21,17 @@ snapshots["sbb-sidebar-close-button renders Shadow DOM"] =
 `;
 /* end snapshot sbb-sidebar-close-button renders Shadow DOM */
 
-snapshots["sbb-sidebar-close-button renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Close sidebar"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-sidebar-close-button renders A11y tree Firefox */
-
 snapshots["sbb-sidebar-close-button renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
-      "name": "Close sidebar"
+      "name": "Close sidebar",
+      "invalid": false,
+      "focusable": true
     }
   ]
 }

--- a/src/elements/sidebar/sidebar-container/__snapshots__/sidebar-container.snapshot.spec.snap.js
+++ b/src/elements/sidebar/sidebar-container/__snapshots__/sidebar-container.snapshot.spec.snap.js
@@ -18,20 +18,16 @@ snapshots["sbb-sidebar-container renders Shadow DOM"] =
 snapshots["sbb-sidebar-container renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "role": "generic",
+      "name": ""
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-sidebar-container renders A11y tree Chrome */
-
-snapshots["sbb-sidebar-container renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-sidebar-container renders A11y tree Firefox */
 

--- a/src/elements/sidebar/sidebar-content/__snapshots__/sidebar-content.snapshot.spec.snap.js
+++ b/src/elements/sidebar/sidebar-content/__snapshots__/sidebar-content.snapshot.spec.snap.js
@@ -20,32 +20,16 @@ snapshots["sbb-sidebar-content renders Shadow DOM"] =
 snapshots["sbb-sidebar-content renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Some content"
+      "role": "main",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-sidebar-content renders A11y tree Chrome */
-
-snapshots["sbb-sidebar-content renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Some content"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-sidebar-content renders A11y tree Firefox */
 

--- a/src/elements/sidebar/sidebar-title/__snapshots__/sidebar-title.snapshot.spec.snap.js
+++ b/src/elements/sidebar/sidebar-title/__snapshots__/sidebar-title.snapshot.spec.snap.js
@@ -21,8 +21,8 @@ snapshots["sbb-sidebar-title renders Shadow DOM"] =
 snapshots["sbb-sidebar-title renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "heading",
@@ -34,21 +34,4 @@ snapshots["sbb-sidebar-title renders A11y tree Chrome"] =
 </p>
 `;
 /* end snapshot sbb-sidebar-title renders A11y tree Chrome */
-
-snapshots["sbb-sidebar-title renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "Title",
-      "level": 2
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-sidebar-title renders A11y tree Firefox */
 

--- a/src/elements/sidebar/sidebar/__snapshots__/sidebar.snapshot.spec.snap.js
+++ b/src/elements/sidebar/sidebar/__snapshots__/sidebar.snapshot.spec.snap.js
@@ -29,20 +29,16 @@ snapshots["sbb-sidebar renders Shadow DOM"] =
 snapshots["sbb-sidebar renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "role": "navigation",
+      "name": ""
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-sidebar renders A11y tree Chrome */
-
-snapshots["sbb-sidebar renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-sidebar renders A11y tree Firefox */
 

--- a/src/elements/skiplink-list/__snapshots__/skiplink-list.snapshot.spec.snap.js
+++ b/src/elements/skiplink-list/__snapshots__/skiplink-list.snapshot.spec.snap.js
@@ -176,61 +176,16 @@ snapshots["sbb-skiplink-list renders with title Shadow DOM"] =
 snapshots["sbb-skiplink-list renders with title A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "heading",
-      "name": "Skip to",
-      "level": 3
-    },
-    {
-      "role": "link",
-      "name": "Link 1"
-    },
-    {
-      "role": "link",
-      "name": "Link 2"
-    },
-    {
-      "role": "link",
-      "name": "Link 3"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-skiplink-list renders with title A11y tree Chrome */
-
-snapshots["sbb-skiplink-list renders with title A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "Skip to",
-      "level": 3
-    },
-    {
-      "role": "link",
-      "name": "Link 1",
-      "value": "https://www.sbb.ch/"
-    },
-    {
-      "role": "link",
-      "name": "Link 2",
-      "value": "https://www.sbb.ch/"
-    },
-    {
-      "role": "link",
-      "name": "Link 3",
-      "value": "https://www.sbb.ch/"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-skiplink-list renders with title A11y tree Firefox */
 

--- a/src/elements/slider/__snapshots__/slider.snapshot.spec.snap.js
+++ b/src/elements/slider/__snapshots__/slider.snapshot.spec.snap.js
@@ -185,21 +185,12 @@ snapshots["sbb-slider renders readonly Shadow DOM"] =
 snapshots["sbb-slider renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Label"
-    },
-    {
-      "role": "slider",
-      "name": "Label",
-      "valuetext": "",
-      "valuemin": 0,
-      "valuemax": 100,
-      "orientation": "horizontal",
-      "value": 1
+      "role": "generic",
+      "name": ""
     }
   ]
 }
@@ -210,17 +201,20 @@ snapshots["sbb-slider renders A11y tree Chrome"] =
 snapshots["sbb-slider renders with properties A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "slider",
       "name": "",
-      "valuetext": "",
+      "value": 100,
+      "invalid": false,
+      "focusable": true,
+      "settable": true,
+      "orientation": "horizontal",
       "valuemin": 0,
       "valuemax": 500,
-      "orientation": "horizontal",
-      "value": 100
+      "valuetext": ""
     }
   ]
 }
@@ -231,18 +225,19 @@ snapshots["sbb-slider renders with properties A11y tree Chrome"] =
 snapshots["sbb-slider renders disabled A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "slider",
       "name": "",
-      "valuetext": "",
+      "value": 100,
       "disabled": true,
+      "invalid": false,
+      "orientation": "horizontal",
       "valuemin": 0,
       "valuemax": 500,
-      "orientation": "horizontal",
-      "value": 100
+      "valuetext": ""
     }
   ]
 }
@@ -253,100 +248,25 @@ snapshots["sbb-slider renders disabled A11y tree Chrome"] =
 snapshots["sbb-slider renders readonly A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "slider",
       "name": "",
-      "valuetext": "",
+      "value": 100,
+      "invalid": false,
+      "focusable": true,
+      "orientation": "horizontal",
       "valuemin": 0,
       "valuemax": 500,
-      "orientation": "horizontal",
-      "value": 100
+      "valuetext": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-slider renders readonly A11y tree Chrome */
-
-snapshots["sbb-slider renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Label"
-    },
-    {
-      "role": "slider",
-      "name": "Label",
-      "valuetext": "1",
-      "value": "1"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-slider renders A11y tree Firefox */
-
-snapshots["sbb-slider renders with properties A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "slider",
-      "name": "",
-      "valuetext": "100",
-      "value": "100"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-slider renders with properties A11y tree Firefox */
-
-snapshots["sbb-slider renders disabled A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "slider",
-      "name": "",
-      "valuetext": "100",
-      "disabled": true,
-      "value": "100"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-slider renders disabled A11y tree Firefox */
-
-snapshots["sbb-slider renders readonly A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "slider",
-      "name": "",
-      "valuetext": "100",
-      "value": "100"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-slider renders readonly A11y tree Firefox */
 
 snapshots["sbb-slider renders in form DOM"] = 
 `<sbb-slider
@@ -392,54 +312,16 @@ snapshots["sbb-slider renders in form Shadow DOM"] =
 snapshots["sbb-slider renders in form A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "slider",
-      "name": "",
-      "valuetext": "",
-      "valuemin": 0,
-      "valuemax": 10,
-      "orientation": "horizontal",
-      "value": 1
-    },
-    {
-      "role": "slider",
-      "name": "",
-      "valuetext": "",
-      "valuemin": 0,
-      "valuemax": 10,
-      "orientation": "horizontal",
-      "value": 1
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-slider renders in form A11y tree Chrome */
-
-snapshots["sbb-slider renders in form A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "slider",
-      "name": "",
-      "valuetext": "1",
-      "value": "1"
-    },
-    {
-      "role": "slider",
-      "name": "",
-      "valuetext": "1",
-      "value": "1"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-slider renders in form A11y tree Firefox */
 

--- a/src/elements/status/__snapshots__/status.snapshot.spec.snap.js
+++ b/src/elements/status/__snapshots__/status.snapshot.spec.snap.js
@@ -65,12 +65,40 @@ snapshots["sbb-status renders with title Shadow DOM"] =
 snapshots["sbb-status renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Status info text"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "ignored": true,
+                  "role": "none"
+                }
+              ]
+            },
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "role": "StaticText",
+                  "name": "Status info text"
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }
@@ -78,61 +106,52 @@ snapshots["sbb-status renders A11y tree Chrome"] =
 `;
 /* end snapshot sbb-status renders A11y tree Chrome */
 
-snapshots["sbb-status renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Status info text"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-status renders A11y tree Firefox */
-
 snapshots["sbb-status renders with title A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "heading",
-      "name": "Title",
-      "level": 3
-    },
-    {
-      "role": "text",
-      "name": "Status info text"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "ignored": true,
+                  "role": "none"
+                }
+              ]
+            },
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "role": "heading",
+                  "name": "Title",
+                  "level": 3
+                },
+                {
+                  "role": "StaticText",
+                  "name": "Status info text"
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-status renders with title A11y tree Chrome */
-
-snapshots["sbb-status renders with title A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "Title",
-      "level": 3
-    },
-    {
-      "role": "text leaf",
-      "name": "Status info text "
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-status renders with title A11y tree Firefox */
 

--- a/src/elements/stepper/step-label/__snapshots__/step-label.snapshot.spec.snap.js
+++ b/src/elements/stepper/step-label/__snapshots__/step-label.snapshot.spec.snap.js
@@ -83,32 +83,19 @@ snapshots["sbb-step-label renders disabled Shadow DOM"] =
 snapshots["sbb-step-label A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "tab",
-      "name": "Label"
+      "name": "Label",
+      "invalid": false,
+      "focusable": true,
+      "selected": false
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-step-label A11y tree Chrome */
-
-snapshots["sbb-step-label A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text",
-      "name": ""
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-step-label A11y tree Firefox */
 

--- a/src/elements/stepper/step/__snapshots__/step.snapshot.spec.snap.js
+++ b/src/elements/stepper/step/__snapshots__/step.snapshot.spec.snap.js
@@ -24,20 +24,16 @@ snapshots["sbb-step renders Shadow DOM"] =
 snapshots["sbb-step renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "role": "tabpanel",
+      "name": ""
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-step renders A11y tree Chrome */
-
-snapshots["sbb-step renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-step renders A11y tree Firefox */
 

--- a/src/elements/stepper/stepper/__snapshots__/stepper.snapshot.spec.snap.js
+++ b/src/elements/stepper/stepper/__snapshots__/stepper.snapshot.spec.snap.js
@@ -65,76 +65,16 @@ snapshots["sbb-stepper renders Shadow DOM"] =
 snapshots["sbb-stepper renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "tab",
-      "name": "Test step label 1",
-      "selected": true
-    },
-    {
-      "role": "tab",
-      "name": "Test step label 2"
-    },
-    {
-      "role": "tab",
-      "name": "Test step label 3",
-      "disabled": true
-    },
-    {
-      "role": "tab",
-      "name": "Test step label 4"
-    },
-    {
-      "role": "text",
-      "name": "Test step content 1"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-stepper renders A11y tree Chrome */
-
-snapshots["sbb-stepper renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "tab",
-      "name": "1 Test step label 1",
-      "selected": true
-    },
-    {
-      "role": "tab",
-      "name": "2 Test step label 2"
-    },
-    {
-      "role": "tab",
-      "name": "3 Test step label 3",
-      "disabled": true
-    },
-    {
-      "role": "tab",
-      "name": "4 Test step label 4"
-    },
-    {
-      "role": "text leaf",
-      "name": "Test step content 1"
-    },
-    {
-      "role": "tabpanel",
-      "name": "2 Test step label 2"
-    },
-    {
-      "role": "tabpanel",
-      "name": "3 Test step label 3"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-stepper renders A11y tree Firefox */
 

--- a/src/elements/table/table-wrapper/__snapshots__/table-wrapper.snapshot.spec.snap.js
+++ b/src/elements/table/table-wrapper/__snapshots__/table-wrapper.snapshot.spec.snap.js
@@ -41,56 +41,28 @@ snapshots["sbb-table-wrapper renders Shadow DOM"] =
 snapshots["sbb-table-wrapper renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Col 1"
-    },
-    {
-      "role": "text",
-      "name": "Col 2"
-    },
-    {
-      "role": "text",
-      "name": "Data 1"
-    },
-    {
-      "role": "text",
-      "name": "Data 2"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "role": "table",
+              "name": "Table caption"
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-table-wrapper renders A11y tree Chrome */
-
-snapshots["sbb-table-wrapper renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Col 1"
-    },
-    {
-      "role": "text leaf",
-      "name": "Col 2"
-    },
-    {
-      "role": "text leaf",
-      "name": "Data 1"
-    },
-    {
-      "role": "text leaf",
-      "name": "Data 2"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-table-wrapper renders A11y tree Firefox */
 

--- a/src/elements/tabs/tab-group/__snapshots__/tab-group.snapshot.spec.snap.js
+++ b/src/elements/tabs/tab-group/__snapshots__/tab-group.snapshot.spec.snap.js
@@ -72,75 +72,80 @@ snapshots["sbb-tab-group renders Shadow DOM"] =
 `;
 /* end snapshot sbb-tab-group renders Shadow DOM */
 
-snapshots["sbb-tab-group renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "tab",
-      "name": "Test tab label 1",
-      "selected": true
-    },
-    {
-      "role": "tab",
-      "name": "Test tab label 2"
-    },
-    {
-      "role": "tab",
-      "name": "Test tab label 3"
-    },
-    {
-      "role": "tab",
-      "name": "Test tab label 4"
-    },
-    {
-      "role": "tabpanel",
-      "name": "",
-      "children": [
-        {
-          "role": "text leaf",
-          "name": "Test tab content 1 "
-        }
-      ]
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-tab-group renders A11y tree Firefox */
-
 snapshots["sbb-tab-group renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "tab",
-      "name": "Test tab label 1",
-      "selected": true
-    },
-    {
-      "role": "tab",
-      "name": "Test tab label 2"
-    },
-    {
-      "role": "tab",
-      "name": "Test tab label 3"
-    },
-    {
-      "role": "tab",
-      "name": "Test tab label 4"
-    },
-    {
-      "role": "tabpanel",
-      "name": "",
+      "ignored": true,
+      "role": "none",
       "children": [
         {
-          "role": "text",
-          "name": "Test tab content 1"
+          "role": "tablist",
+          "name": "",
+          "multiselectable": false,
+          "orientation": "horizontal"
+        },
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "role": "tabpanel",
+              "name": "",
+              "focusable": true
+            },
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "ignored": true,
+                      "role": "none"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "ignored": true,
+                      "role": "none"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "ignored": true,
+                      "role": "none"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/src/elements/tabs/tab-label/__snapshots__/tab-label.snapshot.spec.snap.js
+++ b/src/elements/tabs/tab-label/__snapshots__/tab-label.snapshot.spec.snap.js
@@ -95,39 +95,18 @@ snapshots["sbb-tab-label renders an H1 heading tag if the provided level is grea
 snapshots["sbb-tab-label A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "tab",
-      "name": "Tab title"
+      "name": "Tab title",
+      "focusable": true,
+      "selected": false
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-tab-label A11y tree Chrome */
-
-snapshots["sbb-tab-label A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text container",
-      "name": "",
-      "children": [
-        {
-          "role": "heading",
-          "name": "Tab title",
-          "level": 1
-        }
-      ]
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-tab-label A11y tree Firefox */
 

--- a/src/elements/tabs/tab-nav-bar/__snapshots__/tab-nav-bar.snapshot.spec.snap.js
+++ b/src/elements/tabs/tab-nav-bar/__snapshots__/tab-nav-bar.snapshot.spec.snap.js
@@ -57,50 +57,16 @@ snapshots["sbb-tab-nav-bar renders Shadow DOM"] =
 snapshots["sbb-tab-nav-bar renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "link",
-      "name": "Nav item 1"
-    },
-    {
-      "role": "link",
-      "name": "Nav item 2"
-    },
-    {
-      "role": "text",
-      "name": "Nav item 3"
+      "role": "navigation",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-tab-nav-bar renders A11y tree Chrome */
-
-snapshots["sbb-tab-nav-bar renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "link",
-      "name": "Nav item 1",
-      "value": "https://www.sbb.ch/"
-    },
-    {
-      "role": "link",
-      "name": "Nav item 2",
-      "value": "https://www.sbb.ch/"
-    },
-    {
-      "role": "text leaf",
-      "name": "Nav item 3"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-tab-nav-bar renders A11y tree Firefox */
 

--- a/src/elements/tabs/tab/__snapshots__/tab.snapshot.spec.snap.js
+++ b/src/elements/tabs/tab/__snapshots__/tab.snapshot.spec.snap.js
@@ -20,20 +20,22 @@ snapshots["sbb-tab renders Shadow DOM"] =
 snapshots["sbb-tab renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none"
+        }
+      ]
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-tab renders A11y tree Chrome */
-
-snapshots["sbb-tab renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-tab renders A11y tree Firefox */
 

--- a/src/elements/tag/tag-group/__snapshots__/tag-group.snapshot.spec.snap.js
+++ b/src/elements/tag/tag-group/__snapshots__/tag-group.snapshot.spec.snap.js
@@ -67,51 +67,16 @@ snapshots["sbb-tag-group renders Shadow DOM"] =
 snapshots["sbb-tag-group renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "First tag",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "Second tag",
-      "pressed": false
-    },
-    {
-      "role": "button",
-      "name": "Third tag",
-      "pressed": false
+      "role": "group",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-tag-group renders A11y tree Chrome */
-
-snapshots["sbb-tag-group renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "toggle button",
-      "name": "First tag"
-    },
-    {
-      "role": "toggle button",
-      "name": "Second tag"
-    },
-    {
-      "role": "toggle button",
-      "name": "Third tag"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-tag-group renders A11y tree Firefox */
 

--- a/src/elements/tag/tag/__snapshots__/tag.snapshot.spec.snap.js
+++ b/src/elements/tag/tag/__snapshots__/tag.snapshot.spec.snap.js
@@ -137,12 +137,14 @@ snapshots["sbb-tag renders slotted icon and amount Shadow DOM"] =
 snapshots["sbb-tag A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
       "name": "Label",
+      "invalid": false,
+      "focusable": true,
       "pressed": false
     }
   ]
@@ -150,20 +152,4 @@ snapshots["sbb-tag A11y tree Chrome"] =
 </p>
 `;
 /* end snapshot sbb-tag A11y tree Chrome */
-
-snapshots["sbb-tag A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "toggle button",
-      "name": "Label"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-tag A11y tree Firefox */
 

--- a/src/elements/teaser-hero/__snapshots__/teaser-hero.snapshot.spec.snap.js
+++ b/src/elements/teaser-hero/__snapshots__/teaser-hero.snapshot.spec.snap.js
@@ -56,32 +56,15 @@ snapshots["sbb-teaser-hero renders Shadow DOM"] =
 `;
 /* end snapshot sbb-teaser-hero renders Shadow DOM */
 
-snapshots["sbb-teaser-hero renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "link",
-      "name": "label",
-      "value": "https://www.sbb.ch/"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-teaser-hero renders A11y tree Firefox */
-
 snapshots["sbb-teaser-hero renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "link",
-      "name": "label"
+      "role": "generic",
+      "name": ""
     }
   ]
 }

--- a/src/elements/teaser-product/teaser-product-static/__snapshots__/teaser-product-static.snapshot.spec.snap.js
+++ b/src/elements/teaser-product/teaser-product-static/__snapshots__/teaser-product-static.snapshot.spec.snap.js
@@ -48,40 +48,60 @@ snapshots["sbb-teaser-product-static renders Shadow DOM"] =
 snapshots["sbb-teaser-product-static renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Content"
-    },
-    {
-      "role": "text",
-      "name": "Footnote"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "role": "figure",
+                      "name": ""
+                    }
+                  ]
+                },
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "role": "paragraph",
+                      "name": ""
+                    },
+                    {
+                      "ignored": true,
+                      "role": "none",
+                      "children": [
+                        {
+                          "role": "paragraph",
+                          "name": ""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-teaser-product-static renders A11y tree Chrome */
-
-snapshots["sbb-teaser-product-static renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Content"
-    },
-    {
-      "role": "text leaf",
-      "name": "Footnote"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-teaser-product-static renders A11y tree Firefox */
 

--- a/src/elements/teaser-product/teaser-product/__snapshots__/teaser-product.snapshot.spec.snap.js
+++ b/src/elements/teaser-product/teaser-product/__snapshots__/teaser-product.snapshot.spec.snap.js
@@ -55,48 +55,15 @@ snapshots["sbb-teaser-product renders Shadow DOM"] =
 `;
 /* end snapshot sbb-teaser-product renders Shadow DOM */
 
-snapshots["sbb-teaser-product renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "link",
-      "name": "",
-      "value": "https://www.sbb.ch/"
-    },
-    {
-      "role": "text leaf",
-      "name": "Content"
-    },
-    {
-      "role": "text leaf",
-      "name": "Footnote"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-teaser-product renders A11y tree Firefox */
-
 snapshots["sbb-teaser-product renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "link",
+      "role": "generic",
       "name": ""
-    },
-    {
-      "role": "text",
-      "name": "Content"
-    },
-    {
-      "role": "text",
-      "name": "Footnote"
     }
   ]
 }

--- a/src/elements/teaser/__snapshots__/teaser.snapshot.spec.snap.js
+++ b/src/elements/teaser/__snapshots__/teaser.snapshot.spec.snap.js
@@ -151,43 +151,18 @@ snapshots["sbb-teaser renders below with projected content Shadow DOM"] =
 snapshots["sbb-teaser renders after centered A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "​"
-    },
-    {
-      "role": "link",
-      "name": "SBB teaser"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-teaser renders after centered A11y tree Chrome */
-
-snapshots["sbb-teaser renders after centered A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "statictext",
-      "name": "​"
-    },
-    {
-      "role": "link",
-      "name": "SBB teaser",
-      "value": "https://github.com/sbb-design-systems/lyne-components"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-teaser renders after centered A11y tree Firefox */
 
 snapshots["sbb-teaser renders after with title set DOM"] = 
 `<sbb-teaser

--- a/src/elements/time-input/__snapshots__/time-input.snapshot.spec.snap.js
+++ b/src/elements/time-input/__snapshots__/time-input.snapshot.spec.snap.js
@@ -22,34 +22,24 @@ snapshots["sbb-time-input renders Shadow DOM"] =
 snapshots["sbb-time-input renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "textbox",
       "name": "HH:MM",
-      "value": "13:30"
+      "value": "13:30",
+      "invalid": false,
+      "focusable": true,
+      "editable": "plaintext",
+      "settable": true,
+      "multiline": false,
+      "readonly": false,
+      "required": false
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-time-input renders A11y tree Chrome */
-
-snapshots["sbb-time-input renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "textbox",
-      "name": "",
-      "value": "13:30"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-time-input renders A11y tree Firefox */
 

--- a/src/elements/timetable-form/timetable-form-field/__snapshots__/timetable-form-field.snapshot.spec.snap.js
+++ b/src/elements/timetable-form/timetable-form-field/__snapshots__/timetable-form-field.snapshot.spec.snap.js
@@ -68,48 +68,46 @@ snapshots["sbb-timetable-form-field renders Shadow DOM"] =
 snapshots["sbb-timetable-form-field renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "​"
-    },
-    {
-      "role": "text",
-      "name": "From"
-    },
-    {
-      "role": "textbox",
-      "name": "From"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none"
+            }
+          ]
+        },
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "role": "generic",
+              "name": ""
+            },
+            {
+              "role": "generic",
+              "name": ""
+            },
+            {
+              "ignored": true,
+              "role": "none"
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-timetable-form-field renders A11y tree Chrome */
-
-snapshots["sbb-timetable-form-field renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "statictext",
-      "name": "​"
-    },
-    {
-      "role": "text leaf",
-      "name": "From"
-    },
-    {
-      "role": "textbox",
-      "name": "From"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-timetable-form-field renders A11y tree Firefox */
 

--- a/src/elements/timetable-form/timetable-form-swap-button/__snapshots__/timetable-form-swap-button.snapshot.spec.snap.js
+++ b/src/elements/timetable-form/timetable-form-swap-button/__snapshots__/timetable-form-swap-button.snapshot.spec.snap.js
@@ -27,32 +27,18 @@ snapshots["sbb-timetable-form-swap-button renders Shadow DOM"] =
 snapshots["sbb-timetable-form-swap-button renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "button",
-      "name": "Swap from and to"
+      "name": "Swap from and to",
+      "invalid": false,
+      "focusable": true
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-timetable-form-swap-button renders A11y tree Chrome */
-
-snapshots["sbb-timetable-form-swap-button renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Swap from and to"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-timetable-form-swap-button renders A11y tree Firefox */
 

--- a/src/elements/timetable-form/timetable-form/__snapshots__/timetable-form.snapshot.spec.snap.js
+++ b/src/elements/timetable-form/timetable-form/__snapshots__/timetable-form.snapshot.spec.snap.js
@@ -102,133 +102,16 @@ snapshots["sbb-timetable-form renders DOM"] =
 snapshots["sbb-timetable-form renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "image",
-      "name": "Logo"
-    },
-    {
-      "role": "text",
-      "name": "​"
-    },
-    {
-      "role": "text",
-      "name": "From"
-    },
-    {
-      "role": "textbox",
-      "name": "From"
-    },
-    {
-      "role": "button",
-      "name": "Swap from and to"
-    },
-    {
-      "role": "text",
-      "name": "​"
-    },
-    {
-      "role": "text",
-      "name": "To"
-    },
-    {
-      "role": "textbox",
-      "name": "To"
-    },
-    {
-      "role": "text",
-      "name": "​"
-    },
-    {
-      "role": "textbox",
-      "name": "HH:MM",
-      "value": "13:30"
-    },
-    {
-      "role": "radio",
-      "name": "Dep",
-      "checked": true
-    },
-    {
-      "role": "radio",
-      "name": "Arr",
-      "checked": false
-    },
-    {
-      "role": "button",
-      "name": "Search"
+      "role": "generic",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-timetable-form renders A11y tree Chrome */
-
-snapshots["sbb-timetable-form renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "diagram",
-      "name": "Logo"
-    },
-    {
-      "role": "statictext",
-      "name": "​"
-    },
-    {
-      "role": "text leaf",
-      "name": "From"
-    },
-    {
-      "role": "textbox",
-      "name": "From"
-    },
-    {
-      "role": "button",
-      "name": "Swap from and to"
-    },
-    {
-      "role": "statictext",
-      "name": "​"
-    },
-    {
-      "role": "text leaf",
-      "name": "To"
-    },
-    {
-      "role": "textbox",
-      "name": "To"
-    },
-    {
-      "role": "statictext",
-      "name": "​"
-    },
-    {
-      "role": "textbox",
-      "name": "",
-      "value": "13:30"
-    },
-    {
-      "role": "radio",
-      "name": "Dep",
-      "checked": true
-    },
-    {
-      "role": "radio",
-      "name": "Arr"
-    },
-    {
-      "role": "button",
-      "name": "Search"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-timetable-form renders A11y tree Firefox */
 

--- a/src/elements/timetable-occupancy/__snapshots__/timetable-occupancy.snapshot.spec.snap.js
+++ b/src/elements/timetable-occupancy/__snapshots__/timetable-occupancy.snapshot.spec.snap.js
@@ -149,48 +149,16 @@ snapshots["sbb-timetable-occupancy renders only second class wagon Shadow DOM"] 
 snapshots["sbb-timetable-occupancy renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "First Class."
-    },
-    {
-      "role": "text",
-      "name": "Second Class."
+      "role": "list",
+      "name": ""
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-timetable-occupancy renders A11y tree Chrome */
-
-snapshots["sbb-timetable-occupancy renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "First Class."
-    },
-    {
-      "role": "img",
-      "name": "Very high occupancy expected"
-    },
-    {
-      "role": "text leaf",
-      "name": "Second Class."
-    },
-    {
-      "role": "img",
-      "name": "Very high occupancy expected"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-timetable-occupancy renders A11y tree Firefox */
 

--- a/src/elements/title/__snapshots__/title.snapshot.spec.snap.js
+++ b/src/elements/title/__snapshots__/title.snapshot.spec.snap.js
@@ -20,8 +20,8 @@ snapshots["sbb-title renders Shadow DOM"] =
 snapshots["sbb-title A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "heading",
@@ -33,21 +33,4 @@ snapshots["sbb-title A11y tree Chrome"] =
 </p>
 `;
 /* end snapshot sbb-title A11y tree Chrome */
-
-snapshots["sbb-title A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "Sample Title Text",
-      "level": 1
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-title A11y tree Firefox */
 

--- a/src/elements/toast/__snapshots__/toast.snapshot.spec.snap.js
+++ b/src/elements/toast/__snapshots__/toast.snapshot.spec.snap.js
@@ -158,42 +158,72 @@ snapshots["sbb-toast renders with action Shadow DOM"] =
 snapshots["sbb-toast renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none"
+        },
+        {
+          "ignored": true,
+          "role": "none"
+        },
+        {
+          "ignored": true,
+          "role": "none"
+        },
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-toast renders A11y tree Chrome */
 
-snapshots["sbb-toast renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-toast renders A11y tree Firefox */
-
 snapshots["sbb-toast renders readonly A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": ""
+  "role": "generic",
+  "name": "Fixture Container",
+  "children": [
+    {
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none"
+        },
+        {
+          "ignored": true,
+          "role": "none"
+        },
+        {
+          "ignored": true,
+          "role": "none"
+        }
+      ]
+    }
+  ]
 }
 </p>
 `;
 /* end snapshot sbb-toast renders readonly A11y tree Chrome */
-
-snapshots["sbb-toast renders readonly A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": ""
-}
-</p>
-`;
-/* end snapshot sbb-toast renders readonly A11y tree Firefox */
 
 snapshots["sbb-toast renders in dark mode DOM"] = 
 `<sbb-toast

--- a/src/elements/toggle-check/__snapshots__/toggle-check.snapshot.spec.snap.js
+++ b/src/elements/toggle-check/__snapshots__/toggle-check.snapshot.spec.snap.js
@@ -37,12 +37,14 @@ snapshots["sbb-toggle-check renders Shadow DOM"] =
 snapshots["sbb-toggle-check A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "checkbox",
       "name": "​",
+      "invalid": false,
+      "focusable": true,
       "checked": false
     }
   ]
@@ -50,20 +52,4 @@ snapshots["sbb-toggle-check A11y tree Chrome"] =
 </p>
 `;
 /* end snapshot sbb-toggle-check A11y tree Chrome */
-
-snapshots["sbb-toggle-check A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "checkbox",
-      "name": "​"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-toggle-check A11y tree Firefox */
 

--- a/src/elements/toggle-check/toggle-check.spec.ts
+++ b/src/elements/toggle-check/toggle-check.spec.ts
@@ -1,20 +1,12 @@
 import { assert, expect } from '@open-wc/testing';
-import { a11ySnapshot, sendKeys } from '@web/test-runner-commands';
+import { sendKeys } from '@web/test-runner-commands';
 import { html } from 'lit/static-html.js';
-import type { Context } from 'mocha';
 
 import { isChromium, isFirefox } from '../core/dom.ts';
-import { fixture } from '../core/testing/private.ts';
+import { a11yTreeSnapshot, fixture } from '../core/testing/private.ts';
 import { EventSpy, waitForCondition, waitForLitRender } from '../core/testing.ts';
 
 import { SbbToggleCheckElement } from './toggle-check.component.ts';
-
-interface ToggleCheckAccessibilitySnapshot {
-  checked: boolean;
-  role: string;
-  disabled: boolean;
-  required: boolean;
-}
 
 describe(`sbb-toggle-check`, () => {
   describe('general', () => {
@@ -76,77 +68,54 @@ describe(`sbb-toggle-check`, () => {
       expect(root.scrollTop).to.be.equal(0);
     });
 
-    it('should reflect aria-required false', async () => {
-      const snapshot = (await a11ySnapshot({
-        selector: 'sbb-toggle-check',
-      })) as unknown as ToggleCheckAccessibilitySnapshot;
+    // required is currently not supported by CDPSession a11y info
+    it.skip('should reflect aria-required false', async () => {
+      const snapshot = await a11yTreeSnapshot({ selector: 'sbb-toggle-check' });
 
       expect(snapshot.required).to.be.undefined;
     });
 
-    it('should reflect accessibility tree setting required attribute to true', async function (this: Context) {
-      // On Firefox sometimes a11ySnapshot fails. Retrying three times should stabilize the build.
-      this.retries(3);
-
+    // required is currently not supported by CDPSession a11y info
+    it.skip('should reflect accessibility tree setting required attribute to true', async () => {
       element.toggleAttribute('required', true);
       await waitForLitRender(element);
 
-      const snapshot = (await a11ySnapshot({
-        selector: 'sbb-toggle-check',
-      })) as unknown as ToggleCheckAccessibilitySnapshot;
+      const snapshot = await a11yTreeSnapshot({ selector: 'sbb-toggle-check' });
 
-      // TODO: Recheck if it is working in Chromium
-      if (!isChromium) {
-        expect(snapshot.required).to.be.true;
-      }
+      expect(snapshot.required).to.be.true;
     });
 
-    it('should reflect accessibility tree setting required attribute to false', async function (this: Context) {
-      // On Firefox sometimes a11ySnapshot fails. Retrying three times should stabilize the build.
-      this.retries(3);
-
+    // required is currently not supported by CDPSession a11y info
+    it.skip('should reflect accessibility tree setting required attribute to false', async () => {
       element.toggleAttribute('required', true);
       await waitForLitRender(element);
 
       element.removeAttribute('required');
       await waitForLitRender(element);
 
-      const snapshot = (await a11ySnapshot({
-        selector: 'sbb-toggle-check',
-      })) as unknown as ToggleCheckAccessibilitySnapshot;
+      const snapshot = await a11yTreeSnapshot({ selector: 'sbb-toggle-check' });
       expect(snapshot.required).not.to.be.ok;
     });
 
-    it('should reflect accessibility tree setting required property to true', async function (this: Context) {
-      // On Firefox sometimes a11ySnapshot fails. Retrying three times should stabilize the build.
-      this.retries(3);
-
+    // required is currently not supported by CDPSession a11y info
+    it.skip('should reflect accessibility tree setting required property to true', async () => {
       element.required = true;
       await waitForLitRender(element);
 
-      const snapshot = (await a11ySnapshot({
-        selector: 'sbb-toggle-check',
-      })) as unknown as ToggleCheckAccessibilitySnapshot;
+      const snapshot = await a11yTreeSnapshot({ selector: 'sbb-toggle-check' });
 
-      // TODO: Recheck if it is working in Chromium
-      if (!isChromium) {
-        expect(snapshot.required).to.be.true;
-      }
+      expect(snapshot.required).to.be.true;
     });
 
-    it('should reflect accessibility tree setting required property to false', async function (this: Context) {
-      // On Firefox sometimes a11ySnapshot fails. Retrying three times should stabilize the build.
-      this.retries(3);
-
+    // required is currently not supported by CDPSession a11y info
+    it.skip('should reflect accessibility tree setting required property to false', async () => {
       element.required = true;
       await waitForLitRender(element);
 
       element.required = false;
       await waitForLitRender(element);
 
-      const snapshot = (await a11ySnapshot({
-        selector: 'sbb-toggle-check',
-      })) as unknown as ToggleCheckAccessibilitySnapshot;
+      const snapshot = await a11yTreeSnapshot({ selector: 'sbb-toggle-check' });
 
       expect(snapshot.required).not.to.be.ok;
     });
@@ -211,15 +180,15 @@ describe(`sbb-toggle-check`, () => {
         expect(element).not.to.match(':state(checked)');
       }
 
-      const snapshot = (await a11ySnapshot({
-        selector: element.localName,
-      })) as unknown as ToggleCheckAccessibilitySnapshot;
+      if (isChromium) {
+        const snapshot = await a11yTreeSnapshot({ selector: element.localName });
 
-      expect(snapshot.role).to.equal('checkbox');
+        expect(snapshot.role).to.equal('checkbox');
 
-      expect(snapshot.checked, `ariaChecked in ${JSON.stringify(snapshot)}`).to.be.equal(
-        isFirefox && !assertions.ariaChecked ? undefined : assertions.ariaChecked,
-      );
+        expect(snapshot.checked, `ariaChecked in ${JSON.stringify(snapshot)}`).to.be.equal(
+          isFirefox && !assertions.ariaChecked ? undefined : assertions.ariaChecked,
+        );
+      }
 
       expect(inputSpy.count, `'input' event`).to.be.equal(assertions.inputEventCount);
       expect(changeSpy.count, `'change' event`).to.be.equal(assertions.changeEventCount);
@@ -467,12 +436,13 @@ describe(`sbb-toggle-check`, () => {
                 assertions.disabledSelector,
               );
 
-              const snapshot = (await a11ySnapshot({
-                selector: element.localName,
-              })) as unknown as ToggleCheckAccessibilitySnapshot;
-              expect(snapshot.disabled, `ariaDisabled in ${JSON.stringify(snapshot)}`).to.be.equal(
-                assertions.ariaDisabled,
-              );
+              if (isChromium) {
+                const snapshot = await a11yTreeSnapshot({ selector: element.localName });
+                expect(
+                  snapshot.disabled,
+                  `ariaDisabled in ${JSON.stringify(snapshot)}`,
+                ).to.be.equal(assertions.ariaDisabled);
+              }
 
               element.focus();
               if (assertions.focusable) {

--- a/src/elements/toggle/toggle-option/__snapshots__/toggle-option.snapshot.spec.snap.js
+++ b/src/elements/toggle/toggle-option/__snapshots__/toggle-option.snapshot.spec.snap.js
@@ -92,12 +92,13 @@ snapshots["sbb-toggle-option renders unchecked disabled Shadow DOM"] =
 snapshots["sbb-toggle-option renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "radio",
       "name": "",
+      "focusable": true,
       "checked": true
     }
   ]
@@ -109,12 +110,13 @@ snapshots["sbb-toggle-option renders A11y tree Chrome"] =
 snapshots["sbb-toggle-option renders unchecked A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "radio",
       "name": "",
+      "focusable": true,
       "checked": false
     }
   ]
@@ -126,13 +128,14 @@ snapshots["sbb-toggle-option renders unchecked A11y tree Chrome"] =
 snapshots["sbb-toggle-option renders checked disabled A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "radio",
       "name": "",
       "disabled": true,
+      "focusable": true,
       "checked": true
     }
   ]
@@ -144,13 +147,14 @@ snapshots["sbb-toggle-option renders checked disabled A11y tree Chrome"] =
 snapshots["sbb-toggle-option renders unchecked disabled A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
       "role": "radio",
       "name": "",
       "disabled": true,
+      "focusable": true,
       "checked": false
     }
   ]
@@ -158,72 +162,4 @@ snapshots["sbb-toggle-option renders unchecked disabled A11y tree Chrome"] =
 </p>
 `;
 /* end snapshot sbb-toggle-option renders unchecked disabled A11y tree Chrome */
-
-snapshots["sbb-toggle-option renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "radio",
-      "name": "",
-      "checked": true
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-toggle-option renders A11y tree Firefox */
-
-snapshots["sbb-toggle-option renders unchecked A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "radio",
-      "name": ""
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-toggle-option renders unchecked A11y tree Firefox */
-
-snapshots["sbb-toggle-option renders checked disabled A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "radio",
-      "name": "",
-      "disabled": true,
-      "checked": true
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-toggle-option renders checked disabled A11y tree Firefox */
-
-snapshots["sbb-toggle-option renders unchecked disabled A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "radio",
-      "name": "",
-      "disabled": true
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-toggle-option renders unchecked disabled A11y tree Firefox */
 

--- a/src/elements/toggle/toggle/__snapshots__/toggle.snapshot.spec.snap.js
+++ b/src/elements/toggle/toggle/__snapshots__/toggle.snapshot.spec.snap.js
@@ -31,43 +31,18 @@ snapshots["sbb-toggle renders Shadow DOM"] =
 snapshots["sbb-toggle renders A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "radio",
-      "name": "Value one",
-      "checked": true
-    },
-    {
-      "role": "radio",
-      "name": "Value two",
-      "checked": false
+      "role": "radiogroup",
+      "name": "",
+      "invalid": false,
+      "required": false
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-toggle renders A11y tree Chrome */
-
-snapshots["sbb-toggle renders A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "radio",
-      "name": "Value one",
-      "checked": true
-    },
-    {
-      "role": "radio",
-      "name": "Value two"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-toggle renders A11y tree Firefox */
 

--- a/src/elements/tooltip/__snapshots__/tooltip.snapshot.spec.snap.js
+++ b/src/elements/tooltip/__snapshots__/tooltip.snapshot.spec.snap.js
@@ -29,41 +29,15 @@ snapshots["sbb-tooltip Shadow DOM"] =
 `;
 /* end snapshot sbb-tooltip Shadow DOM */
 
-snapshots["sbb-tooltip A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "button",
-      "name": "Button",
-      "description": "Tooltip"
-    },
-    {
-      "role": "text leaf",
-      "name": "Tooltip"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-tooltip A11y tree Firefox */
-
 snapshots["sbb-tooltip A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "button",
-      "name": "Button",
-      "description": "Tooltip"
-    },
-    {
-      "role": "text",
-      "name": "Tooltip"
+      "role": "generic",
+      "name": ""
     }
   ]
 }

--- a/src/elements/train/train-formation/__snapshots__/train-formation.snapshot.spec.snap.js
+++ b/src/elements/train/train-formation/__snapshots__/train-formation.snapshot.spec.snap.js
@@ -129,76 +129,22 @@ snapshots["sbb-train-formation should render with multiple trains Shadow DOM"] =
 snapshots["sbb-train-formation should render with multiple trains A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "heading",
-      "name": "Train.",
-      "level": 6
-    },
-    {
-      "role": "text",
-      "name": "Coaches of the train"
-    },
-    {
-      "role": "text",
-      "name": "Train coach, Sector, A"
-    },
-    {
-      "role": "heading",
-      "name": "Train.",
-      "level": 6
-    },
-    {
-      "role": "text",
-      "name": "Coaches of the train"
-    },
-    {
-      "role": "text",
-      "name": "Train coach, Sector, B"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "role": "generic",
+          "name": ""
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-train-formation should render with multiple trains A11y tree Chrome */
-
-snapshots["sbb-train-formation should render with multiple trains A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "heading",
-      "name": "Train.",
-      "level": 6
-    },
-    {
-      "role": "text leaf",
-      "name": "Coaches of the train"
-    },
-    {
-      "role": "text leaf",
-      "name": "Train coach, Sector, A"
-    },
-    {
-      "role": "heading",
-      "name": "Train.",
-      "level": 6
-    },
-    {
-      "role": "text leaf",
-      "name": "Coaches of the train"
-    },
-    {
-      "role": "text leaf",
-      "name": "Train coach, Sector, B"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-train-formation should render with multiple trains A11y tree Firefox */
 

--- a/src/elements/train/train-wagon/__snapshots__/train-wagon.snapshot.spec.snap.js
+++ b/src/elements/train/train-wagon/__snapshots__/train-wagon.snapshot.spec.snap.js
@@ -206,50 +206,30 @@ snapshots["sbb-train-wagon should render as type closed wagon without number Sha
 snapshots["sbb-train-wagon should render as type wagon A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Number, 38"
-    },
-    {
-      "role": "text",
-      "name": "First Class"
-    },
-    {
-      "role": "text",
-      "name": "No passage to the previous train coach"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "role": "list",
+              "name": "Train coach"
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-train-wagon should render as type wagon A11y tree Chrome */
-
-snapshots["sbb-train-wagon should render as type wagon A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Number, 38"
-    },
-    {
-      "role": "text leaf",
-      "name": "First Class"
-    },
-    {
-      "role": "text leaf",
-      "name": "No passage to the previous train coach"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-train-wagon should render as type wagon A11y tree Firefox */
 
 snapshots["sbb-train-wagon should render as type wagon end with only one property DOM"] = 
 `<sbb-train-wagon
@@ -308,26 +288,6 @@ snapshots["sbb-train-wagon should render as type wagon end with only one propert
 `;
 /* end snapshot sbb-train-wagon should render as type wagon end with only one property A11y tree Chrome */
 
-snapshots["sbb-train-wagon should render as type wagon end with only one property A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Train coach"
-    },
-    {
-      "role": "text leaf",
-      "name": "First Class"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-train-wagon should render as type wagon end with only one property A11y tree Firefox */
-
 snapshots["sbb-train-wagon should render as type wagon-end-right with only one property DOM"] = 
 `<sbb-train-wagon
   type="wagon-end-right"
@@ -371,42 +331,30 @@ snapshots["sbb-train-wagon should render as type wagon-end-right with only one p
 snapshots["sbb-train-wagon should render as type wagon-end-right with only one property A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "First Class"
-    },
-    {
-      "role": "text",
-      "name": "No passage to the next train coach"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "role": "list",
+              "name": "Train coach"
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-train-wagon should render as type wagon-end-right with only one property A11y tree Chrome */
-
-snapshots["sbb-train-wagon should render as type wagon-end-right with only one property A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "First Class"
-    },
-    {
-      "role": "text leaf",
-      "name": "No passage to the next train coach"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-train-wagon should render as type wagon-end-right with only one property A11y tree Firefox */
 
 snapshots["sbb-train-wagon should render with only label DOM"] = 
 `<sbb-train-wagon
@@ -443,39 +391,43 @@ snapshots["sbb-train-wagon should render with only label Shadow DOM"] =
 `;
 /* end snapshot sbb-train-wagon should render with only label Shadow DOM */
 
-snapshots["sbb-train-wagon should render with only label A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Train coach"
-    },
-    {
-      "role": "text leaf",
-      "name": "Number, 1"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-train-wagon should render with only label A11y tree Firefox */
-
 snapshots["sbb-train-wagon should render with only label A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Train coach"
-    },
-    {
-      "role": "text",
-      "name": "Number, 1"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "role": "StaticText",
+                      "name": "Train coach"
+                    }
+                  ]
+                },
+                {
+                  "role": "generic",
+                  "name": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }
@@ -515,40 +467,50 @@ snapshots["sbb-train-wagon should render as type wagon-end-left Shadow DOM"] =
 snapshots["sbb-train-wagon should render as type wagon-end-left A11y tree Chrome"] = 
 `<p>
   {
-  "role": "WebArea",
-  "name": "",
+  "role": "generic",
+  "name": "Fixture Container",
   "children": [
     {
-      "role": "text",
-      "name": "Train coach"
-    },
-    {
-      "role": "text",
-      "name": "No passage to the previous train coach"
+      "ignored": true,
+      "role": "none",
+      "children": [
+        {
+          "ignored": true,
+          "role": "none",
+          "children": [
+            {
+              "ignored": true,
+              "role": "none",
+              "children": [
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "role": "StaticText",
+                      "name": "Train coach"
+                    }
+                  ]
+                },
+                {
+                  "ignored": true,
+                  "role": "none",
+                  "children": [
+                    {
+                      "role": "StaticText",
+                      "name": "No passage to the previous train coach"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }
 </p>
 `;
 /* end snapshot sbb-train-wagon should render as type wagon-end-left A11y tree Chrome */
-
-snapshots["sbb-train-wagon should render as type wagon-end-left A11y tree Firefox"] = 
-`<p>
-  {
-  "role": "document",
-  "name": "",
-  "children": [
-    {
-      "role": "text leaf",
-      "name": "Train coach"
-    },
-    {
-      "role": "text leaf",
-      "name": "No passage to the previous train coach"
-    }
-  ]
-}
-</p>
-`;
-/* end snapshot sbb-train-wagon should render as type wagon-end-left A11y tree Firefox */
 

--- a/src/elements/train/train-wagon/train-wagon.spec.ts
+++ b/src/elements/train/train-wagon/train-wagon.spec.ts
@@ -69,7 +69,7 @@ describe(`sbb-train-wagon`, () => {
     await waitForLitRender(element);
 
     // Select all accessibility relevant text parts
-    // The alternative of a11ySnapshot() does not work as the list title can't be extracted reliable.
+    // The alternative of a11yTreeSnapshot() does not work as the list title can't be extracted reliable.
     return Array.from(
       element.shadowRoot!.querySelectorAll<HTMLElement>(
         '[aria-label]:not(.sbb-train-wagon__attribute-icon-list), sbb-timetable-occupancy-icon, .sbb-screen-reader-only',

--- a/tools/web-test-runner/aria-tree-plugin.ts
+++ b/tools/web-test-runner/aria-tree-plugin.ts
@@ -1,0 +1,217 @@
+import type { TestRunnerPlugin } from '@web/test-runner-core';
+import type { PlaywrightLauncher } from '@web/test-runner-playwright';
+
+export type A11yTreePayload = { selector?: string };
+
+export function a11yTreePlugin(): TestRunnerPlugin<A11yTreePayload> {
+  const toBoolean = (value: any): boolean | null =>
+    typeof value === 'boolean' ? value : value === 'true' ? true : value === 'false' ? false : null;
+  const toMaybeBoolean = (value: any): boolean | string => toBoolean(value) ?? value;
+  const throwTypeError = (): never => {
+    throw new TypeError(`Internal Error: Expected a boolean value but received a different type.`);
+  };
+  const assertBoolean = (value: any): boolean => {
+    return toBoolean(value) ?? throwTypeError();
+  };
+  return {
+    name: 'a11y-tree-command',
+    async executeCommand({ command, payload, session }): Promise<any> {
+      if (command === 'a11y-tree') {
+        // handle specific behavior for playwright
+        if (session.browser.type === 'playwright') {
+          if (session.browser.name === 'Chromium') {
+            const page = (session.browser as PlaywrightLauncher).getPage(session.id);
+            const client = await page.context().newCDPSession(page);
+
+            await client.send('Accessibility.enable');
+            await client.send('DOM.enable');
+
+            // Get the document root first
+            const { root } = await client.send('DOM.getDocument', { depth: -1 });
+
+            // Query for the element to get its nodeId
+            const { nodeId } = await client.send('DOM.querySelector', {
+              nodeId: root.nodeId,
+              selector: payload?.selector || 'body',
+            });
+
+            const snapshot = await client.send('Accessibility.getPartialAXTree', { nodeId });
+            const rootNode = snapshot.nodes.at(0)!;
+            if (!rootNode) {
+              return null;
+            }
+
+            function convertNode(node: typeof rootNode, allNodes: (typeof rootNode)[]): A11yNode {
+              const result: Partial<A11yNode> = {};
+              if (node.ignored) {
+                result.ignored = node.ignored;
+              }
+              if (node.role) {
+                result.role = node.role.value;
+              }
+              if (node.name) {
+                result.name = node.name.value;
+              }
+              if (node.description) {
+                result.description = node.description.value;
+              }
+              if (node.value) {
+                result.value = node.value.value;
+              }
+              if (node.properties) {
+                for (const property of node.properties) {
+                  try {
+                    if (property.value === undefined) {
+                      // Skip undefined values
+                    } else if (property.name === 'atomic') {
+                      result.atomic = assertBoolean(property.value.value);
+                    } else if (property.name === 'autocomplete') {
+                      result.autocomplete = property.value.value;
+                    } else if (property.name === 'busy') {
+                      result.busy = toMaybeBoolean(property.value.value);
+                    } else if (property.name === 'checked') {
+                      result.checked = toMaybeBoolean(property.value.value);
+                    } else if (property.name === 'describedby') {
+                      result.describedby = property.value.value;
+                    } else if (property.name === 'disabled') {
+                      result.disabled = assertBoolean(property.value.value);
+                    } else if (property.name === 'editable') {
+                      result.editable = toMaybeBoolean(property.value.value);
+                    } else if (property.name === 'expanded') {
+                      result.expanded = assertBoolean(property.value.value);
+                    } else if (property.name === 'focusable') {
+                      result.focusable = assertBoolean(property.value.value);
+                    } else if (property.name === 'focused') {
+                      result.focused = assertBoolean(property.value.value);
+                    } else if (property.name === 'hasPopup') {
+                      result.hasPopup = property.value.value;
+                    } else if (property.name === 'invalid') {
+                      result.invalid = toMaybeBoolean(property.value.value);
+                    } else if (property.name === 'labelledby') {
+                      result.labelledby = property.value.value;
+                    } else if (property.name === 'level') {
+                      result.level = property.value.value;
+                    } else if (property.name === 'live') {
+                      result.live = property.value.value;
+                    } else if (property.name === 'multiline') {
+                      result.multiline = assertBoolean(property.value.value);
+                    } else if (property.name === 'multiselectable') {
+                      result.multiselectable = assertBoolean(property.value.value);
+                    } else if (property.name === 'orientation') {
+                      result.orientation = property.value.value;
+                    } else if (property.name === 'pressed') {
+                      result.pressed = toMaybeBoolean(property.value.value);
+                    } else if (property.name === 'readonly') {
+                      result.readonly = assertBoolean(property.value.value);
+                    } else if (property.name === 'relevant') {
+                      result.relevant = property.value.value;
+                    } else if (property.name === 'required') {
+                      result.required = assertBoolean(property.value.value);
+                    } else if (property.name === 'roledescription') {
+                      result.roledescription = property.value.value;
+                    } else if (property.name === 'selected') {
+                      result.selected = assertBoolean(property.value.value);
+                    } else if (property.name === 'valuemin') {
+                      result.valuemin = property.value.value;
+                    } else if (property.name === 'valuemax') {
+                      result.valuemax = property.value.value;
+                    } else if (property.name === 'valuetext') {
+                      result.valuetext = property.value.value;
+                    } else if (property.name === 'settable') {
+                      result.settable = assertBoolean(property.value.value);
+                    } else {
+                      throw new Error(
+                        `Unsupported property "${property.name}" in accessibility tree snapshot.`,
+                      );
+                    }
+                  } catch {
+                    throw new Error(
+                      `A11y Tree Plugin: Unexpected value for "${property.name}": ${JSON.stringify(property.value.value)}. ` +
+                        'Please update adapter code in tools/web-test-runner/aria-tree-plugin.ts!',
+                    );
+                  }
+                }
+              }
+
+              if (node.childIds) {
+                const children = node.childIds
+                  .map((childId) => {
+                    const childNode = allNodes.find((n) => n.nodeId === childId);
+                    return childNode ? convertNode(childNode, allNodes) : null;
+                  })
+                  .filter((n): n is A11yNode => !!n);
+                if (children.length) {
+                  result.children = children;
+                }
+              }
+
+              return result as A11yNode;
+            }
+
+            return convertNode(rootNode!, snapshot.nodes);
+          }
+
+          return null;
+        }
+
+        // you might not be able to support all browser launchers
+        throw new Error(
+          `Acessibility tree is not supported for browser type ${session.browser.type}.`,
+        );
+      }
+    },
+  };
+}
+
+export interface A11yNode {
+  /**
+   * Whether this node is ignored for accessibility
+   */
+  ignored?: boolean;
+  /**
+   * This `Node`'s role, whether explicit or implicit.
+   */
+  role?: string;
+  /**
+   * The accessible name for this `Node`.
+   */
+  name?: string;
+  /**
+   * The accessible description for this `Node`.
+   */
+  description?: string;
+  /**
+   * The value for this `Node`.
+   */
+  value?: string;
+
+  atomic?: boolean;
+  autocomplete?: string;
+  busy?: boolean | string;
+  checked?: boolean | string;
+  describedby?: string;
+  disabled?: boolean;
+  editable?: boolean | string;
+  expanded?: boolean;
+  focusable?: boolean;
+  focused?: boolean;
+  hasPopup?: string;
+  invalid?: boolean | string;
+  labelledby?: string;
+  level?: string;
+  live?: string;
+  multiline?: boolean;
+  multiselectable?: boolean;
+  orientation?: string;
+  pressed?: boolean | string;
+  readonly?: boolean;
+  relevant?: string;
+  required?: boolean;
+  roledescription?: string;
+  selected?: boolean;
+  settable?: boolean;
+  valuemin?: string;
+  valuemax?: string;
+  valuetext?: string;
+  children?: A11yNode[];
+}

--- a/tools/web-test-runner/index.ts
+++ b/tools/web-test-runner/index.ts
@@ -1,3 +1,4 @@
+export * from './aria-tree-plugin.ts';
 export * from './configure-container-playwright-browser.ts';
 export * from './container-playwright-browser-plugin.ts';
 export * from './minimal-reporter.ts';

--- a/web-test-runner.config.ts
+++ b/web-test-runner.config.ts
@@ -9,7 +9,6 @@ import {
   type TestRunnerCoreConfig,
   type TestRunnerGroupConfig,
 } from '@web/test-runner';
-import { a11ySnapshotPlugin } from '@web/test-runner-commands/plugins';
 import {
   type PlaywrightLauncherArgs,
   playwrightLauncher,
@@ -19,6 +18,7 @@ import { visualRegressionPlugin } from '@web/test-runner-visual-regression/plugi
 import { initCompiler } from 'sass';
 
 import {
+  a11yTreePlugin,
   configureRemotePlaywrightBrowser,
   minimalReporter,
   patchedSummaryReporter,
@@ -200,7 +200,7 @@ export default {
   browsers: browsers,
   concurrentBrowsers: 3,
   plugins: [
-    a11ySnapshotPlugin(),
+    a11yTreePlugin(),
     litSsrPlugin({
       workerInitModules: [
         './tools/node-esm-hook/register-hooks.ts',


### PR DESCRIPTION
We have previously depended on the deprecated aria snapshot capabilities of Playwright. This has recently been removed and no cross browser alternative exists at the moment.
Due to this we at least try to use the Chromium API for reading the accessibility tree.

The relevant files are `tools/web-test-runner/aria-tree-plugin.ts` and `src/elements/core/testing/private/a11y-tree-snapshot.ts`.