### PR TITLE
feat(form-field): add optional type to custom control API

### DIFF
--- a/src/elements/autocomplete/__snapshots__/autocomplete.snapshot.spec.snap.js
+++ b/src/elements/autocomplete/__snapshots__/autocomplete.snapshot.spec.snap.js
@@ -121,6 +121,11 @@ snapshots["sbb-autocomplete renders in form field Safari Shadow DOM"] =
         <slot>
         </slot>
       </div>
+      <sbb-icon
+        class="sbb-form-field__select-input-icon"
+        name="chevron-small-down-small"
+      >
+      </sbb-icon>
     </div>
     <slot name="suffix">
     </slot>
@@ -243,6 +248,11 @@ snapshots["sbb-autocomplete renders in form field Chrome-Firefox Shadow DOM"] =
         <slot>
         </slot>
       </div>
+      <sbb-icon
+        class="sbb-form-field__select-input-icon"
+        name="chevron-small-down-small"
+      >
+      </sbb-icon>
     </div>
     <slot name="suffix">
     </slot>

--- a/src/elements/chip/chip-group/__snapshots__/chip-group.snapshot.spec.snap.js
+++ b/src/elements/chip/chip-group/__snapshots__/chip-group.snapshot.spec.snap.js
@@ -74,6 +74,11 @@ snapshots["sbb-chip-group renders with form-field Shadow DOM"] =
         <slot>
         </slot>
       </div>
+      <sbb-icon
+        class="sbb-form-field__select-input-icon"
+        name="chevron-small-down-small"
+      >
+      </sbb-icon>
     </div>
     <slot name="suffix">
     </slot>

--- a/src/elements/datepicker/datepicker/__snapshots__/datepicker.snapshot.spec.snap.js
+++ b/src/elements/datepicker/datepicker/__snapshots__/datepicker.snapshot.spec.snap.js
@@ -66,6 +66,11 @@ snapshots["sbb-datepicker renders Shadow DOM"] =
         <slot>
         </slot>
       </div>
+      <sbb-icon
+        class="sbb-form-field__select-input-icon"
+        name="chevron-small-down-small"
+      >
+      </sbb-icon>
     </div>
     <slot name="suffix">
     </slot>

--- a/src/elements/form-field/form-field/__snapshots__/form-field.snapshot.spec.snap.js
+++ b/src/elements/form-field/form-field/__snapshots__/form-field.snapshot.spec.snap.js
@@ -45,6 +45,11 @@ snapshots["sbb-form-field renders input Shadow DOM"] =
         <slot>
         </slot>
       </div>
+      <sbb-icon
+        class="sbb-form-field__select-input-icon"
+        name="chevron-small-down-small"
+      >
+      </sbb-icon>
     </div>
     <slot name="suffix">
     </slot>
@@ -105,6 +110,11 @@ snapshots["sbb-form-field renders disabled input Shadow DOM"] =
         <slot>
         </slot>
       </div>
+      <sbb-icon
+        class="sbb-form-field__select-input-icon"
+        name="chevron-small-down-small"
+      >
+      </sbb-icon>
     </div>
     <slot name="suffix">
     </slot>
@@ -173,6 +183,11 @@ snapshots["sbb-form-field renders readonly input with error Shadow DOM"] =
         <slot>
         </slot>
       </div>
+      <sbb-icon
+        class="sbb-form-field__select-input-icon"
+        name="chevron-small-down-small"
+      >
+      </sbb-icon>
     </div>
     <slot name="suffix">
     </slot>

