### PR TITLE
fix(sbb-select): avoid displaying `undefined` entry in select

### DIFF
--- a/src/elements/select/select.component.ts
+++ b/src/elements/select/select.component.ts
@@ -456,8 +456,10 @@ class SbbSelectElement<T = string> extends SbbUpdateSchedulerMixin(
   }
 
   public override disconnectedCallback(): void {
+    // Take back the trigger element previously moved to the light DOM.
+    // Due to timing issues, this needs to be done before calling super.disconnectedCallback().
+    this.prepend(this._triggerElement);
     super.disconnectedCallback();
-    this.prepend(this._triggerElement); // Take back the trigger element previously moved to the light DOM
     this._openPanelEventsController?.abort();
   }
 

--- a/src/elements/select/select.spec.ts
+++ b/src/elements/select/select.spec.ts
@@ -770,6 +770,45 @@ describe(`sbb-select`, () => {
         expect(element.isOpen).to.be.true;
       });
     });
+
+    it('should work correctly after removing from DOM and re-adding', async () => {
+      // Set initial value
+      element.value = '2';
+      await waitForLitRender(element);
+
+      // Check initial state
+      expect(element.value).to.be.equal('2');
+      expect(secondOption.selected).to.be.true;
+      expect(root.querySelector<SbbSelectElement>('.sbb-select-trigger')!).to.exist;
+
+      // Remove from DOM
+      element.remove();
+      await waitForLitRender(root);
+
+      expect(root.querySelector<SbbSelectElement>('.sbb-select-trigger')!).not.to.exist;
+
+      // Re-add to DOM
+      root.insertBefore(element, root.firstElementChild);
+      await waitForLitRender(root);
+
+      // Verify element is back
+      const reAddedElement = root.querySelector<SbbSelectElement>('sbb-select')!;
+      expect(reAddedElement).to.exist;
+      expect(reAddedElement).to.equal(element);
+      expect(root.querySelector<SbbSelectElement>('.sbb-select-trigger')!).to.exist;
+
+      // Check that value is preserved
+      expect(reAddedElement.value).to.be.equal('2');
+      expect(secondOption.selected).to.be.true;
+
+      // Check that select can be opened
+      const openSpy = new EventSpy(SbbSelectElement.events.open, reAddedElement);
+      reAddedElement.open();
+      await waitForLitRender(reAddedElement);
+
+      await openSpy.calledOnce();
+      expect(reAddedElement.isOpen).to.be.true;
+    });
   });
 
   describe('form association', () => {


### PR DESCRIPTION
Closes #4444