### PR TITLE
fix: remove temporalDateAdapter instance

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -14,6 +14,10 @@ import leanTheme from '../src/elements/core/styles/lean-theme.scss?inline';
 import offBrandTheme from '../src/elements/core/styles/off-brand-theme.scss?inline';
 import safetyTheme from '../src/elements/core/styles/safety-theme.scss?inline';
 
+if (typeof Temporal !== 'object') {
+  await import('temporal-polyfill/global');
+}
+
 const originalStyleSheet = Array.from(document.styleSheets).find((stylesheet) =>
   Array.from(stylesheet.cssRules).find((value) =>
     // We assume that we target the standard theme file if this variable is included.

--- a/src/elements/core/datetime/native-date-adapter.ts
+++ b/src/elements/core/datetime/native-date-adapter.ts
@@ -5,7 +5,7 @@ import { DateAdapter } from './date-adapter.ts';
 /**
  * Matches strings that have the form of a valid RFC 3339 string
  * (https://tools.ietf.org/html/rfc3339). Note that the string may not actually be a valid date
- * because the regex will match strings an without of bounds month, date, etc.
+ * because the regex will match strings and without of bounds month, date, etc.
  */
 const ISO_8601_REGEX =
   /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|(?:(?:\+|-)\d{2}:\d{2}))?)?$/;

--- a/src/elements/core/datetime/temporal-date-adapter.ts
+++ b/src/elements/core/datetime/temporal-date-adapter.ts
@@ -7,7 +7,7 @@ import { DateAdapter } from './date-adapter.ts';
 /**
  * Matches strings that have the form of a valid RFC 3339 string
  * (https://tools.ietf.org/html/rfc3339). Note that the string may not actually be a valid date
- * because the regex will match strings an without of bounds month, date, etc.
+ * because the regex will match strings and without of bounds month, date, etc.
  */
 const ISO_8601_REGEX =
   /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|(?:(?:\+|-)\d{2}:\d{2}))?)?$/;
@@ -194,5 +194,3 @@ export class TemporalDateAdapter extends DateAdapter<Temporal.PlainDate> {
     return Array.from({ length }).map((_, i) => valueFunction(i));
   }
 }
-
-export const temporalDateAdapter = new TemporalDateAdapter();


### PR DESCRIPTION
The `temporalDateAdapter` was mistakenly added during implementation, but it is not needed (and breaks browser that do not yet support Temporal).
Due to this we remove this variable.