### PR TITLE
fix(sbb-tab-group): ignore calculated height in fixedHeight conditions

### DIFF
--- a/src/elements/tabs/tab-group/tab-group.component.ts
+++ b/src/elements/tabs/tab-group/tab-group.component.ts
@@ -44,7 +44,6 @@ class SbbTabGroupElement extends SbbElementInternalsMixin(SbbHydrationMixin(LitE
   } as const;
 
   private _tabGroupElement!: HTMLElement;
-  private _tabContentElement!: HTMLElement;
   private _tabGroupResizeObserver = new ResizeController(this, {
     target: null,
     skipInitial: true,
@@ -209,7 +208,7 @@ class SbbTabGroupElement extends SbbElementInternalsMixin(SbbHydrationMixin(LitE
    * @internal
    */
   protected setTabContentHeight(contentHeight: number): void {
-    this._tabContentElement.style.height = `${contentHeight}px`;
+    this.style.setProperty('--sbb-tab-content-height', `${contentHeight}px`);
   }
 
   protected override render(): TemplateResult {
@@ -221,10 +220,7 @@ class SbbTabGroupElement extends SbbElementInternalsMixin(SbbHydrationMixin(LitE
       >
         <slot name="tab-bar" @slotchange=${this._onLabelSlotChange}></slot>
       </div>
-      <div
-        class="sbb-tab-group-content"
-        ${ref((el?: Element) => (this._tabContentElement = el as HTMLElement))}
-      >
+      <div class="sbb-tab-group-content">
         <slot @slotchange=${throttle(this._onContentSlotChange, 150)}></slot>
       </div>
     `;

--- a/src/elements/tabs/tab-group/tab-group.scss
+++ b/src/elements/tabs/tab-group/tab-group.scss
@@ -14,6 +14,8 @@
 }
 
 .sbb-tab-group-content {
+  height: var(--sbb-tab-content-height);
+
   :host([fixed-height]) & {
     @include sbb.scrollbar;
 


### PR DESCRIPTION
As the style tag with the assigned height was winning, the height of 100% in fixed height condition was ignored. Initially, this worked, but for any screen resize, the fixed size won.