### PR TITLE
style: set line-height to avoid overrides

### DIFF
--- a/src/elements/autocomplete/autocomplete-base-element.scss
+++ b/src/elements/autocomplete/autocomplete-base-element.scss
@@ -15,6 +15,7 @@
 
   display: none;
   font-weight: normal;
+  line-height: var(--sbb-typo-line-height-text);
 }
 
 :host([size='s']) {

--- a/src/elements/breadcrumb/breadcrumb-group/breadcrumb-group.scss
+++ b/src/elements/breadcrumb/breadcrumb-group/breadcrumb-group.scss
@@ -5,6 +5,9 @@
 
   // Allows size calculation even if in grid or flex context.
   min-width: 0;
+
+  // Set the line-height for adjacent elements in order to prevent from influence of a consumer-set line-height.
+  line-height: var(--sbb-typo-line-height-text);
 }
 
 :host(:state(loaded)) {
@@ -36,7 +39,10 @@
 
 #sbb-breadcrumb-ellipsis {
   @include sbb.button-reset;
-  @include sbb.text-xxs--regular;
+
+  font-family: var(--sbb-typo-font-family);
+  font-weight: normal;
+  font-size: var(--sbb-text-font-size);
 
   // line height and letter-spacing needed to match squares drawn in Figma.
   line-height: 0;

--- a/src/elements/breadcrumb/breadcrumb-group/breadcrumb-group.scss
+++ b/src/elements/breadcrumb/breadcrumb-group/breadcrumb-group.scss
@@ -42,7 +42,7 @@
 
   font-family: var(--sbb-typo-font-family);
   font-weight: normal;
-  font-size: var(--sbb-text-font-size);
+  font-size: var(--sbb-text-font-size-xxs);
 
   // line height and letter-spacing needed to match squares drawn in Figma.
   line-height: 0;

--- a/src/elements/button/common/button-common.scss
+++ b/src/elements/button/common/button-common.scss
@@ -157,6 +157,7 @@ $active: ':active, :state(active), [loading]';
   font-size: var(--sbb-text-font-size-xs);
   font-weight: bold;
   letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-line-height-text);
   text-align: left;
   white-space: nowrap;
   text-decoration: none;

--- a/src/elements/button/common/mini-button-label-common.scss
+++ b/src/elements/button/common/mini-button-label-common.scss
@@ -28,6 +28,7 @@ $icon-only: ':where(:state(slotted-icon), :state(has-icon-name)):not(:state(slot
 
   font-size: var(--sbb-text-font-size-xxs);
   letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-line-height-text);
   display: var(--sbb-mini-button-label-display);
   transition: translate var(--sbb-mini-button-transition-duration)
     var(--sbb-mini-button-transition-easing-function);

--- a/src/elements/calendar/calendar/calendar.scss
+++ b/src/elements/calendar/calendar/calendar.scss
@@ -63,6 +63,7 @@
   height: var(--sbb-calendar-control-view-change-height);
   font-size: var(--sbb-text-font-size-s);
   letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-letter-spacing-text);
   text-transform: capitalize;
   cursor: var(--sbb-cursor-pointer);
   padding-inline: var(--sbb-calendar-control-view-change-padding-inline);

--- a/src/elements/calendar/calendar/calendar.scss
+++ b/src/elements/calendar/calendar/calendar.scss
@@ -6,6 +6,9 @@
   // We add width definition to host, to make overwriting easy for consumers.
   width: max-content;
 
+  // Set the line-height for adjacent elements in order to prevent from influence of a consumer-set line-height.
+  line-height: var(--sbb-typo-line-height-text);
+
   --sbb-calendar-cell-size: #{sbb.px-to-rem-build(44)};
 
   // Match Figma design

--- a/src/elements/card/card-badge/card-badge.scss
+++ b/src/elements/card/card-badge/card-badge.scss
@@ -35,10 +35,10 @@
 }
 
 .sbb-card-badge-content {
-  @include sbb.text--bold;
-
   font-size: var(--sbb-text-font-size-xxs);
   letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-line-height-text);