--- a/src/elements/form-field/form-field/form-field.component.ts
+++ b/src/elements/form-field/form-field/form-field.component.ts
@@ -47,6 +47,11 @@ export interface SbbFormFieldElementControl {
   readonly readOnly?: boolean;
   /** Whether the control is disabled. */
   readonly disabled: boolean;
+  /**
+   * The type of the control. This is used as a state representation.
+   * When using 'select', the form field will display the dropdown icon.
+   */
+  readonly type?: 'select' | string;
 
   /**
    * Handles a click on the control's container.
@@ -191,6 +196,7 @@ export class SbbFormFieldElement extends SbbNegativeMixin(SbbElement) {
 
   private _inputFormAbortController = new AbortController();
   private _control: SbbFormFieldElementControl | null = null;
+  private _previousType: string | null = null;
 
   public constructor() {
     super();
@@ -376,6 +382,8 @@ export class SbbFormFieldElement extends SbbNegativeMixin(SbbElement) {
       attributes: true,
       attributeFilter: ['readonly', 'disabled', 'form', 'class', 'data-expanded', 'maxlength'],
     });
+    // TODO(breaking-change): Rename input-type to input-element and explicit-input-type to input-type.
+    // Also adapt documentation.
     this.internals.states.add(`input-type-${this._input.localName}`);
     this._syncLabelInputReferences();
     return 'changed';
@@ -422,6 +430,13 @@ export class SbbFormFieldElement extends SbbNegativeMixin(SbbElement) {
     this.toggleState('readonly', this._control?.readOnly ?? this._input!.hasAttribute('readonly'));
     this.toggleState('disabled', this._control?.disabled ?? this._input!.hasAttribute('disabled'));
     this.toggleState('has-popup-open', this._input!.hasAttribute('data-expanded'));
+
+    if (this._previousType) {
+      this.internals.states.delete(`explicit-input-type-${this._previousType}`);
+    }
+
+    this._previousType = this._control?.type ?? (this._input as { type?: string }).type ?? 'text';
+    this.internals.states.add(`explicit-input-type-${this._previousType}`);
   }
 
   private _registerInputFormListener(): void {
@@ -628,12 +643,10 @@ export class SbbFormFieldElement extends SbbNegativeMixin(SbbElement) {
             <div class="sbb-form-field__input">
               <slot @slotchange=${this._onSlotInputChange}></slot>
             </div>
-            ${this.hasUpdated && ['select', 'sbb-select'].includes(this._input?.localName as string)
-              ? html`<sbb-icon
-                  name="chevron-small-down-small"
-                  class="sbb-form-field__select-input-icon"
-                ></sbb-icon>`
-              : nothing}
+            <sbb-icon
+              name="chevron-small-down-small"
+              class="sbb-form-field__select-input-icon"
+            ></sbb-icon>
           </div>
           <slot name="suffix" @slotchange=${this._syncNegative}></slot>
         </div>

--- a/src/elements/form-field/form-field/form-field.scss
+++ b/src/elements/form-field/form-field/form-field.scss
@@ -299,11 +299,23 @@ slot[name='hint'] {
 .sbb-form-field__select-input-icon {
   @include sbb.absolute-center-y;
 
+  display: none;
   position: absolute;
   inset-inline-end: 0;
   margin-block-start: calc(-1 * var(--sbb-form-field-margin-block-start) / 2);
   pointer-events: none;
   color: var(--sbb-form-field-arrow-color);
+
+  :host(
+      :is(
+        :state(input-type-select),
+        :state(input-type-sbb-select),
+        :state(explicit-input-type-select)
+      )
+    )
+    & {
+    display: inline-block;
+  }
 }
 
 .sbb-form-field__input-container {

--- a/src/elements/form-field/form-field/form-field.spec.ts
+++ b/src/elements/form-field/form-field/form-field.spec.ts
@@ -596,6 +596,22 @@ describe(`sbb-form-field`, () => {
       expect(containerClickSpy).to.have.been.calledOnce;
       expect(input).to.have.focus;
     });
+
+    it('should update type state from control', async () => {
+      expect(element).not.to.match(':state(explicit-input-type-select)');
+      control.type = 'select';
+      element.dispatchEvent(new SbbFormFieldControlEvent(control));
+      expect(element).to.match(':state(input-type-sbb-custom-control)');
+      expect(element).to.match(':state(explicit-input-type-select)');
+    });
+
+    it('should update type state from input element', async () => {
+      expect(element).not.to.match(':state(explicit-input-type-select)');
+      (input as { type?: string }).type = 'select';
+      element.dispatchEvent(new SbbFormFieldControlEvent(control));
+      expect(element).to.match(':state(input-type-sbb-custom-control)');
+      expect(element).to.match(':state(explicit-input-type-select)');
+    });
   });
 
   describe('with icon and tooltip', () => {

--- a/src/elements/timetable-form/timetable-form-field/__snapshots__/timetable-form-field.snapshot.spec.snap.js
+++ b/src/elements/timetable-form/timetable-form-field/__snapshots__/timetable-form-field.snapshot.spec.snap.js
@@ -53,6 +53,11 @@ snapshots["sbb-timetable-form-field renders Shadow DOM"] =
         <slot>
         </slot>
       </div>
+      <sbb-icon
+        class="sbb-form-field__select-input-icon"
+        name="chevron-small-down-small"
+      >
+      </sbb-icon>
     </div>
     <slot name="suffix">
     </slot>

--- a/tools/web-test-runner/node-hook.ts
+++ b/tools/web-test-runner/node-hook.ts
@@ -23,8 +23,8 @@ const rootHref = new URL('../../', import.meta.url).href;
 const tsconfigFile = join(projectRoot, 'tsconfig.json');
 const cachePath = join(projectRoot, 'node_modules', '.cache', 'node-hook-typescript-transform');
 mkdirSync(cachePath, { recursive: true });
-// Remove stale caches (older than a month)
-const staleDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+// Remove stale caches (older than a week)
+const staleDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
 readdirSync(cachePath, { withFileTypes: true })
   .filter((d) => d.isFile() && statSync(join(cachePath, d.name)).mtime < staleDate)
   .forEach((d) => rmSync(join(cachePath, d.name)));
@@ -105,7 +105,7 @@ registerHooks({
       const file = fileURLToPath(url);
       const code = readFileSync(file, 'utf8');
 
-      const key = jsonifiedOptions + file;
+      const key = jsonifiedOptions + code;
       const hash = createHash('sha256').update(key).digest('hex');
       const cacheFilePath = join(cachePath, hash);
       if (existsSync(cacheFilePath)) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,8 +47,8 @@ function typescriptTransform(): PluginOption {
   const name = 'vite-plugin-typescript-transform';
   const cachePath = join(projectRoot, 'node_modules', '.cache', name);
   mkdirSync(cachePath, { recursive: true });
-  // Remove stale caches (older than a month)
-  const staleDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  // Remove stale caches (older than a week)
+  const staleDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
   readdirSync(cachePath, { withFileTypes: true })
     .filter((d) => d.isFile() && statSync(join(cachePath, d.name)).mtime < staleDate)
     .forEach((d) => rmSync(join(cachePath, d.name)));
@@ -84,7 +84,7 @@ function typescriptTransform(): PluginOption {
         return;
       }
 
-      const key = jsonifiedOptions + file;
+      const key = jsonifiedOptions + code;
       const hash = createHash('sha256').update(key).digest('hex');
       const cacheFilePath = join(cachePath, hash);
       if (existsSync(cacheFilePath)) {


### PR DESCRIPTION
This PR adds the optional `type?: 'select' | string` property to the `SbbFormFieldElementControl` interface.
This enables setting `type` to `select`, which will display the drop down icon in the form field.

Closes #4773