### PR TITLE
fix(sbb-journey-header): add max-width

### DIFF
--- a/src/elements/journey-header/journey-header.scss
+++ b/src/elements/journey-header/journey-header.scss
@@ -31,4 +31,8 @@ sbb-icon {
       transform: rotate(-180deg);
     }
   }
+
+  > span {
+    max-width: 100%;
+  }
 }

--- a/src/elements/journey-header/journey-header.visual.spec.ts
+++ b/src/elements/journey-header/journey-header.visual.spec.ts
@@ -74,4 +74,26 @@ describe(`sbb-journey-header`, () => {
       });
     }
   });
+
+  describeViewports({ viewports: ['zero'] }, () => {
+    for (const negative of [false, true]) {
+      describe(`negative=${negative}`, () => {
+        it(
+          `longContent=true`,
+          visualDiffDefault.with(async (setup) => {
+            await setup.withFixture(
+              html` <sbb-journey-header
+                style="word-break: break-word"
+                ?negative=${negative}
+                origin="Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu"
+                destination="Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch"
+              >
+              </sbb-journey-header>`,
+              { backgroundColor: negative ? 'var(--sbb-background-color-1-negative)' : undefined },
+            );
+          }),
+        );
+      });
+    }
+  });
 });


### PR DESCRIPTION
In order to wrap text, the sbb-journey-header's inner spans must have a max-width.