+  font-weight: bold;
   position: relative;
   display: flex;
   align-items: center;

--- a/src/elements/checkbox/common/checkbox-common.scss
+++ b/src/elements/checkbox/common/checkbox-common.scss
@@ -1,5 +1,11 @@
 @use '../../core/styles' as sbb;
 
+:host {
+  font-size: var(--sbb-checkbox-font-size);
+  letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-line-height-text);
+}
+
 :host([size='xs']) {
   --sbb-checkbox-font-size: var(--sbb-text-font-size-xs);
   --sbb-checkbox-dimension: var(--sbb-checkbox-dimension-xs);
@@ -27,8 +33,6 @@
 }
 
 .sbb-checkbox {
-  font-size: var(--sbb-checkbox-font-size);
-  letter-spacing: var(--sbb-typo-letter-spacing-text);
   position: relative;
   display: block;
   width: 100%;

--- a/src/elements/checkbox/common/checkbox-common.scss
+++ b/src/elements/checkbox/common/checkbox-common.scss
@@ -1,11 +1,5 @@
 @use '../../core/styles' as sbb;
 
-:host {
-  font-size: var(--sbb-checkbox-font-size);
-  letter-spacing: var(--sbb-typo-letter-spacing-text);
-  line-height: var(--sbb-typo-line-height-text);
-}
-
 :host([size='xs']) {
   --sbb-checkbox-font-size: var(--sbb-text-font-size-xs);
   --sbb-checkbox-dimension: var(--sbb-checkbox-dimension-xs);
@@ -39,6 +33,9 @@
   cursor: var(--sbb-checkbox-cursor);
   user-select: none;
   -webkit-tap-highlight-color: transparent;
+  font-size: var(--sbb-checkbox-font-size);
+  letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-line-height-text);
 }
 
 .sbb-checkbox__inner {

--- a/src/elements/chip/chip-group/chip-group.scss
+++ b/src/elements/chip/chip-group/chip-group.scss
@@ -7,6 +7,9 @@
   gap: var(--sbb-chip-group-gap);
   align-items: center;
   margin-block: var(--sbb-chip-group-margin-block);
+
+  // Set the line-height for adjacent elements in order to prevent from influence of a consumer-set line-height.
+  line-height: var(--sbb-typo-line-height-text);
 }
 
 :host(:is(:state(size-s), :state(empty))) {

--- a/src/elements/core/styles/core.scss
+++ b/src/elements/core/styles/core.scss
@@ -403,8 +403,7 @@ $theme: 'standard' !default;
   --sbb-cursor-pointer: pointer;
 
   // Infinity border radius, can be used to achieve rounded border on start and end
-  // TODO: Check if infinity is supported by all browsers (e.g. Firefox) -> calc(1em * infinity);
-  --sbb-border-radius-infinity: 100000em;
+  --sbb-border-radius-infinity: calc(infinity * 1px);
 
   // TODO: Remove complete block when new lean theme is complete
   // TODO: Also remove all occurrences of the variables in lyne-components (e.g. --sbb-title-font-size-level-1-lean)

--- a/src/elements/core/styles/core.scss
+++ b/src/elements/core/styles/core.scss
@@ -212,6 +212,9 @@ $theme: 'standard' !default;
 @use '../../signet/signet.global' as signet with (
   $theme: $theme
 );
+@use '../../select/select.global' as select with (
+  $theme: $theme
+);
 @use '../../slider/slider.global' as slider with (
   $theme: $theme
 );
@@ -239,6 +242,9 @@ $theme: 'standard' !default;
 @use '../../teaser/teaser.global' as teaser with (
   $theme: $theme
 );
+@use '../../teaser-hero/teaser-hero.global' as teaser-hero with (
+  $theme: $theme
+);
 @use '../../teaser-panel/teaser-panel.global' as teaser-panel with (
   $theme: $theme
 );
@@ -257,6 +263,9 @@ $theme: 'standard' !default;
   $theme: $theme
 );
 @use '../../timetable-occupancy/timetable-occupancy.global' as timetable-occupancy with (
+  $theme: $theme
+);
+@use '../../time-input/time-input.global' as time-input with (
   $theme: $theme
 );
 @use '../../toggle/toggle/toggle.global' as toggle with (
@@ -339,6 +348,7 @@ $theme: 'standard' !default;
   @include selection-expansion-panel.base;
   @include sidebar.base;
   @include signet.base;
+  @include select.base;
   @include slider.base;
   @include status.base;
   @include step-label.base;
@@ -347,12 +357,14 @@ $theme: 'standard' !default;
   @include tab-label-common.base;
   @include tag.base;
   @include teaser.base;
+  @include teaser-hero.base;
   @include teaser-panel.base;
   @include teaser-product-common.base;
   @include timetable-form.base;
   @include timetable-form-details.base;
   @include timetable-form-field.base;
   @include timetable-occupancy.base;
+  @include time-input.base;
   @include toggle.base;
   @include toggle-option.base;
   @include tooltip.base;
@@ -382,9 +394,6 @@ $theme: 'standard' !default;
   --sbb-train-formation-wagon-width: #{functions.px-to-rem-build(80)};
   --sbb-train-formation-wagon-height: #{functions.px-to-rem-build(40)};
   --sbb-train-formation-wagon-gap: var(--sbb-spacing-fixed-1x);
-
-  // Time Input
-  --sbb-time-input-max-width: #{functions.px-to-rem-build(58)};
 
   // Overlay
   --sbb-overlay-default-z-index: 1000;
@@ -442,7 +451,6 @@ $theme: 'standard' !default;
     @include sbb-css-tokens.breakpoint-large;
 
     @include button.base-breakpoint-large;
-
     @include chip-group.base-breakpoint-large;
     @include dialog.base-breakpoint-large;
     @include flip-card.base-breakpoint-large;
@@ -451,6 +459,7 @@ $theme: 'standard' !default;
     @include menu.base-breakpoint-large;
     @include teaser-panel.base-breakpoint-large;
     @include teaser-product-common.base-breakpoint-large;
+    @include time-input.base-breakpoint-large;
 
     // TODO: Remove complete block when new lean theme is complete
     // Only render the block in standard theme as fallback for CSS class usage
@@ -459,9 +468,6 @@ $theme: 'standard' !default;
         --sbb-title-font-size-level-6-lean: var(--sbb-typo-scale-0-875x);
       }
     }
