### PR TITLE
fix: revert to esbuild CSS minifier

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -294,7 +294,7 @@ async function buildLibrary(pkg: PackageBuilder): Promise<void> {
           formats: ['es'],
         },
         outDir: pkg.outDir,
-        cssMinify: pkg.production,
+        cssMinify: pkg.production ? 'esbuild' : false,
         minify: pkg.production,
         emptyOutDir: false,
         sourcemap: pkg.production ? false : 'inline',


### PR DESCRIPTION
With Vite 8 lightningcss is used per default, which replaces `light-dark` with a polyfill, which breaks our styles.