### PR TITLE
fix: missing theme in visual-regression-app

### DIFF
--- a/src/visual-regression-app/src/main.ts
+++ b/src/visual-regression-app/src/main.ts
@@ -3,7 +3,7 @@ import { html, LitElement, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 import '@sbb-esta/lyne-elements/core.js';
-import '@sbb-esta/lyne-elements/core/styles/core.scss';
+import '@sbb-esta/lyne-elements/core/styles/standard-theme.scss';
 
 // Lit Router uses URLPattern which is not defined so far in Firefox and Safari.
 // TODO: Remove as soon as possible

--- a/src/visual-regression-app/src/main.ts
+++ b/src/visual-regression-app/src/main.ts
@@ -3,7 +3,7 @@ import { html, LitElement, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 import '@sbb-esta/lyne-elements/core.js';
-import '@sbb-esta/lyne-elements/core/styles/standard-theme.scss';
+import '@sbb-esta/lyne-elements/core/styles/core.scss';
 
 // Lit Router uses URLPattern which is not defined so far in Firefox and Safari.
 // TODO: Remove as soon as possible

--- a/src/visual-regression-app/src/main.ts
+++ b/src/visual-regression-app/src/main.ts
@@ -3,6 +3,7 @@ import { html, LitElement, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 import '@sbb-esta/lyne-elements/core.js';
+import '@sbb-esta/lyne-elements/core/styles/core.scss';
 
 // Lit Router uses URLPattern which is not defined so far in Firefox and Safari.
 // TODO: Remove as soon as possible


### PR DESCRIPTION
Commit #4707 broke the visual-regression app.
Directly importing the core style seems to fix it (not sure it's the right approach)