-
-    // Time Input
-    --sbb-time-input-max-width: #{functions.px-to-rem-build(65)};
   }
 
   @include mediaqueries.mq($from: ultra) {
@@ -488,10 +494,13 @@ $theme: 'standard' !default;
 @include lead-container.rules;
 @include message.rules;
 @include option.rules;
+@include select.rules;
 @include sidebar.rules;
 @include sidebar-close-button.rules;
 @include sidebar-container.rules;
 @include tab-nav-bar.rules;
+@include teaser.rules;
+@include teaser-hero.rules;
 @include teaser-product-common.rules;
 @include toggle.rules;
 
@@ -561,22 +570,6 @@ html {
   pointer-events: all;
 }
 
-// Helper class for the application name and version in sbb-header.
-.sbb-header-info {
-  @include typo.text-xs--regular;
-
-  display: flex;
-  padding-inline: var(--sbb-spacing-fixed-4x);
-  gap: var(--sbb-spacing-fixed-1x);
-  align-items: baseline;
-  color: var(--sbb-color-1);
-
-  strong + * {
-    font-size: var(--sbb-text-font-size-xxs);
-    color: light-dark(var(--sbb-color-granite), var(--sbb-color-smoke));
-  }
-}
-
 // In smaller title font-sizes, the space after the title is smaller than the default paragraph space before.
 // Due to margin collapsing, the wrong paragraph space wins.
 // To prevent the mistakenly large gap, we reset the paragraph space.
@@ -592,7 +585,6 @@ img {
 
 // Target the slotted `sbb-image` which are generally wrapped by a <figure> (therefore are not reachable with the :slotted)
 // Apply the brightness effect on mouse hover
-// TODO: Move back to the teaser components when the global CSS refactoring happens
 :is(sbb-teaser, sbb-teaser-hero, sbb-teaser-product) {
   --sbb-teaser-image-brightness-hover: var(--sbb-hover-image-brightness);
   --sbb-teaser-image-animation-duration: var(
@@ -612,34 +604,6 @@ img {
     filter: brightness(var(--sbb-teaser-image-brightness, 1));
     transition: filter var(--sbb-teaser-image-animation-duration)
       var(--sbb-teaser-image-animation-easing);
-  }
-}
-
-sbb-teaser :is(sbb-image, img):not(.sbb-figure-overlap-image) {
-  --sbb-image-object-fit: cover;
-  --sbb-image-aspect-ratio: 4 / 3;
-
-  transition-property: filter, scale;
-  will-change: filter, scale;
-  scale: var(--sbb-teaser-scale, 1);
-}
-
-// TODO: Move back to the teaser-hero components when the global CSS refactoring happens
-sbb-teaser-hero {
-  :is(sbb-image, img):not(.sbb-figure-overlap-image) {
-    --sbb-image-aspect-ratio: 1 / 1;
-
-    border-radius: 0;
-
-    @include mediaqueries.mq($from: small) {
-      --sbb-image-aspect-ratio: 16 / 9;
-    }
-  }
-
-  img:not(.sbb-figure-overlap-image) {
-    display: block;
-    align-self: stretch;
-    width: 100%;
   }
 }
 
@@ -676,27 +640,8 @@ sbb-train-formation[view='top'] sbb-train-wagon {
   --sbb-train-wagon-wagon-end-right-shape: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='40' viewBox='0 0 80 40' fill='none'%3E%3Cpath d='M8.5,0.5 h51.5 a19.5,19.5 0 0 1 19.5,19.5 v0 a19.5,19.5 0 0 1 -19.5,19.5 h-51.5 a8,8 0 0 1 -8,-8 v-23 a8,8 0 0 1 8,-8 z' stroke='%23000000' stroke-width='1'/%3E%3C/svg%3E");
 }
 
-// We set some dimension to the selects trigger element in order that the screen reader's outline box looks more accurate.
-.sbb-select-trigger {
-  width: 100%;
-
-  // We set the smallest possible height (zero breakpoint, size s)
-  height: var(--sbb-size-element-xs);
-
-  sbb-form-field & {
-    top: 0;
-  }
-}
-
 .sbb-overlay-outlet {
   position: fixed;
   inset: 0;
   pointer-events: none;
-}
-
-// Sets ellipsis on all sbb-option child elements
-.sbb-options-nowrap {
-  --sbb-option-text-overflow: ellipsis;
-  --sbb-option-overflow: hidden;
-  --sbb-option-white-space: nowrap;
 }

--- a/src/elements/core/styles/mixins/typo.scss
+++ b/src/elements/core/styles/mixins/typo.scss
@@ -7,9 +7,9 @@
   margin-inline: 0;
   font-family: var(--sbb-typo-font-family);
   font-weight: bold;
-  line-height: var(--sbb-title-line-height, var(--sbb-typo-line-height-heading));
-  letter-spacing: var(--sbb-typo-letter-spacing-heading);
   font-size: var(--sbb-title-font-size);
+  letter-spacing: var(--sbb-typo-letter-spacing-heading);
+  line-height: var(--sbb-title-line-height, var(--sbb-typo-line-height-heading));
 }
 
 @mixin title--level-1 {

--- a/src/elements/expansion-panel/expansion-panel-header/expansion-panel-header.scss
+++ b/src/elements/expansion-panel/expansion-panel-header/expansion-panel-header.scss
@@ -59,6 +59,7 @@
   font-size: var(--sbb-expansion-panel-header-font-size);
   font-weight: normal;
   letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-line-height-text);
   -webkit-tap-highlight-color: transparent;
 }
 

--- a/src/elements/footer/footer.scss
+++ b/src/elements/footer/footer.scss
@@ -16,6 +16,7 @@
   // Include text style and color as fallback for paragraph texts inside the footer.
   font-size: var(--sbb-footer-font-size);
   letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-line-height-text);
   color: var(--sbb-footer-color);
   padding-block: var(--sbb-footer-padding-block);
   background-color: var(--sbb-footer-background-color);

