### PR TITLE
chore(option): fix event bubbling

### DIFF
--- a/src/elements/option/option/option-base-element.ts
+++ b/src/elements/option/option/option-base-element.ts
@@ -62,7 +62,7 @@ export abstract class SbbOptionBaseElement<T = string> extends SbbDisabledMixin(
     }
     // Notify the sbb-select to re-check its value against the option's one.
     /** @internal */
-    this.dispatchEvent(new Event('ɵoptionvaluechange'));
+    this.dispatchEvent(new Event('ɵoptionvaluechange', { bubbles: true }));
   }
   public get value(): T {
     return (this._value ?? this.getAttribute('value')) as T;

--- a/src/elements/select/select.component.ts
+++ b/src/elements/select/select.component.ts
@@ -122,8 +122,8 @@ export class SbbSelectElement<T = string> extends SbbUpdateSchedulerMixin(
   @property()
   public set value(value: T[] | T) {
     this._value = value;
-    this._updateOptionsFromValue();
     this._isValueManuallyAssigned = true;
+    this._updateOptionsFromValue();
   }
   public get value(): T[] | T | null {
     return this._value;

--- a/src/elements/select/select.spec.ts
+++ b/src/elements/select/select.spec.ts
@@ -1347,21 +1347,21 @@ describe(`sbb-select`, () => {
 
     it("should update the value when the option's value is set", async () => {
       expect(element.getDisplayValue()).to.be.equal('');
-      expect(firstOption).not.to.have.attribute('selected');
+      expect(firstOption.getAttribute('selected')).to.be.null;
 
-      element.value = '1';
+      element.setAttribute('value', '1');
       await waitForLitRender(element);
-      expect(firstOption).to.have.attribute('selected');
+      expect(firstOption.getAttribute('selected')).not.to.be.null;
       expect(element.getDisplayValue()).to.be.equal('First');
 
-      firstOption.value = 'fake';
+      firstOption.setAttribute('value', 'fake');
       await waitForLitRender(element);
-      expect(firstOption).not.to.have.attribute('selected');
+      expect(firstOption.getAttribute('selected')).to.be.null;
       expect(element.getDisplayValue()).to.be.equal('');
 
-      firstOption.value = '1';
+      element.setAttribute('value', 'fake');
       await waitForLitRender(element);
-      expect(firstOption).to.have.attribute('selected');
+      expect(firstOption.getAttribute('selected')).not.to.be.null;
       expect(element.getDisplayValue()).to.be.equal('First');
     });
   });


### PR DESCRIPTION
Missing 'bubbles: true' on the option event, moved the setting of '_isValueManuallyAssigned' due to timing issues in tests.