### PR TITLE
fix: missing theme in visual-regression-app (#4780)

### DIFF
--- a/src/visual-regression-app/src/main.ts
+++ b/src/visual-regression-app/src/main.ts
@@ -2,6 +2,7 @@ import { Router } from '@lit-labs/router';
 import { html, LitElement, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
+import '@sbb-esta/lyne-elements/core.js';
 import '@sbb-esta/lyne-elements/core/styles/standard-theme.scss';
 
 // Lit Router uses URLPattern which is not defined so far in Firefox and Safari.


### PR DESCRIPTION
Cherry-pick on 4.x of https://github.com/sbb-design-systems/lyne-components/pull/4780