--- a/src/elements/form-field/error/error.scss
+++ b/src/elements/form-field/error/error.scss
@@ -12,6 +12,7 @@
   color: var(--sbb-error-color);
   min-height: var(--_sbb-error-height);
   font-size: var(--sbb-error-font-size);
+  line-height: var(--sbb-typo-line-height-text);
   letter-spacing: var(--sbb-typo-letter-spacing-text);
 
   @include sbb.if-forced-colors {

--- a/src/elements/form-field/form-field/form-field.scss
+++ b/src/elements/form-field/form-field/form-field.scss
@@ -36,6 +36,9 @@
   display: inline-block;
   color: var(--sbb-form-field-color);
   font-weight: normal;
+
+  // Set the line-height for adjacent elements in order to prevent from influence of a consumer-set line-height.
+  line-height: var(--sbb-typo-line-height-text);
 }
 
 :host(:where(:not([width='collapse']))) {

--- a/src/elements/form-field/hint/hint.scss
+++ b/src/elements/form-field/hint/hint.scss
@@ -7,6 +7,7 @@
   color: var(--sbb-form-field-label-color);
   font-size: var(--sbb-form-field-hint-font-size);
   letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-line-height-texts);
 }
 
 :host([negative]) {

--- a/src/elements/header/header/header.global.scss
+++ b/src/elements/header/header/header.global.scss
@@ -27,11 +27,6 @@ $theme: 'standard' !default;
 }
 
 @mixin rules {
-  // Move container below header
-  sbb-header + :where(sbb-sidebar-container, sbb-icon-sidebar-container) {
-    margin-block-start: var(--sbb-header-height);
-  }
-
   :root:has(sbb-header[size='m']) {
     --sbb-header-height: var(--sbb-spacing-fixed-14x);
   }
@@ -47,6 +42,28 @@ $theme: 'standard' !default;
 
     :root:has(sbb-header[size='s']) {
       --sbb-header-height: var(--sbb-spacing-fixed-14x);
+    }
+  }
+
+  // Move container below header
+  sbb-header + :where(sbb-sidebar-container, sbb-icon-sidebar-container) {
+    margin-block-start: var(--sbb-header-height);
+  }
+
+  // Helper class for the application name and version in sbb-header.
+  .sbb-header-info {
+    display: flex;
+    padding-inline: var(--sbb-spacing-fixed-4x);
+    gap: var(--sbb-spacing-fixed-1x);
+    align-items: baseline;
+    color: var(--sbb-color-1);
+    font-size: var(--sbb-text-font-size-xs);
+    letter-spacing: var(--sbb-typo-letter-spacing-text);
+
+    strong + * {
+      font-size: var(--sbb-text-font-size-xxs);
+      letter-spacing: var(--sbb-typo-letter-spacing-text);
+      color: light-dark(var(--sbb-color-granite), var(--sbb-color-smoke));
     }
   }
 }

