### PR TITLE
fix: avoid bleeding of font-weight

### DIFF
--- a/src/elements-experimental/autocomplete-grid/autocomplete-grid/autocomplete-grid.visual.spec.ts
+++ b/src/elements-experimental/autocomplete-grid/autocomplete-grid/autocomplete-grid.visual.spec.ts
@@ -380,5 +380,40 @@ describe('sbb-autocomplete-grid', () => {
         });
       }),
     );
+
+    it(
+      'inside bold context',
+      visualDiffDefault.with(async (setup) => {
+        await setup.withFixture(
+          html`<div style="font-weight: bold;">
+            <input id="bold-input" placeholder="Placeholder" />
+            <sbb-autocomplete-grid origin="bold-input" trigger="bold-input">
+              <sbb-autocomplete-grid-row>
+                <sbb-autocomplete-grid-option value="Option 1"
+                  >Option 1</sbb-autocomplete-grid-option
+                >
+                <sbb-autocomplete-grid-cell>
+                  <sbb-autocomplete-grid-button
+                    icon-name="pen-small"
+                  ></sbb-autocomplete-grid-button>
+                </sbb-autocomplete-grid-cell>
+              </sbb-autocomplete-grid-row>
+              <sbb-autocomplete-grid-row>
+                <sbb-autocomplete-grid-option value="Option 2"
+                  >Option 2</sbb-autocomplete-grid-option
+                >
+                <sbb-autocomplete-grid-cell>
+                  <sbb-autocomplete-grid-button
+                    icon-name="pen-small"
+                  ></sbb-autocomplete-grid-button>
+                </sbb-autocomplete-grid-cell>
+              </sbb-autocomplete-grid-row>
+            </sbb-autocomplete-grid>
+          </div>`,
+        );
+
+        setup.withPostSetupAction(() => openAutocomplete(setup));
+      }),
+    );
   });
 });

--- a/src/elements/autocomplete/autocomplete-base-element.scss
+++ b/src/elements/autocomplete/autocomplete-base-element.scss
@@ -14,6 +14,7 @@
   );
 
   display: none;
+  font-weight: normal;
 }
 
 :host([size='s']) {

--- a/src/elements/autocomplete/autocomplete.visual.spec.ts
+++ b/src/elements/autocomplete/autocomplete.visual.spec.ts
@@ -354,5 +354,22 @@ describe('sbb-autocomplete', () => {
         });
       }),
     );
+
+    it(
+      'inside bold context',
+      visualDiffDefault.with(async (setup) => {
+        await setup.withFixture(
+          html`<div style="font-weight: bold;">
+            <input id="bold-input" placeholder="Placeholder" />
+            <sbb-autocomplete origin="bold-input" trigger="bold-input">
+              <sbb-option value="Option 1">Option 1</sbb-option>
+              <sbb-option value="Option 2">Option 2</sbb-option>
+            </sbb-autocomplete>
+          </div>`,
+        );
+
+        setup.withPostSetupAction(() => openAutocomplete(setup));
+      }),
+    );
   });
 });

--- a/src/elements/date-input/date-input.scss
+++ b/src/elements/date-input/date-input.scss
@@ -10,6 +10,7 @@
   max-width: 100%;
   cursor: text;
   align-items: center;
+  font-weight: normal;
 
   @include sbb.if-forced-colors {
     color: FieldText;

--- a/src/elements/date-input/date-input.visual.spec.ts
+++ b/src/elements/date-input/date-input.visual.spec.ts
@@ -98,5 +98,16 @@ describe('sbb-date-input', () => {
         }),
       );
     });
+
+    it(
+      'inside bold context',
+      visualDiffDefault.with(async (setup) => {
+        await setup.withFixture(
+          html`<div style="font-weight: bold;">
+            <sbb-date-input value="2024-12-11"></sbb-date-input>
+          </div>`,
+        );
+      }),
+    );
   });
 });

--- a/src/elements/form-field/form-field/form-field.scss
+++ b/src/elements/form-field/form-field/form-field.scss
@@ -35,6 +35,7 @@
 
   display: inline-block;
   color: var(--sbb-form-field-color);
+  font-weight: normal;
 }
 
 :host(:where(:not([width='collapse']))) {

--- a/src/elements/form-field/form-field/form-field.visual.spec.ts
+++ b/src/elements/form-field/form-field/form-field.visual.spec.ts
@@ -559,5 +559,19 @@ describe(`sbb-form-field`, () => {
         );
       }),
     );
+
+    it(
+      'inside bold context',
+      visualDiffDefault.with(async (setup) => {
+        await setup.withFixture(
+          html`<div style="font-weight: bold;">
+            <sbb-form-field>
+              <label>Input name</label>
+              <input placeholder="Input placeholder" value="Input value" />
+            </sbb-form-field>
+          </div>`,
+        );
+      }),
+    );
   });
 });

--- a/src/elements/select/select.scss
+++ b/src/elements/select/select.scss
@@ -17,6 +17,7 @@
   );
 
   display: block;
+  font-weight: normal;
 }
 
 :host([size='s']) {

--- a/src/elements/select/select.visual.spec.ts
+++ b/src/elements/select/select.visual.spec.ts
@@ -337,6 +337,25 @@ describe('sbb-select', () => {
       }),
     );
 
+    it(
+      'inside bold context',
+      visualDiffDefault.with(async (setup) => {
+        await setup.withFixture(
+          html`<div style="font-weight: bold;">
+            <sbb-select placeholder="Select">
+              <sbb-option value="1">Option 1</sbb-option>
+              <sbb-option value="2">Option 2</sbb-option>
+            </sbb-select>
+          </div>`,
+        );
+        setup.withPostSetupAction(() => {
+          const element = setup.snapshotElement.querySelector('sbb-select')!;
+          element.focus();
+          element.open();
+        });
+      }),
+    );
+
     describeEach(
       {
         negative: [false, true],

--- a/src/elements/time-input/time-input.scss
+++ b/src/elements/time-input/time-input.scss
@@ -13,6 +13,7 @@
   max-width: var(--sbb-time-input-max-width);
   cursor: text;
   align-items: center;
+  font-weight: normal;
 
   @include sbb.if-forced-colors {
     color: FieldText;

--- a/src/elements/time-input/time-input.visual.spec.ts
+++ b/src/elements/time-input/time-input.visual.spec.ts
@@ -99,5 +99,16 @@ describe(`sbb-time-input`, () => {
         }),
       );
     }
+
+    it(
+      'inside bold context',
+      visualDiffDefault.with(async (setup) => {
+        await setup.withFixture(
+          html`<div style="font-weight: bold;">
+            <sbb-time-input value="12:00"></sbb-time-input>
+          </div>`,
+        );
+      }),
+    );
   });
 });


### PR DESCRIPTION
A couple of components are expected to be used inside a bold context. By setting font-weight: normal, we avoid displaying it in bold.
