### PR TITLE
build: create script for applying changelog to main branch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -116,13 +116,14 @@ jobs:
           RELEASE_TAG: ${{ steps.release.outputs.version }}
           TEAMS_WEBHOOK: ${{ secrets.TEAMS_WEBHOOK }}
 
-      - name: Cherry-pick CHANGELOG.md into ${{ github.event.repository.default_branch }}
+      - name: Apply CHANGELOG.md into ${{ github.event.repository.default_branch }}
         if: ${{ steps.release.outputs.release_created && github.ref_name != 'main' }}
         run: |
+          node scripts/changelog.ts extract
           git config user.email "github-actions@github.com"
           git config user.name "github-actions"
           git checkout ${{ github.event.repository.default_branch }}
-          git show ${{ github.sha }} -- CHANGELOG.md | git apply -
+          node scripts/changelog.ts insert
           git commit -a -m "chore: update changelog"
           git push
 

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -1,0 +1,54 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+const { positionals } = parseArgs({
+  allowPositionals: true,
+});
+const changelogPath = fileURLToPath(new URL('../CHANGELOG.md', import.meta.url));
+const extractPath = fileURLToPath(
+  new URL('../dist/changelog/changelog-extract.json', import.meta.url),
+);
+const changelog = readFileSync(changelogPath, 'utf8');
+const versionRegex = /## \[(\d+\.\d+\.\d+.*?)\]\(/g;
+
+if (positionals[0] === 'extract') {
+  const latestMatch = versionRegex.exec(changelog);
+  const previousMatch = versionRegex.exec(changelog);
+  mkdirSync(dirname(extractPath), { recursive: true });
+  console.log(`Extracting changelog for version ${latestMatch![1]}...`);
+  writeFileSync(
+    extractPath,
+    JSON.stringify({
+      [latestMatch![1]]: changelog.substring(latestMatch!.index, previousMatch!.index),
+    }),
+    'utf8',
+  );
+} else if (positionals[0] === 'insert') {
+  if (!existsSync(extractPath)) {
+    throw new Error(
+      `Extracted changelog not found at ${extractPath}. Please run "extract" command first.`,
+    );
+  }
+
+  const extractedChangelog = JSON.parse(readFileSync(extractPath, 'utf8'));
+  const extractedVersion = Object.keys(extractedChangelog)[0];
+  const extractedContent = extractedChangelog[extractedVersion];
+  const latestMatch = versionRegex.exec(changelog);
+
+  if (changelog.includes(`## [${extractedVersion}]`)) {
+    console.log(
+      `Changelog for version ${extractedVersion} already exists in ${changelogPath}. Skipping insertion.`,
+    );
+  } else {
+    console.log(`Inserting changelog for version ${extractedVersion}...`);
+    const updatedChangelog =
+      changelog.substring(0, latestMatch!.index) +
+      extractedContent +
+      changelog.substring(latestMatch!.index);
+    writeFileSync(changelogPath, updatedChangelog, 'utf8');
+  }
+} else {
+  throw new Error(`Unknown command ${positionals[0]}`);
+}


### PR DESCRIPTION
We currently use git cherry pick to apply the generated changelog from our release branches to our default branch.
This can easily fail, if the git state between release branches and the default branch is no longer aligned.
Due to this, this PR refactors this to just use a script that manually extracts the generated changelog and separately applies it to the changelog on the default branch.