--- a/src/elements/header/header/header.scss
+++ b/src/elements/header/header/header.scss
@@ -17,6 +17,9 @@
 
   // Setting the height here reserves the space for the header which will else be lost with fixed position.
   height: var(--sbb-header-height);
+
+  // Set the line-height for adjacent elements in order to prevent from influence of a consumer-set line-height.
+  line-height: var(--sbb-typo-line-height-text);
 }
 
 :host([size='s']) {

--- a/src/elements/link/common/block-link.scss
+++ b/src/elements/link/common/block-link.scss
@@ -32,8 +32,9 @@
 
 .sbb-action-base {
   gap: var(--sbb-block-link-gap);
-  letter-spacing: var(--sbb-typo-letter-spacing-text);
   font-size: var(--sbb-block-link-font-size);
+  letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-line-height-text);
 }
 
 .sbb-link__icon {

--- a/src/elements/message/message.scss
+++ b/src/elements/message/message.scss
@@ -3,6 +3,9 @@
 :host {
   display: block;
   text-align: center;
+
+  // Set the line-height for adjacent elements in order to prevent from influence of a consumer-set line-height.
+  line-height: var(--sbb-typo-line-height-text);
 }
 
 ::slotted(sbb-title[slot='title']) {

--- a/src/elements/notification/notification.scss
+++ b/src/elements/notification/notification.scss
@@ -34,8 +34,9 @@ $open-anim-height-to: calc(
   --sbb-focus-outline-color: var(--sbb-focus-outline-color-default);
 
   display: block;
-  letter-spacing: var(--sbb-typo-letter-spacing-text);
   font-size: var(--sbb-notification-font-size);
+  letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-line-height-text);
 }
 
 // By default, the open animation is disabled

--- a/src/elements/option/option/option.global.scss
+++ b/src/elements/option/option/option.global.scss
@@ -38,4 +38,11 @@ $theme: 'standard' !default;
       --sbb-option-hint-padding-block-end: var(--sbb-spacing-fixed-1x);
     }
   }
