### PR TITLE
build: publish dev packages

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -61,31 +61,10 @@ jobs:
 
       - name: Update npm
         run: npm install --global npm@latest
-      - name: 'Release: Determine npm tag'
-        if: ${{ steps.release.outputs.release_created }}
-        id: npm_tag
-        run: echo "npm_tag=$([[ "${{ steps.version.outputs.version }}" == *"-"* ]] && echo "next" || echo "latest")" >> $GITHUB_OUTPUT
-
-      - name: 'Release: Publish @sbb-esta/lyne-elements'
-        if: ${{ steps.release.outputs.release_created }}
-        run: |
-          cd dist/elements
-          npm publish --tag ${{ steps.npm_tag.outputs.npm_tag }}
-      - name: 'Release: Publish @sbb-esta/lyne-elements-experimental'
-        if: ${{ steps.release.outputs.release_created }}
-        run: |
-          cd dist/elements-experimental
-          npm publish --tag ${{ steps.npm_tag.outputs.npm_tag }}
-      - name: 'Release: Publish @sbb-esta/lyne-react'
-        if: ${{ steps.release.outputs.release_created }}
-        run: |
-          cd dist/react
-          npm publish --tag ${{ steps.npm_tag.outputs.npm_tag }}
-      - name: 'Release: Publish @sbb-esta/lyne-react-experimental'
-        if: ${{ steps.release.outputs.release_created }}
-        run: |
-          cd dist/react-experimental
-          npm publish --tag ${{ steps.npm_tag.outputs.npm_tag }}
+      - name: Publish packages
+        run: node scripts/publish.ts
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
 
       - uses: ./.github/actions/setup-mint
       - name: 'Container: Build and publish release image'

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,0 +1,64 @@
+import { execSync } from 'node:child_process';
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const releaseVersion = process.env.VERSION?.trim() || null;
+const dryRun = !process.env.CI;
+const distDir = fileURLToPath(new URL('../dist/', import.meta.url));
+
+interface PackageJson {
+  name: string;
+  version: string;
+  keywords?: string[];
+}
+
+if (dryRun) {
+  console.log('Running in dry-run mode. No packages will be published to npm.');
+}
+
+const packages = readdirSync(distDir, { withFileTypes: true, recursive: true })
+  .filter((d) => d.name === 'package.json')
+  .map((d) => join(d.parentPath, d.name));
+for (const packagePath of packages) {
+  const packageContent = readFileSync(packagePath, 'utf-8');
+  const pkg = JSON.parse(packageContent) as PackageJson;
+  if (!pkg.name.startsWith('@sbb-esta/')) {
+    throw new Error(`Unexpected package name ${pkg.name} in ${packagePath}`);
+  }
+
+  const latestInfo = (await fetch(`https://registry.npmjs.org/${pkg.name}/latest`).then((r) =>
+    r.json(),
+  )) as PackageJson;
+  const latestMajor = parseInt(latestInfo.version.split('.')[0]);
+  const releaseMajor = parseInt(pkg.version.split('.')[0]);
+  const tag = pkg.version.includes('-')
+    ? 'next'
+    : latestMajor <= releaseMajor
+      ? 'latest'
+      : `v${releaseMajor}-lts`;
+  const publish = (): void => {
+    console.log(`Publishing ${pkg.name} with version ${pkg.version} to npm with tag ${tag}`);
+    execSync(`npm publish --tag ${tag}${dryRun ? ' --dry-run' : ''}`, {
+      stdio: 'inherit',
+      cwd: dirname(packagePath),
+    });
+  };
+
+  if (releaseVersion) {
+    publish();
+  }
+
+  pkg.name += '-dev';
+  pkg.version += `-dev.${Math.floor(Date.now() / 1000)}`;
+  pkg.keywords = [
+    ...(pkg.keywords || []),
+    `https://github.com/${process.env.GITHUB_REPOSITORY}/commit/${process.env.GITHUB_SHA}`,
+  ];
+  try {
+    writeFileSync(packagePath, JSON.stringify(pkg, null, 2), 'utf8');
+    publish();
+  } finally {
+    writeFileSync(packagePath, packageContent, 'utf8');
+  }
+}


### PR DESCRIPTION
This PR refactors the publishing workflow and adds publishing of dev packges (from release and main branches).
This will allow us in consuming repository (e.g. lyne-angular) to depend on the dev packages for faster iteration.