### PR TITLE
refactor(sbb-radio-button): expose gap variable

### DIFF
--- a/src/elements/radio-button/common/radio-button-common.global.scss
+++ b/src/elements/radio-button/common/radio-button-common.global.scss
@@ -3,6 +3,7 @@
 $theme: 'standard' !default;
 
 @mixin base {
+  --sbb-radio-button-label-gap: var(--sbb-spacing-fixed-2x);
   --sbb-radio-button-label-color: var(--sbb-color-3);
   --sbb-radio-button-background-color: var(--sbb-background-color-1);
   --sbb-radio-button-border-width: var(--sbb-border-width-1x);

--- a/src/elements/radio-button/common/radio-button-common.scss
+++ b/src/elements/radio-button/common/radio-button-common.scss
@@ -110,7 +110,7 @@
     // The border color acts as background color.
     border: var(--sbb-radio-button-background-fake-border-width) solid
       var(--sbb-radio-button-background-color);
-    margin-inline-end: var(--sbb-spacing-fixed-2x);
+    margin-inline-end: var(--sbb-radio-button-label-gap);
   }
 
   &::after {

--- a/src/elements/radio-button/radio-button/radio-button.scss
+++ b/src/elements/radio-button/radio-button/radio-button.scss
@@ -8,16 +8,14 @@
   outline: none !important;
 }
 
+:host(:not(:state(slotted), :state(slotted-icon), :state(has-icon-name))) {
+  --sbb-radio-button-label-gap: 0;
+}
+
 .sbb-radio-button {
   :host(:focus-visible) & {
     @include sbb.focus-outline;
 
     border-radius: calc(var(--sbb-border-radius-4x) - var(--sbb-focus-outline-offset));
-  }
-}
-
-.sbb-radio-button__label-slot::before {
-  :host(:not(:state(slotted), :state(slotted-icon), :state(has-icon-name))) & {
-    margin-inline-end: 0;
   }
 }


### PR DESCRIPTION
In customer projects it could happen that that using a calculation with the gap is needed. Having a CSS variable helps here (aligned to how it's done in the sbb-checkbox)