+
+  // Sets ellipsis on all sbb-option child elements
+  .sbb-options-nowrap {
+    --sbb-option-text-overflow: ellipsis;
+    --sbb-option-overflow: hidden;
+    --sbb-option-white-space: nowrap;
+  }
 }

--- a/src/elements/paginator/compact-paginator/compact-paginator.scss
+++ b/src/elements/paginator/compact-paginator/compact-paginator.scss
@@ -26,6 +26,7 @@
 .sbb-paginator__pages {
   font-size: var(--sbb-compact-paginator-font-size);
   letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-line-height-text);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/elements/paginator/paginator/paginator.scss
+++ b/src/elements/paginator/paginator/paginator.scss
@@ -7,6 +7,9 @@
   );
 
   display: block;
+
+  // Prevent influence from consumer-set line-height
+  line-height: var(--sbb-typo-line-height-text);
 }
 
 :host([size='s']) {

--- a/src/elements/paginator/paginator/paginator.scss
+++ b/src/elements/paginator/paginator/paginator.scss
@@ -96,10 +96,11 @@
 .sbb-paginator__page--number-item {
   @include sbb.button-reset;
 
-  // The text mixin is needed to override the button base style
-  --sbb-text-font-size: var(--sbb-paginator-font-size);
-  @include sbb.text;
-
+  font-family: var(--sbb-typo-font-family);
+  letter-spacing: var(--sbb-typo-letter-spacing-text);
+  font-size: var(--sbb-paginator-font-size);
+  line-height: var(--sbb-typo-line-height-text);
+  font-weight: normal;
   position: relative;
   cursor: var(--sbb-paginator-page-cursor);
   outline: none !important;

--- a/src/elements/radio-button/common/radio-button-common.scss
+++ b/src/elements/radio-button/common/radio-button-common.scss
@@ -68,6 +68,7 @@
 .sbb-radio-button {
   font-size: var(--sbb-radio-button-font-size);
   letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-line-height-text);
   display: block;
   cursor: var(--sbb-radio-button-cursor);
   user-select: none;

--- a/src/elements/select/select.global.scss
+++ b/src/elements/select/select.global.scss
@@ -1,0 +1,24 @@
+@use '../core/styles' as sbb;
+
+$theme: 'standard' !default;
+
+@mixin base {
+  --sbb-select-placeholder-fallback-color: light-dark(
+    var(--sbb-color-metal),
+    var(--sbb-color-smoke)
+  );
+}
+
+@mixin rules {
+  // We set some dimension to the selects trigger element in order that the screen reader's outline box looks more accurate.
+  .sbb-select-trigger {
+    width: 100%;
+
+    // We set the smallest possible height (zero breakpoint, size s)
+    height: var(--sbb-size-element-xs);
+
+    sbb-form-field & {
+      top: 0;
+    }
+  }
+}

--- a/src/elements/select/select.scss
+++ b/src/elements/select/select.scss
@@ -11,10 +11,6 @@
     --sbb-select-z-index,
     var(--sbb-overlay-default-z-index)
   );
-  --sbb-select-placeholder-fallback-color: light-dark(
-    var(--sbb-color-metal),
-    var(--sbb-color-smoke)
-  );
 
   display: block;
   font-weight: normal;

--- a/src/elements/select/select.scss
+++ b/src/elements/select/select.scss
@@ -18,6 +18,7 @@
 
   display: block;
   font-weight: normal;
+  line-height: var(--sbb-typo-line-height-text);
 }
 
 :host([size='s']) {

--- a/src/elements/status/status.scss
+++ b/src/elements/status/status.scss
@@ -8,6 +8,7 @@
   color: var(--sbb-status-text-color);
   font-size: var(--sbb-status-font-size);
   letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-line-height-text);
 }
 
 :host([type='error']) {

--- a/src/elements/stepper/step-label/step-label.scss
+++ b/src/elements/stepper/step-label/step-label.scss
@@ -24,6 +24,7 @@
   color: var(--sbb-step-label-color);
   font-size: var(--sbb-step-label-font-size);
   letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-line-height-text);
 
   &::before {
     @include sbb.absolute-center-x-y;

--- a/src/elements/stepper/step/step.scss
+++ b/src/elements/stepper/step/step.scss
@@ -9,8 +9,6 @@
   );
 
   display: contents;
