### PR TITLE
fix: use pure path in react and define in component creation

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -740,7 +740,7 @@ function renderTemplate(
       : `@sbb-esta/lyne-react/core.js`;
   const moduleParts = module.path.split('/');
   const moduleName = moduleParts[0];
-  const importPath = `${['button', 'link'].includes(moduleName) ? `${moduleName}/${moduleParts[1]}` : moduleName}.js`;
+  const importPath = `${moduleName}.pure.js`;
   const componentsImports = new Map<string, string[]>().set(importPath, [declaration.name]);
 
   if (declaration.events?.some((e) => !e.type)) {

--- a/src/react/core/create-component.ts
+++ b/src/react/core/create-component.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import type { SbbElement } from '@sbb-esta/lyne-elements/core.js';
 import {
   isServer,
   type ComplexAttributeConverter,
@@ -234,6 +235,8 @@ export const createComponent = <I extends HTMLElement, E extends EventNames = {}
   events,
   displayName,
 }: Options<I, E>): ReactWebComponent<I, E> => {
+  (elementClass as unknown as typeof SbbElement).define?.();
+
   const eventProps = new Set(Object.keys(events ?? {}));
 
   if (DEV_MODE && !NODE_MODE) {


### PR DESCRIPTION
This fixes an import path issue for buttons and links and attempts to guarantee calling define for a custom element, by having the call in the component creation function.