### PR TITLE
refactor(tabs): replace throttle with debounce mechanism

### DIFF
--- a/src/elements/core/eventing/throttle.ts
+++ b/src/elements/core/eventing/throttle.ts
@@ -1,3 +1,4 @@
+/** @deprecated */
 export const throttle = <F extends (...args: any[]) => any>(
   func: F,
   delay: number,

--- a/src/elements/tabs/tab-group/tab-group.component.ts
+++ b/src/elements/tabs/tab-group/tab-group.component.ts
@@ -16,7 +16,6 @@ import {
   ɵstateController,
   forceType,
   isLean,
-  throttle,
   boxSizingStyles,
 } from '../../core.ts';
 import { tabGroupCommonStyles } from '../common/styles.ts';
@@ -57,6 +56,7 @@ export class SbbTabGroupElement extends SbbElement {
     skipInitial: true,
     callback: () => this._onTabGroupElementResize(),
   });
+  private _contentSlotChangeDebounceId?: ReturnType<typeof setTimeout>;
 
   /**
    * Size variant, either s, l or xl.
@@ -155,15 +155,20 @@ export class SbbTabGroupElement extends SbbElement {
     });
   }
 
-  private _onContentSlotChange = (): void => {
-    this.labels.forEach((tabLabel) => tabLabel['linkToTab']());
-    this.labels.find((tabLabel) => tabLabel.active)?.activate();
-  };
+  private _onContentSlotChange(): void {
+    if (this._contentSlotChangeDebounceId) {
+      clearTimeout(this._contentSlotChangeDebounceId);
+    }
+    this._contentSlotChangeDebounceId = setTimeout(() => {
+      this.labels.forEach((tabLabel) => tabLabel['linkToTab']());
+      this.labels.find((tabLabel) => tabLabel.active)?.activate();
+    }, 150);
+  }
 
-  private _onLabelSlotChange = (): void => {
+  private _onLabelSlotChange(): void {
     this.labels.forEach((tabLabel) => tabLabel['linkToTab']());
     this._ensureActiveTab();
-  };
+  }
 
   private _ensureActiveTab(): void {
     if (
@@ -241,10 +246,10 @@ export class SbbTabGroupElement extends SbbElement {
       ${!this.fixedHeight
         ? html`
             <div class="sbb-tab-group-content">
-              <slot @slotchange=${throttle(this._onContentSlotChange, 150)}></slot>
+              <slot @slotchange=${this._onContentSlotChange}></slot>
             </div>
           `
-        : html`<slot @slotchange=${throttle(this._onContentSlotChange, 150)}></slot>`}
+        : html`<slot @slotchange=${this._onContentSlotChange}></slot>`}
     `;
   }
 }


### PR DESCRIPTION
The current throttle implementation might fail if called again within the throttle timer. Due to this, we replace throttle with a local debounce mechanism and deprecate the throttle function.