-  font-size: var(--sbb-text-font-size-m);
-  letter-spacing: var(--sbb-typo-letter-spacing-text);
 }
 
 :host(:state(selected)) {

--- a/src/elements/stepper/step/step.scss
+++ b/src/elements/stepper/step/step.scss
@@ -9,6 +9,8 @@
   );
 
   display: contents;
+  font-size: var(--sbb-text-font-size-m);
+  letter-spacing: var(--sbb-typo-letter-spacing-text);
 }
 
 :host(:state(selected)) {

--- a/src/elements/tabs/common/tab-label-common.scss
+++ b/src/elements/tabs/common/tab-label-common.scss
@@ -61,6 +61,7 @@
   transition: color var(--sbb-tab-label-animation-duration) var(--sbb-tab-label-animation-easing);
   font-size: var(--sbb-tab-label-font-size);
   letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-line-height-text);
   font-weight: var(--sbb-tab-label-font-weight);
   text-decoration: var(--sbb-tab-label-text-decoration);
 

--- a/src/elements/tag/tag/tag.scss
+++ b/src/elements/tag/tag/tag.scss
@@ -92,6 +92,7 @@ $active: ':active, :state(active)';
   max-width: 100%;
   font-size: var(--sbb-text-font-size-xs);
   letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-line-height-text);
   gap: var(--sbb-tag-gap);
   padding-inline: var(--sbb-tag-padding-inline);
   cursor: var(--sbb-tag-cursor, var(--sbb-cursor-pointer));

--- a/src/elements/teaser-hero/teaser-hero.global.scss
+++ b/src/elements/teaser-hero/teaser-hero.global.scss
@@ -1,0 +1,27 @@
+@use '../core/styles' as sbb;
+
+$theme: 'standard' !default;
+
+@mixin base {
+  --sbb-teaser-hero-link-font-weight: 400;
+}
+
+@mixin rules {
+  sbb-teaser-hero {
+    :is(sbb-image, img):not(.sbb-figure-overlap-image) {
+      --sbb-image-aspect-ratio: 1 / 1;
+
+      border-radius: 0;
+
+      @include sbb.mq($from: small) {
+        --sbb-image-aspect-ratio: 16 / 9;
+      }
+    }
+
+    img:not(.sbb-figure-overlap-image) {
+      display: block;
+      align-self: stretch;
+      width: 100%;
+    }
+  }
+}

