### PR TITLE
chore: update build target to es2023

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -49,6 +49,18 @@ const calculateGzipSize = async (content: string): Promise<number> =>
   (await gzipAsync(content)).length;
 const calculateBrotliSize = async (content: string): Promise<number> =>
   (await brotliAsync(content)).length;
+const result = ts.readConfigFile(join(projectRoot, 'tsconfig.json'), ts.sys.readFile);
+if (result.error) {
+  throw new Error(`Error reading tsconfig.json: ${result.error.messageText}`);
+}
+const options = ts.convertCompilerOptionsFromJson(result.config.compilerOptions, projectRoot);
+if (options.errors.length) {
+  throw new Error(
+    `Error parsing tsconfig.json: ${options.errors.map((e) => e.messageText).join(', ')}`,
+  );
+}
+const scriptTarget = options.options.target!;
+
 const { positionals } = parseArgs({ allowPositionals: true });
 const buildTargets = new Set(positionals);
 
@@ -407,7 +419,7 @@ function buildRootIndex(pkg: PackageBuilder): void {
     const content = readFileSync(file, 'utf8');
     if (content.includes('elementName')) {
       const moduleName = relative(pkg.root, file).split('/')[0];
-      const sourceFile = ts.createSourceFile(file, content, ts.ScriptTarget.ES2022, true);
+      const sourceFile = ts.createSourceFile(file, content, scriptTarget, true);
       const customElements = sourceFile.statements
         .filter(ts.isClassDeclaration)
         .filter((c) =>
@@ -939,7 +951,7 @@ async function buildSizeStats(pkg: PackageBuilder): Promise<void> {
       stats.jsBrotliSize += brotliSize;
       stats.jsGzipSize += gzipSize;
       stats.jsFiles[key] = { size, brotliSize, gzipSize };
-      const sourceFile = ts.createSourceFile(file, content, ts.ScriptTarget.ES2022, true);
+      const sourceFile = ts.createSourceFile(file, content, scriptTarget, true);
 
       let cssTaggedName = '';
       let cssSize = 0;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "./dist/out-tsc",
-    "target": "es2022",
+    "target": "es2023",
     "module": "nodenext",
-    "lib": ["es2022", "DOM", "DOM.Iterable"],
+    "lib": ["es2023", "DOM", "DOM.Iterable"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
BREAKING CHANGE: The library now targets es2023