### PR TITLE
build: add frame-ancestors for digital.sbb.ch

### DIFF
--- a/.github/default.conf
+++ b/.github/default.conf
@@ -32,16 +32,13 @@ server {
     }
     expires -1;
     add_header Cache-Control "no-cache";
-    # Prevents site being used inside an iframe (Recommended by Cyber@SBB)
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
-    add_header X-Frame-Options SAMEORIGIN;
     # Forces usage of HTTPS (Recommended by Cyber@SBB)
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
     # Configures CSP (Recommended by Cyber@SBB)
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
     # https://angular.io/guide/security#content-security-policy
-    add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; font-src 'self' https://cdn.app.sbb.ch/; connect-src 'self' https://icons.app.sbb.ch/;";
+    add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; font-src 'self' https://cdn.app.sbb.ch/; connect-src 'self' https://icons.app.sbb.ch/; frame-ancestors 'self' https://digital.sbb.ch;";
     try_files $uri $uri/ /index.html =404;
   }
 


### PR DESCRIPTION
The previous CSP configuration broke digital.sbb.ch, as it limited access via iframe. This PR adds the `frame-ancestors` configuration to CSP, to re-allow this usage.