### PR TITLE
refactor: improve support for scrollbar styles in shadow DOM

### DIFF
--- a/src/elements/core/styles/host-scrollbar.scss
+++ b/src/elements/core/styles/host-scrollbar.scss
@@ -1,0 +1,6 @@
+@use './mixins/scrollbar';
+
+:host {
+  @include scrollbar.scrollbar-variables;
+  @include scrollbar.scrollbar-rules;
+}

--- a/src/elements/core/styles/mixins/scrollbar.scss
+++ b/src/elements/core/styles/mixins/scrollbar.scss
@@ -1,8 +1,6 @@
 @use '../core/functions';
 
 @mixin scrollbar-rules {
-  --sbb-scrollbar-width: var(--sbb-spacing-fixed-3x);
-
   &::-webkit-scrollbar {
     // Total width
     width: var(--sbb-scrollbar-width);
@@ -40,12 +38,9 @@
   //  We have to use the `not` selector as Chrome supports both, the -webkit-* and the following properties.
   //  As long as possible we use the -webkit-* approach as we have more styling possibilities there.
   @supports not selector(::-webkit-scrollbar) {
-    // stylelint-disable-next-line block-no-redundant-nested-style-rules
-    & {
-      scrollbar-width: var(--sbb-scrollbar-width-firefox);
-      scrollbar-color: var(--sbb-scrollbar-color, currentcolor)
-        var(--sbb-scrollbar-track-color, transparent);
-    }
+    scrollbar-width: var(--sbb-scrollbar-width-firefox);
+    scrollbar-color: var(--sbb-scrollbar-color, currentcolor)
+      var(--sbb-scrollbar-track-color, transparent);
   }
 }
 
@@ -90,6 +85,8 @@
 }
 
 @mixin scrollbar-variables($size: thin, $negative: false, $track-visible: false) {
+  --sbb-scrollbar-width: var(--sbb-spacing-fixed-3x);
+
   @if $size == thin {
     @include scrollbar-variables--size-thin;
   } @else {

--- a/src/elements/core/styles/scrollbar.scss
+++ b/src/elements/core/styles/scrollbar.scss
@@ -1,13 +1,15 @@
 @use './mixins/scrollbar';
 
-.sbb-scrollbar,
-.sbb-scrollbar-negative,
-.sbb-scrollbar-thick,
-.sbb-scrollbar-thick-negative,
-.sbb-scrollbar-track-visible,
-.sbb-scrollbar-negative-track-visible,
-.sbb-scrollbar-thick-track-visible,
-.sbb-scrollbar-thick-negative-track-visible {
+:is(
+  .sbb-scrollbar,
+  .sbb-scrollbar-negative,
+  .sbb-scrollbar-thick,
+  .sbb-scrollbar-thick-negative,
+  .sbb-scrollbar-track-visible,
+  .sbb-scrollbar-negative-track-visible,
+  .sbb-scrollbar-thick-track-visible,
+  .sbb-scrollbar-thick-negative-track-visible
+) {
   @include scrollbar.scrollbar-rules;
 }
 

--- a/src/elements/core/styles/styles.ts
+++ b/src/elements/core/styles/styles.ts
@@ -1,5 +1,7 @@
 import { unsafeCSS } from 'lit';
 
 import boxSizingStylesString from './box-sizing.scss?inline';
+import hostScrollbarString from './host-scrollbar.scss?inline';
 
 export const boxSizingStyles = unsafeCSS(boxSizingStylesString);
+export const hostScrollbarStyles = unsafeCSS(hostScrollbarString);

--- a/src/elements/dialog/dialog-content/dialog-content.component.ts
+++ b/src/elements/dialog/dialog-content/dialog-content.component.ts
@@ -1,6 +1,7 @@
 import { type CSSResultGroup, html, type TemplateResult, unsafeCSS } from 'lit';
 
-import { SbbElement } from '../../core.ts';
+import { hostScrollbarStyles, SbbElement, SbbPropertyWatcherController } from '../../core.ts';
+import type { SbbDialogElement } from '../dialog/dialog.component.ts';
 
 import style from './dialog-content.scss?inline';
 
@@ -11,13 +12,23 @@ import style from './dialog-content.scss?inline';
  */
 export class SbbDialogContentElement extends SbbElement {
   public static override readonly elementName: string = 'sbb-dialog-content';
-  public static override styles: CSSResultGroup = unsafeCSS(style);
+  public static override styles: CSSResultGroup = [hostScrollbarStyles, unsafeCSS(style)];
+
+  public constructor() {
+    super();
+    this.addController(
+      new SbbPropertyWatcherController(this, () => this.closest<SbbDialogElement>('sbb-dialog'), {
+        negative: (d) => this.toggleState('negative', d.negative),
+      }),
+    );
+  }
 
   public override connectedCallback(): void {
     super.connectedCallback();
 
-    // As we can't include the scrollbar mixin on the host and to minimize
-    // payload, we decided to add the scrollbar class here.
+    // When including the scrollbar styles on the host, there is no hover effect of the scrollbar possible.
+    // In most cases, the component will be used in Light DOM. To also support the hover effect,
+    // we additionally add the `sbb-scrollbar` CSS class to the host.
     // This is an exception as we normally don't alter the classList of the host.
     this.classList.add('sbb-scrollbar');
   }

--- a/src/elements/dialog/dialog-content/dialog-content.global.scss
+++ b/src/elements/dialog/dialog-content/dialog-content.global.scss
@@ -4,13 +4,14 @@ $theme: 'standard' !default;
 
 @mixin rules {
   sbb-dialog-content {
-    // If there is a title, remove top spacing for the content
+    // If there is a title, reduce the top spacing for the content
     sbb-dialog:has(> sbb-dialog-title) > &,
     sbb-dialog:state(has-intermediate-element):has(> * > sbb-dialog-title) > * > & {
       padding-block-start: var(--sbb-spacing-fixed-1x);
     }
 
     // Set the negative scrollbar colors for dialog content when dialog is negative
+    // This is additionally ended in Light DOM to be more specific in overriding the variables.
     sbb-dialog[negative] > &,
     sbb-dialog[negative]:state(has-intermediate-element) > * > & {
       @include sbb.scrollbar-variables--color-negative;

--- a/src/elements/dialog/dialog-content/dialog-content.global.scss
+++ b/src/elements/dialog/dialog-content/dialog-content.global.scss
@@ -11,7 +11,7 @@ $theme: 'standard' !default;
     }
 
     // Set the negative scrollbar colors for dialog content when dialog is negative
-    // This is additionally ended in Light DOM to be more specific in overriding the variables.
+    // This is additionally added to the Light DOM to be more specific in overriding the variables.
     sbb-dialog[negative] > &,
     sbb-dialog[negative]:state(has-intermediate-element) > * > & {
       @include sbb.scrollbar-variables--color-negative;

--- a/src/elements/dialog/dialog-content/dialog-content.scss
+++ b/src/elements/dialog/dialog-content/dialog-content.scss
@@ -8,6 +8,10 @@
   overflow: auto;
 }
 
+:host(:state(negative)) {
+  @include sbb.scrollbar-variables--color-negative;
+}
+
 // If there is no scrollable content, the scroll area gets focus.
 // As it is impossible to place the scrollbar outside of the scroll area,
 // we need to fix the outline offset to avoid clipping of the focus outline.

--- a/src/elements/icon-sidebar/icon-sidebar-content/icon-sidebar-content.component.ts
+++ b/src/elements/icon-sidebar/icon-sidebar-content/icon-sidebar-content.component.ts
@@ -1,6 +1,6 @@
 import { type CSSResultGroup, html, type TemplateResult, unsafeCSS } from 'lit';
 
-import { SbbElement } from '../../core.ts';
+import { hostScrollbarStyles, SbbElement } from '../../core.ts';
 import { sidebarContentCommonStyle } from '../../sidebar/common/styles.ts';
 
 import style from './icon-sidebar-content.scss?inline';
@@ -12,13 +12,18 @@ import style from './icon-sidebar-content.scss?inline';
  */
 export class SbbIconSidebarContentElement extends SbbElement {
   public static override readonly elementName: string = 'sbb-icon-sidebar-content';
-  public static override styles: CSSResultGroup = [sidebarContentCommonStyle, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [
+    hostScrollbarStyles,
+    sidebarContentCommonStyle,
+    unsafeCSS(style),
+  ];
 
   public override connectedCallback(): void {
     super.connectedCallback();
 
-    // As we can't include the scrollbar mixin on the host and to minimize
-    // payload, we decided to add the scrollbar class here.
+    // When including the scrollbar styles on the host, there is no hover effect of the scrollbar possible.
+    // In most cases, the component will be used in Light DOM. To also support the hover effect,
+    // we additionally add the `sbb-scrollbar` CSS class to the host.
     // This is an exception as we normally don't alter the classList of the host.
     this.classList.add('sbb-scrollbar');
   }

--- a/src/elements/icon-sidebar/icon-sidebar/icon-sidebar.component.ts
+++ b/src/elements/icon-sidebar/icon-sidebar/icon-sidebar.component.ts
@@ -1,7 +1,7 @@
 import { type CSSResultGroup, html, type TemplateResult, unsafeCSS } from 'lit';
 import { property } from 'lit/decorators.js';
 
-import { SbbElement } from '../../core.ts';
+import { hostScrollbarStyles, SbbElement } from '../../core.ts';
 import type { SbbIconSidebarContainerElement } from '../icon-sidebar-container/icon-sidebar-container.component.ts';
 
 import style from './icon-sidebar.scss?inline';
@@ -14,7 +14,7 @@ import style from './icon-sidebar.scss?inline';
 export class SbbIconSidebarElement extends SbbElement {
   public static override readonly elementName: string = 'sbb-icon-sidebar';
   public static override readonly role = 'navigation';
-  public static override styles: CSSResultGroup = unsafeCSS(style);
+  public static override styles: CSSResultGroup = [hostScrollbarStyles, unsafeCSS(style)];
 
   /** Background color of the icon sidebar. Either `white` or `milk`. **/
   @property({ reflect: true })
@@ -28,8 +28,9 @@ export class SbbIconSidebarElement extends SbbElement {
   public override connectedCallback(): void {
     super.connectedCallback();
 
-    // As we can't include the scrollbar mixin on the host and to minimize
-    // payload, we decided to add the scrollbar class here.
+    // When including the scrollbar styles on the host, there is no hover effect of the scrollbar possible.
+    // In most cases, the component will be used in Light DOM. To also support the hover effect,
+    // we additionally add the `sbb-scrollbar` CSS class to the host.
     // This is an exception as we normally don't alter the classList of the host.
     this.classList.add('sbb-scrollbar');
   }

--- a/src/elements/sidebar/readme.md
+++ b/src/elements/sidebar/readme.md
@@ -349,9 +349,9 @@ property when the navigation changes.
 
 #### Slots
 
-| Name | Description                                                                                      |
-| ---- | ------------------------------------------------------------------------------------------------ |
-|      | Use the unnamed slot to add any content elements. Further `sbb-sidebar-container`s are possible. |
+| Name | Description                                                                                                |
+| ---- | ---------------------------------------------------------------------------------------------------------- |
+|      | Use the unnamed slot to add any content elements. Further `<sbb-sidebar-container>` elements are possible. |
 
 ### class: `SbbSidebarElement`, `sbb-sidebar`
 

--- a/src/elements/sidebar/sidebar-content/sidebar-content.component.ts
+++ b/src/elements/sidebar/sidebar-content/sidebar-content.component.ts
@@ -1,6 +1,6 @@
 import { type CSSResultGroup, html, type TemplateResult, unsafeCSS } from 'lit';
 
-import { SbbElement } from '../../core.ts';
+import { hostScrollbarStyles, SbbElement } from '../../core.ts';
 import { sidebarContentCommonStyle } from '../common/styles.ts';
 
 import style from './sidebar-content.scss?inline';
@@ -8,18 +8,22 @@ import style from './sidebar-content.scss?inline';
 /**
  * Container for the sidebar content. Intended to be placed inside an `sbb-sidebar-container` element.
  *
- * @slot - Use the unnamed slot to add any content elements.
- * Further `sbb-sidebar-container`s are possible.
+ * @slot - Use the unnamed slot to add any content elements. Further `<sbb-sidebar-container>` elements are possible.
  */
 export class SbbSidebarContentElement extends SbbElement {
   public static override readonly elementName: string = 'sbb-sidebar-content';
-  public static override styles: CSSResultGroup = [sidebarContentCommonStyle, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [
+    hostScrollbarStyles,
+    sidebarContentCommonStyle,
+    unsafeCSS(style),
+  ];
 
   public override connectedCallback(): void {
     super.connectedCallback();
 
-    // As we can't include the scrollbar mixin on the host and to minimize
-    // payload, we decided to add the scrollbar class here.
+    // When including the scrollbar styles on the host, there is no hover effect of the scrollbar possible.
+    // In most cases, the component will be used in Light DOM. To also support the hover effect,
+    // we additionally add the `sbb-scrollbar` CSS class to the host.
     // This is an exception as we normally don't alter the classList of the host.
     this.classList.add('sbb-scrollbar');
   }

--- a/src/elements/table/table-wrapper/table-wrapper.component.ts
+++ b/src/elements/table/table-wrapper/table-wrapper.component.ts
@@ -9,7 +9,7 @@ import {
 } from 'lit';
 import { property } from 'lit/decorators.js';
 
-import { forceType, SbbElement, SbbNegativeMixin } from '../../core.ts';
+import { forceType, hostScrollbarStyles, SbbElement, SbbNegativeMixin } from '../../core.ts';
 
 import style from './table-wrapper.scss?inline';
 
@@ -21,7 +21,7 @@ import style from './table-wrapper.scss?inline';
 export class SbbTableWrapperElement extends SbbNegativeMixin(SbbElement) {
   public static override readonly elementName: string = 'sbb-table-wrapper';
   public static override readonly role = 'section';
-  public static override styles: CSSResultGroup = unsafeCSS(style);
+  public static override styles: CSSResultGroup = [hostScrollbarStyles, unsafeCSS(style)];
 
   /** Whether the table wrapper is focusable. */
   @forceType()
@@ -45,8 +45,9 @@ export class SbbTableWrapperElement extends SbbNegativeMixin(SbbElement) {
   public override connectedCallback(): void {
     super.connectedCallback();
 
-    // As we can't include the scrollbar mixin on the host and to minimize
-    // payload, we decided to add the scrollbar class here.
+    // When including the scrollbar styles on the host, there is no hover effect of the scrollbar possible.
+    // In most cases, the component will be used in Light DOM. To also support the hover effect,
+    // we additionally add the scrollbar CSS classes to the host.
     // This is an exception as we normally don't alter the classList of the host.
     this._updateScrollbarClass();
   }

--- a/src/elements/table/table-wrapper/table-wrapper.scss
+++ b/src/elements/table/table-wrapper/table-wrapper.scss
@@ -3,6 +3,8 @@
 :host {
   display: block;
   overflow: auto;
+
+  @include sbb.scrollbar-variables($size: thick, $negative: false, $track-visible: true);
 }
 
 :host(:focus-visible) {
@@ -11,4 +13,8 @@
 
 ::slotted(.sbb-table) {
   width: 100%;
+}
+
+:host([negative]) {
+  @include sbb.scrollbar-variables($size: thick, $negative: true, $track-visible: true);
 }

--- a/src/elements/tabs/tab/tab.component.ts
+++ b/src/elements/tabs/tab/tab.component.ts
@@ -1,7 +1,7 @@
 import { ResizeController } from '@lit-labs/observers/resize-controller.js';
 import { type CSSResultGroup, html, type TemplateResult, unsafeCSS } from 'lit';
 
-import { SbbElement } from '../../core.ts';
+import { hostScrollbarStyles, SbbElement } from '../../core.ts';
 import type { SbbTabGroupElement } from '../tab-group/tab-group.component.ts';
 import type { SbbTabLabelElement } from '../tab-label/tab-label.component.ts';
 
@@ -16,7 +16,7 @@ import style from './tab.scss?inline';
 export class SbbTabElement extends SbbElement {
   public static override readonly elementName: string = 'sbb-tab';
   public static override role = 'tabpanel';
-  public static override styles: CSSResultGroup = unsafeCSS(style);
+  public static override styles: CSSResultGroup = [hostScrollbarStyles, unsafeCSS(style)];
   public static readonly events = {
     active: 'active',
   } as const;
@@ -43,8 +43,9 @@ export class SbbTabElement extends SbbElement {
     super.connectedCallback();
     this.tabIndex = 0;
 
-    // As we can't include the scrollbar mixin on the host and to minimize
-    // payload, we decided to add the scrollbar class here.
+    // When including the scrollbar styles on the host, there is no hover effect of the scrollbar possible.
+    // In most cases, the component will be used in Light DOM. To also support the hover effect,
+    // we additionally add the `sbb-scrollbar` CSS class to the host.
     // This is an exception as we normally don't alter the classList of the host.
     this.classList.add('sbb-scrollbar');
   }


### PR DESCRIPTION
Currently, when using some of the components where the `sbb-scrollbar` CSS class is added to the host, the scrollbar styles do not work at all when using such a component inside a shadow DOM. With this PR, the scrollbar styles are also added to the host. However, unfortunately, the hover effect of the scrollbar thumb is not working when applying the scrollbar styles on the host. Due to this fact we keep both solutions: styles on shadow DOM but also additionally the CSS class on the host. With this solutions we only miss the hover effect if a consumer uses a component in the shadow DOM.