### PR TITLE
docs: add public var `--sbb-page-spacing-padding` entry

### DIFF
--- a/src/elements/container/container/container.component.ts
+++ b/src/elements/container/container/container.component.ts
@@ -19,9 +19,8 @@ import style from './container.scss?lit&inline';
  * @slot - Use the unnamed slot to add anything to the container.
  * @slot sticky-bar - The slot used by the sbb-sticky-bar component.
  * @slot image - The slot used to slot an `sbb-image` to use as background.
- * @cssprop --sbb-page-spacing-padding - Use this variable to override the page spacing, which should
- * only be needed in very rare cases. Overriding this variable unsets the main behavior of the container,
- * which is to use the default page spacing.
+ * @cssprop --sbb-page-spacing-padding - Use this variable to override the default page spacing.
+ * Note that overriding this will disable the standard responsive spacing behavior of the container.
  */
 export
 @customElement('sbb-container')

--- a/src/elements/container/container/readme.md
+++ b/src/elements/container/container/readme.md
@@ -65,9 +65,9 @@ but it's up to the consumer to correctly set the `negative` property on slotted 
 
 ## CSS Properties
 
-| Name                         | Default | Description                                                                                                                                                                                                   |
-| ---------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--sbb-page-spacing-padding` |         | Use this variable to override the page spacing, which should only be needed in very rare cases. Overriding this variable unsets the main behavior of the container, which is to use the default page spacing. |
+| Name                         | Default | Description                                                                                                                                               |
+| ---------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--sbb-page-spacing-padding` |         | Use this variable to override the default page spacing. Note that overriding this will disable the standard responsive spacing behavior of the container. |
 
 ## Slots
 


### PR DESCRIPTION
With https://github.com/sbb-design-systems/lyne-components/pull/3899 we added a public variable. However, as it is not documented, it could get forgiven. This PR adds the documentation with notice that it shouldn't normally be used.