### PR TITLE
fix(form-field): layout for Angular custom components in size=s

### DIFF
--- a/src/elements/form-field/form-field/form-field.global.scss
+++ b/src/elements/form-field/form-field/form-field.global.scss
@@ -100,6 +100,13 @@ $theme: 'standard' !default;
       @include sbb.ellipsis;
       @include sbb.input-reset;
 
+      // Form elements are naturally in 'display: inline-block'; however, since the form-element container
+      // is in 'display: flex' (class "sbb-form-field__input"), they are block-ified, as per documentation:
+      // https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Flexible_box_layout/Basic_concepts#the_flex_container
+      // Setting 'display: block' should not change anything on lyne-elements, but is useful for consumers of lyne-angular,
+      // since the rule is valid for Angular custom components which have an inner form element.
+      display: block;
+
       // Use !important here to not interfere with Firefox focus ring definition
       // which appears in normalize CSS of several frameworks.
       outline: none !important;
@@ -164,6 +171,12 @@ $theme: 'standard' !default;
       margin-block: calc(
         0.5 * (var(--sbb-form-field-input-text-size) * (var(--sbb-typo-line-height-text) - 1.25))
       );
+    }
+
+    // This rule matches the analogous one in the form-field.scss,
+    // and it's useful for Angular custom components, assuming that they have an internal form element.
+    &[size='s'] > :has(input, sbb-date-input, sbb-time-input, select, sbb-select) {
+      margin-block-end: #{sbb.px-to-rem-build(-2)};
     }
 
     :where(textarea) {

--- a/src/elements/form-field/form-field/form-field.global.scss
+++ b/src/elements/form-field/form-field/form-field.global.scss
@@ -103,9 +103,9 @@ $theme: 'standard' !default;
       // Form elements are naturally in 'display: inline-block'; however, since the form-element container
       // is in 'display: flex' (class "sbb-form-field__input"), they are block-ified, as per documentation:
       // https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Flexible_box_layout/Basic_concepts#the_flex_container
-      // Setting 'display: block' should not change anything on lyne-elements, but is useful for consumers of lyne-angular,
+      // Setting 'display: flex' should not change anything on lyne-elements, but is useful for consumers of lyne-angular,
       // since the rule is valid for Angular custom components which have an inner form element.
-      display: block;
+      display: flex;
 
       // Use !important here to not interfere with Firefox focus ring definition
       // which appears in normalize CSS of several frameworks.
@@ -175,7 +175,8 @@ $theme: 'standard' !default;
 
     // This rule matches the analogous one in the form-field.scss,
     // and it's useful for Angular custom components, assuming that they have an internal form element.
-    &[size='s'] > :has(input, sbb-date-input, sbb-time-input, select, sbb-select) {
+    &[size='s']
+      > :not(sbb-chip-group):has(input, sbb-date-input, sbb-time-input, select, sbb-select) {
       margin-block-end: #{sbb.px-to-rem-build(-2)};
     }
 

--- a/src/elements/form-field/form-field/form-field.visual.spec.ts
+++ b/src/elements/form-field/form-field/form-field.visual.spec.ts
@@ -15,7 +15,7 @@ import '../../button.ts';
 
 import '../../popover.ts';
 
-@customElement('custom-control-element-input')
+@customElement('custom-input-element')
 class SbbCustomControlElementInput extends SbbElement {
   protected override render(): TemplateResult {
     return html`
@@ -23,12 +23,6 @@ class SbbCustomControlElementInput extends SbbElement {
         <slot></slot>
       </div>
     `;
-  }
-}
-@customElement('custom-control-element-select')
-class SbbCustomControlElementSelect extends SbbElement {
-  protected override render(): TemplateResult {
-    return html` <slot></slot> `;
   }
 }
 
@@ -602,19 +596,18 @@ describe(`sbb-form-field`, () => {
             <div>
               <sbb-form-field size="s">
                 <label>Custom input</label>
-                <custom-control-element-input>
-                  <input placeholder="custom" />
-                </custom-control-element-input>
+                <custom-input-element>
+                  <input placeholder="input" />
+                </custom-input-element>
               </sbb-form-field>
               <sbb-form-field size="s">
                 <label>Native input</label>
-                <input placeholder="custom" />
+                <input placeholder="input" />
               </sbb-form-field>
             </div>
             <div>
               <sbb-form-field size="s">
                 <label>Custom select</label>
-                <custom-control-element-select>
                   <select>
                     <option value="bern">Bern</option>
                     <option value="zurich">Zürich</option>
@@ -622,7 +615,6 @@ describe(`sbb-form-field`, () => {
                     <option value="geneva">Geneva</option>
                     <option value="lausanne">Lausanne</option>
                   </select>
-                </custom-control-element-select>
               </sbb-form-field>
               <sbb-form-field size="s">
                 <label>Native select</label>
@@ -660,8 +652,6 @@ describe(`sbb-form-field`, () => {
 declare global {
   interface HTMLElementTagNameMap {
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    'custom-control-element-input': SbbCustomControlElementInput;
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    'custom-control-element-select': SbbCustomControlElementSelect;
+    'custom-input-element': SbbCustomControlElementInput;
   }
 }

--- a/src/elements/form-field/form-field/form-field.visual.spec.ts
+++ b/src/elements/form-field/form-field/form-field.visual.spec.ts
@@ -1,4 +1,5 @@
 import { html, nothing, type TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
 
 import {
   describeEach,
@@ -7,12 +8,29 @@ import {
   visualDiffDefault,
   visualDiffFocus,
 } from '../../core/testing/private.ts';
-import { isChromium } from '../../core.ts';
+import { isChromium, SbbElement } from '../../core.ts';
 
 import '../../form-field.ts';
 import '../../button.ts';
 
 import '../../popover.ts';
+
+@customElement('custom-control-element-input')
+class SbbCustomControlElementInput extends SbbElement {
+  protected override render(): TemplateResult {
+    return html`
+      <div>
+        <slot></slot>
+      </div>
+    `;
+  }
+}
+@customElement('custom-control-element-select')
+class SbbCustomControlElementSelect extends SbbElement {
+  protected override render(): TemplateResult {
+    return html` <slot></slot> `;
+  }
+}
 
 describe(`sbb-form-field`, () => {
   const formField = (
@@ -574,4 +592,76 @@ describe(`sbb-form-field`, () => {
       }),
     );
   });
+
+  describeViewports({ viewports: ['large'] }, () => {
+    it(
+      'with custom controls',
+      visualDiffDefault.with(async (setup) => {
+        await setup.withFixture(html`
+          <div style="display: flex; flex-direction: column; gap: 1rem;">
+            <div>
+              <sbb-form-field size="s">
+                <label>Custom input</label>
+                <custom-control-element-input>
+                  <input placeholder="custom" />
+                </custom-control-element-input>
+              </sbb-form-field>
+              <sbb-form-field size="s">
+                <label>Native input</label>
+                <input placeholder="custom" />
+              </sbb-form-field>
+            </div>
+            <div>
+              <sbb-form-field size="s">
+                <label>Custom select</label>
+                <custom-control-element-select>
+                  <select>
+                    <option value="bern">Bern</option>
+                    <option value="zurich">Zürich</option>
+                    <option value="basel">Basel</option>
+                    <option value="geneva">Geneva</option>
+                    <option value="lausanne">Lausanne</option>
+                  </select>
+                </custom-control-element-select>
+              </sbb-form-field>
+              <sbb-form-field size="s">
+                <label>Native select</label>
+                <select>
+                  <option value="bern">Bern</option>
+                  <option value="zurich">Zürich</option>
+                  <option value="basel">Basel</option>
+                  <option value="geneva">Geneva</option>
+                  <option value="lausanne">Lausanne</option>
+                </select>
+              </sbb-form-field>
+            </div>
+            <div>
+              <sbb-form-field size="s">
+                <label>Custom textarea</label>
+                  <div>
+                    <div>
+                      <textarea rows="3"></textarea>
+                    </div>
+                  </div>
+              </sbb-form-field>
+              <sbb-form-field size="s">
+                <label>Native textarea</label>
+                <textarea rows="3"></textarea>
+              </sbb-form-field>
+            </div>
+            </div>
+          </div>
+        `);
+      }),
+    );
+  });
 });
+
+declare global {
+  interface HTMLElementTagNameMap {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    'custom-control-element-input': SbbCustomControlElementInput;
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    'custom-control-element-select': SbbCustomControlElementSelect;
+  }
+}


### PR DESCRIPTION
In the sbb-form-field, the input's containers in the shadowDom are all in display flex, so even if the slotted form (input, select,..) is naturally is inline-block, it become block, as specified in https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Flexible_box_layout/Basic_concepts#the_flex_container
So, setting display: block would suffice to solve the height issue; however, the date-input and the time-input are in display flex, so block has been changed to flex (**NOTE TO REVIEWER**: split the behavior?). 
This fixes the issue because in an angular custom component as in the provided example, the rule is applied to any slotted input, tested with, e.g.
```
@Component({
  selector: 'sbb-custom-control-textarea',
  template: `
    <div>
      <div>
        <textarea id="textarea" rows="3"></textarea>
      </div>
    </div>`,
    ...
})
export class CustomControlComponentTextarea { }
```

The same idea applies with the negative margin, which adapts a similar rule present in the form-field.scss (the shown rule is applied on the input container)
```
.sbb-form-field__input {
  ...
  :host(
      [size='s']:is(
        :state(input-type-input),
        :state(input-type-select),
        :state(input-type-sbb-select),
        :state(input-type-sbb-date-input),
        :state(input-type-sbb-time-input)
      )
    )
    & {
    // In size s, the natural height of the text input is too small.
    // To not reserve too much space, we decrease the height.
    margin-block-end: #{sbb.px-to-rem-build(-2)};
  }
}
```