### PR TITLE
build: add CSP for image CDN

### DIFF
--- a/.github/default.conf
+++ b/.github/default.conf
@@ -38,7 +38,7 @@ server {
     # Configures CSP (Recommended by Cyber@SBB)
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
     # https://angular.io/guide/security#content-security-policy
-    add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; font-src 'self' https://cdn.app.sbb.ch/; connect-src 'self' https://icons.app.sbb.ch/; frame-ancestors 'self' https://digital.sbb.ch;";
+    add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; font-src 'self' https://cdn.app.sbb.ch/; connect-src 'self' https://icons.app.sbb.ch/; frame-ancestors 'self' https://digital.sbb.ch; img-src 'self' https://cdn.img.sbb.ch;";
     try_files $uri $uri/ /index.html =404;
   }
 


### PR DESCRIPTION
Currently images from the SBB image CDN are blocked due to CSP. This PR adds the necessary config to allow these.