--- a/src/elements/teaser-hero/teaser-hero.scss
+++ b/src/elements/teaser-hero/teaser-hero.scss
@@ -1,19 +1,12 @@
 @use '../core/styles' as sbb;
 
 :host {
-  --sbb-teaser-hero-link-font-weight: 400;
-
   display: block;
   position: relative;
 
   // Use !important here to not interfere with Firefox focus ring definition
   // which appears in normalize CSS of several frameworks.
   outline: none !important;
-}
-
-// Hide panel when no content or link-content is provided.
-:host(:not(:state(slotted), :state(slotted-link-content), [link-content])) sbb-teaser-panel {
-  display: none;
 }
 
 ::slotted([slot='image']) {
@@ -35,6 +28,11 @@ sbb-teaser-panel {
   // To avoid having a 0 height if you only slotted the panel content
   :host(:not(:state(slotted-image))) & {
     position: static;
+  }
+
+  // Hide when no content or link-content is provided.
+  :host(:not(:state(slotted), :state(slotted-link-content), [link-content])) & {
+    display: none;
   }
 }
 

--- a/src/elements/teaser/teaser.global.scss
+++ b/src/elements/teaser/teaser.global.scss
@@ -12,3 +12,14 @@ $theme: 'standard' !default;
   --sbb-teaser-border-radius: var(--sbb-border-radius-4x);
   --sbb-teaser-image-width: #{sbb.px-to-rem-build(300)};
 }
+
+@mixin rules {
+  sbb-teaser :is(sbb-image, img):not(.sbb-figure-overlap-image) {
+    --sbb-image-object-fit: cover;
+    --sbb-image-aspect-ratio: 4 / 3;
+
+    transition-property: filter, scale;
+    will-change: filter, scale;
+    scale: var(--sbb-teaser-scale, 1);
+  }
+}

--- a/src/elements/time-input/time-input.global.scss
+++ b/src/elements/time-input/time-input.global.scss
@@ -1,0 +1,11 @@
+@use '../core/styles' as sbb;
+
+$theme: 'standard' !default;
+
+@mixin base {
+  --sbb-time-input-max-width: #{sbb.px-to-rem-build(58)};
+}
+
+@mixin base-breakpoint-large {
+  --sbb-time-input-max-width: #{sbb.px-to-rem-build(65)};
+}

--- a/src/elements/timetable-occupancy/timetable-occupancy.scss
+++ b/src/elements/timetable-occupancy/timetable-occupancy.scss
@@ -34,9 +34,9 @@
 
 .sbb-timetable-occupancy__list-item-class {
   color: var(--sbb-timetable-occupancy-color);
-  line-height: 1;
   font-size: var(--sbb-timetable-occupancy-font-size);
   letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: 1;
 }
 
 .sbb-timetable-occupancy__list-item-icon {

--- a/src/elements/toggle/toggle/toggle.scss
+++ b/src/elements/toggle/toggle/toggle.scss
@@ -23,6 +23,9 @@
   user-select: none;
   -webkit-tap-highlight-color: transparent;
 
+  // Set the line-height for adjacent elements in order to prevent from influence of a consumer-set line-height.
+  line-height: var(--sbb-typo-line-height-text);
+
   // White pill of selected toggle option
   &::before {
     content: '';

--- a/src/elements/tooltip/tooltip.scss
+++ b/src/elements/tooltip/tooltip.scss
@@ -22,6 +22,7 @@
   animation-timing-function: var(--sbb-tooltip-animation-easing);
   font-size: var(--sbb-tooltip-font-size);
   letter-spacing: var(--sbb-typo-letter-spacing-text);
+  line-height: var(--sbb-typo-line-height-text);
 
   // Reset [popover] styles
   border: none;


### PR DESCRIPTION
In some circumstandes, consumer-set line-heights can win over component line-heights. Wherever it makes sense, line-height definition was added to stabilize the design. 