### PR TITLE
fix(dialog): tests broken on Safari

### DIFF
--- a/src/elements/dialog/dialog/dialog.component.ts
+++ b/src/elements/dialog/dialog/dialog.component.ts
@@ -82,7 +82,7 @@ export class SbbDialogElement extends SbbOverlayBaseElement {
   /** Announce the accessibility label or dialog title for screen readers. */
   public announceTitle(): void {
     this.setAriaLiveRefContent(
-      this.accessibilityLabel || this.querySelector('sbb-dialog-title')?.innerText.trim(),
+      this.accessibilityLabel || this.querySelector('sbb-dialog-title')?.textContent.trim(),
     );
   }
 


### PR DESCRIPTION
On dialog opening, the internal `sbb-screenreader-only` content is set based on the content of the `sbb-dialog-title`
for some unknown reason, in WebKit only the `innerText` is an empty string, so it has been changed to `textContent`.