### PR TITLE
fix(select): force update value

### DIFF
--- a/src/elements/option/option/option-base-element.ts
+++ b/src/elements/option/option/option-base-element.ts
@@ -60,6 +60,9 @@ export abstract class SbbOptionBaseElement<T = string> extends SbbDisabledMixin(
     } else {
       this._value = value;
     }
+    // Notify the sbb-select to re-check its value against the option's one.
+    /** @internal */
+    this.dispatchEvent(new Event('ɵoptionvaluechange'));
   }
   public get value(): T {
     return (this._value ?? this.getAttribute('value')) as T;

--- a/src/elements/select/select.component.ts
+++ b/src/elements/select/select.component.ts
@@ -221,6 +221,20 @@ export class SbbSelectElement<T = string> extends SbbUpdateSchedulerMixin(
       }),
     );
 
+    // If any option value changes, recheck it against the select's value.
+    this.addController(
+      new MutationController(this, {
+        config: { attributeFilter: ['value'], subtree: true },
+        callback: (record) => {
+          record.forEach((e) => {
+            if ((e.target as HTMLElement).localName === 'sbb-option') {
+              this._updateValueOptionState();
+            }
+          });
+        },
+      }),
+    );
+
     this.addController(
       new SbbPropertyWatcherController(this, () => this.closest('sbb-form-field'), {
         negative: (e) => {

--- a/src/elements/select/select.component.ts
+++ b/src/elements/select/select.component.ts
@@ -194,6 +194,10 @@ export class SbbSelectElement<T = string> extends SbbUpdateSchedulerMixin(
     super();
     this.addEventListener?.('optionselectionchange', (e: Event) => this._onOptionChanged(e));
     this.addEventListener?.('optionLabelChanged', (e: Event) => this._onOptionLabelChanged(e));
+    /** Forces the sbb-select to update his value. */
+    this.addEventListener?.('ɵoptionvaluechange', () => this._updateValueOptionState(), {
+      capture: true,
+    });
     this.addEventListener?.('ɵoptgroupslotchange', () => this._updateValueOptionState(), {
       capture: true,
     });
@@ -214,20 +218,6 @@ export class SbbSelectElement<T = string> extends SbbUpdateSchedulerMixin(
       new MutationController(this, {
         config: { attributeFilter: ['aria-labelledby', 'aria-label', 'aria-describedby'] },
         callback: () => this._syncAriaLabels(),
-      }),
-    );
-
-    // If any option value changes, recheck it against the select's value.
-    this.addController(
-      new MutationController(this, {
-        config: { attributeFilter: ['value'], subtree: true },
-        callback: (record) => {
-          record.forEach((e) => {
-            if ((e.target as HTMLElement).localName === 'sbb-option') {
-              this._updateValueOptionState();
-            }
-          });
-        },
       }),
     );
 

--- a/src/elements/select/select.component.ts
+++ b/src/elements/select/select.component.ts
@@ -195,9 +195,7 @@ export class SbbSelectElement<T = string> extends SbbUpdateSchedulerMixin(
     this.addEventListener?.('optionselectionchange', (e: Event) => this._onOptionChanged(e));
     this.addEventListener?.('optionLabelChanged', (e: Event) => this._onOptionLabelChanged(e));
     /** Forces the sbb-select to update his value. */
-    this.addEventListener?.('ɵoptionvaluechange', () => this._updateValueOptionState(), {
-      capture: true,
-    });
+    this.addEventListener?.('ɵoptionvaluechange', () => this._updateValueOptionState());
     this.addEventListener?.('ɵoptgroupslotchange', () => this._updateValueOptionState(), {
       capture: true,
     });

--- a/src/elements/select/select.component.ts
+++ b/src/elements/select/select.component.ts
@@ -194,10 +194,6 @@ export class SbbSelectElement<T = string> extends SbbUpdateSchedulerMixin(
     super();
     this.addEventListener?.('optionselectionchange', (e: Event) => this._onOptionChanged(e));
     this.addEventListener?.('optionLabelChanged', (e: Event) => this._onOptionLabelChanged(e));
-    /** Forces the sbb-select to update his value. */
-    this.addEventListener?.('ɵoptionvaluechange', () => this._updateValueOptionState(), {
-      capture: true,
-    });
     this.addEventListener?.('ɵoptgroupslotchange', () => this._updateValueOptionState(), {
       capture: true,
     });

--- a/src/elements/select/select.component.ts
+++ b/src/elements/select/select.component.ts
@@ -194,6 +194,10 @@ export class SbbSelectElement<T = string> extends SbbUpdateSchedulerMixin(
     super();
     this.addEventListener?.('optionselectionchange', (e: Event) => this._onOptionChanged(e));
     this.addEventListener?.('optionLabelChanged', (e: Event) => this._onOptionLabelChanged(e));
+    /** Forces the sbb-select to update his value. */
+    this.addEventListener?.('ɵoptionvaluechange', () => this._updateValueOptionState(), {
+      capture: true,
+    });
     this.addEventListener?.('ɵoptgroupslotchange', () => this._updateValueOptionState(), {
       capture: true,
     });

--- a/src/elements/select/select.spec.ts
+++ b/src/elements/select/select.spec.ts
@@ -1353,19 +1353,16 @@ describe(`sbb-select`, () => {
       await waitForLitRender(element);
       expect(firstOption).to.have.attribute('selected');
       expect(element.getDisplayValue()).to.be.equal('First');
-      expect(element).to.match(':state(has-display-value)');
 
       firstOption.value = 'fake';
       await waitForLitRender(element);
       expect(firstOption).not.to.have.attribute('selected');
       expect(element.getDisplayValue()).to.be.equal('');
-      expect(element).not.to.match(':state(has-display-value)');
 
       firstOption.value = '1';
       await waitForLitRender(element);
       expect(firstOption).to.have.attribute('selected');
       expect(element.getDisplayValue()).to.be.equal('First');
-      expect(element).to.match(':state(has-display-value)');
     });
   });
 

--- a/src/elements/select/select.spec.ts
+++ b/src/elements/select/select.spec.ts
@@ -1344,6 +1344,29 @@ describe(`sbb-select`, () => {
       await waitForCondition(() => selectPanel.clientWidth < oldPanelSize);
       expect(selectPanel.clientWidth).to.be.lessThan(oldPanelSize);
     });
+
+    it("should update the value when the option's value is set", async () => {
+      expect(element.getDisplayValue()).to.be.equal('');
+      expect(firstOption).not.to.have.attribute('selected');
+
+      element.value = '1';
+      await waitForLitRender(element);
+      expect(firstOption).to.have.attribute('selected');
+      expect(element.getDisplayValue()).to.be.equal('First');
+      expect(element).to.match(':state(has-display-value)');
+
+      firstOption.value = 'fake';
+      await waitForLitRender(element);
+      expect(firstOption).not.to.have.attribute('selected');
+      expect(element.getDisplayValue()).to.be.equal('');
+      expect(element).not.to.match(':state(has-display-value)');
+
+      firstOption.value = '1';
+      await waitForLitRender(element);
+      expect(firstOption).to.have.attribute('selected');
+      expect(element.getDisplayValue()).to.be.equal('First');
+      expect(element).to.match(':state(has-display-value)');
+    });
   });
 
   describe('with boolean value', () => {


### PR DESCRIPTION
Proposal for resolution of bug [#347](https://github.com/sbb-design-systems/lyne-angular/issues/347)

In Angular, when the option value is set via binding, the 'value' attribute is undefined when the select does the checks on its value and tries to set it based on the provided options.

The idea here is to provide a listener for an internal event, as done for `ɵoptgroupslotchange`; this PR should be completed with another one in the Angular repo which basically triggers the event on the sbb-option after the value is set, something like: 
```
 /**
   * Value of the option.
   */
  @Input()
  public set value(value: T) {
    this.#ngZone.runOutsideAngular(() => {
      this.#element.nativeElement.value = value;
      this.#element.nativeElement.dispatchEvent(new Event('ɵoptionvaluechange'));
    });
  }
  public get value(): T {
    return this.#element.nativeElement.value;
  }
```

