### PR TITLE
refactor(journey-header): remove size property

### DIFF
--- a/src/elements-experimental/journey-summary/journey-summary.component.ts
+++ b/src/elements-experimental/journey-summary/journey-summary.component.ts
@@ -176,7 +176,7 @@ export class SbbJourneySummaryElement extends SbbElement {
       <div class="sbb-journey-summary">
         ${origin
           ? html`<sbb-journey-header
-              size="l"
+              visual-level="4"
               .level=${this.headerLevel || nothing}
               .origin=${origin}
               .destination=${destination}

--- a/src/elements/journey-header/__snapshots__/journey-header.snapshot.spec.snap.js
+++ b/src/elements/journey-header/__snapshots__/journey-header.snapshot.spec.snap.js
@@ -6,68 +6,42 @@ snapshots["sbb-journey-header renders DOM"] =
   destination="B"
   level="3"
   origin="A"
-  size="m"
-  visual-level="5"
+  visual-level="3"
 >
 </sbb-journey-header>
 `;
 /* end snapshot sbb-journey-header renders DOM */
 
 snapshots["sbb-journey-header renders Shadow DOM"] = 
-`<span
-  aria-hidden="true"
-  class="sbb-journey-header"
->
-  <span class="sbb-journey-header__origin">
-    A
-  </span>
-  <sbb-icon name="arrow-long-right-small">
-  </sbb-icon>
-  <span class="sbb-journey-header__destination">
-    B
-  </span>
-</span>
-<sbb-screen-reader-only>
-  Connection from A to B
-</sbb-screen-reader-only>
+`A
+<sbb-icon name="arrow-long-right-small">
+</sbb-icon>
+B
 `;
 /* end snapshot sbb-journey-header renders Shadow DOM */
 
-snapshots["sbb-journey-header renders H1 L-sized round-trip negative DOM"] = 
+snapshots["sbb-journey-header renders visual-level 4 round-trip negative DOM"] = 
 `<sbb-journey-header
   destination="C"
   level="1"
   negative=""
   origin="B"
   round-trip=""
-  size="l"
   visual-level="4"
 >
 </sbb-journey-header>
 `;
-/* end snapshot sbb-journey-header renders H1 L-sized round-trip negative DOM */
+/* end snapshot sbb-journey-header renders visual-level 4 round-trip negative DOM */
 
-snapshots["sbb-journey-header renders H1 L-sized round-trip negative Shadow DOM"] = 
-`<span
-  aria-hidden="true"
-  class="sbb-journey-header"
->
-  <span class="sbb-journey-header__origin">
-    B
-  </span>
-  <sbb-icon name="arrows-long-right-left-small">
-  </sbb-icon>
-  <span class="sbb-journey-header__destination">
-    C
-  </span>
-</span>
-<sbb-screen-reader-only>
-  Connection from B to C and back to B.
-</sbb-screen-reader-only>
+snapshots["sbb-journey-header renders visual-level 4 round-trip negative Shadow DOM"] = 
+`B
+<sbb-icon name="arrows-long-right-left-small">
+</sbb-icon>
+C
 `;
-/* end snapshot sbb-journey-header renders H1 L-sized round-trip negative Shadow DOM */
+/* end snapshot sbb-journey-header renders visual-level 4 round-trip negative Shadow DOM */
 
-snapshots["sbb-journey-header renders H1 L-sized round-trip negative A11y tree Chrome"] = 
+snapshots["sbb-journey-header renders visual-level 4 round-trip negative A11y tree Chrome"] = 
 `<p>
   {
   "role": "generic",
@@ -82,5 +56,5 @@ snapshots["sbb-journey-header renders H1 L-sized round-trip negative A11y tree C
 }
 </p>
 `;
-/* end snapshot sbb-journey-header renders H1 L-sized round-trip negative A11y tree Chrome */
+/* end snapshot sbb-journey-header renders visual-level 4 round-trip negative A11y tree Chrome */
 

--- a/src/elements/journey-header/__snapshots__/journey-header.snapshot.spec.snap.js
+++ b/src/elements/journey-header/__snapshots__/journey-header.snapshot.spec.snap.js
@@ -6,7 +6,7 @@ snapshots["sbb-journey-header renders DOM"] =
   destination="B"
   level="3"
   origin="A"
-  visual-level="3"
+  visual-level="5"
 >
 </sbb-journey-header>
 `;

--- a/src/elements/journey-header/journey-header.component.ts
+++ b/src/elements/journey-header/journey-header.component.ts
@@ -1,7 +1,7 @@
 import {
   type CSSResultGroup,
   html,
-  type PropertyValues,
+  type PropertyDeclaration,
   type TemplateResult,
   unsafeCSS,
 } from 'lit';
@@ -13,37 +13,21 @@ import {
   i18nConnectionFrom,
   i18nConnectionRoundtrip,
   i18nConnectionTo,
-  isLean,
   type SbbElementType,
   SbbLanguageController,
   SbbNegativeMixin,
-  SbbScreenReaderOnlyElement,
 } from '../core.ts';
 import { SbbIconElement } from '../icon.pure.ts';
-import { SbbTitleBase, type SbbTitleLevel } from '../title.pure.ts';
+import { SbbTitleBase } from '../title.pure.ts';
 
 import style from './journey-header.scss?inline';
-
-export type JourneyHeaderSize = 's' | 'm' | 'l';
-
-const sizeToLevel: Map<JourneyHeaderSize, SbbTitleLevel> = new Map<
-  JourneyHeaderSize,
-  SbbTitleLevel
->([
-  ['s', '6'],
-  ['m', '5'],
-  ['l', '4'],
-]);
 
 /**
  * Combined with the `sbb-journey-summary`, it displays the journey's detail.
  */
 export class SbbJourneyHeaderElement extends SbbNegativeMixin(SbbTitleBase) {
   public static override readonly elementName: string = 'sbb-journey-header';
-  public static override elementDependencies: SbbElementType[] = [
-    SbbIconElement,
-    SbbScreenReaderOnlyElement,
-  ];
+  public static override elementDependencies: SbbElementType[] = [SbbIconElement];
   public static override styles: CSSResultGroup = [
     boxSizingStyles,
     SbbTitleBase.styles,
@@ -65,41 +49,38 @@ export class SbbJourneyHeaderElement extends SbbNegativeMixin(SbbTitleBase) {
   @property({ attribute: 'round-trip', type: Boolean })
   public accessor roundTrip: boolean = false;
 
-  /**
-   * Journey header size, either s, m or l.
-   * @default 'm' / 's' (lean)
-   * @deprecated Use visualLevel instead.
-   */
-  @property({ reflect: true }) public accessor size: JourneyHeaderSize = isLean() ? 's' : 'm';
-
-  private _language = new SbbLanguageController(this);
+  private _language = new SbbLanguageController(this).withHandler(() => this._setAriaLabel());
 
   public constructor() {
     super();
 
     this.level = '3' as this['level'];
-    this.visualLevel = sizeToLevel.get(this.size) ?? null;
+    this.visualLevel = '5' as this['visualLevel'];
   }
 
-  protected override willUpdate(changedProperties: PropertyValues<this>): void {
-    super.willUpdate(changedProperties);
+  public override requestUpdate(
+    name?: PropertyKey,
+    oldValue?: unknown,
+    options?: PropertyDeclaration,
+  ): void {
+    super.requestUpdate(name, oldValue, options);
 
-    if (changedProperties.has('size')) {
-      this.visualLevel = sizeToLevel.get(this.size) ?? null;
+    if (name === 'origin' || name === 'destination' || name === 'roundTrip') {
+      this._setAriaLabel();
     }
   }
 
-  protected override render(): TemplateResult {
-    const iconName = this.roundTrip ? 'arrows-long-right-left-small' : 'arrow-long-right-small';
-    const a11yString = `${i18nConnectionFrom[this._language.current]} ${this.origin} ${i18nConnectionTo[this._language.current]} ${this.destination} ${this.roundTrip ? i18nConnectionRoundtrip(this.origin)[this._language.current] : ''}`;
+  private _setAriaLabel(): void {
+    this.internals.ariaLabel = `${i18nConnectionFrom[this._language.current]} ${this.origin} ${i18nConnectionTo[this._language.current]} ${this.destination} ${this.roundTrip ? i18nConnectionRoundtrip(this.origin)[this._language.current] : ''}`;
+  }
 
+  protected override render(): TemplateResult {
     return html`
-      <span class="sbb-journey-header" aria-hidden="true">
-        <span class="sbb-journey-header__origin">${this.origin}</span>
-        <sbb-icon name=${iconName}></sbb-icon>
-        <span class="sbb-journey-header__destination">${this.destination}</span>
-      </span>
-      <sbb-screen-reader-only>${a11yString}</sbb-screen-reader-only>
+      ${this.origin}
+      <sbb-icon
+        name=${this.roundTrip ? 'arrows-long-right-left-small' : 'arrow-long-right-small'}
+      ></sbb-icon>
+      ${this.destination}
     `;
   }
 }

--- a/src/elements/journey-header/journey-header.scss
+++ b/src/elements/journey-header/journey-header.scss
@@ -3,7 +3,17 @@
 :host {
   --sbb-journey-header-gap: var(--sbb-spacing-fixed-1x);
 
-  display: block;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: var(--sbb-journey-header-gap);
+  width: fit-content;
+}
+
+:host(:dir(rtl)) {
+  sbb-icon {
+    rotate: -180deg;
+  }
 }
 
 :host([id]) {
@@ -17,22 +27,4 @@
 sbb-icon {
   // Avoid layout shift after loading the icon
   min-width: var(--sbb-size-icon-ui-small);
-}
-
-.sbb-journey-header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  column-gap: var(--sbb-journey-header-gap);
-  width: fit-content;
-
-  &:dir(rtl) {
-    sbb-icon {
-      transform: rotate(-180deg);
-    }
-  }
-
-  > span {
-    max-width: 100%;
-  }
 }

--- a/src/elements/journey-header/journey-header.snapshot.spec.ts
+++ b/src/elements/journey-header/journey-header.snapshot.spec.ts
@@ -25,14 +25,14 @@ describe(`sbb-journey-header`, () => {
     });
   });
 
-  describe('renders H1 L-sized round-trip negative', () => {
+  describe('renders visual-level 4 round-trip negative', () => {
     let element: SbbJourneyHeaderElement;
 
     beforeEach(async () => {
       element = await fixture(
         html`<sbb-journey-header
           level="1"
-          size="l"
+          visual-level="4"
           round-trip
           origin="B"
           destination="C"

--- a/src/elements/journey-header/journey-header.spec.ts
+++ b/src/elements/journey-header/journey-header.spec.ts
@@ -1,7 +1,8 @@
-import { assert } from '@open-wc/testing';
+import { assert, expect } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
 
-import { fixture } from '../core/testing/private.ts';
+import { elementInternalsSpy, fixture } from '../core/testing/private.ts';
+import { waitForLitRender } from '../core/testing.ts';
 
 import { SbbJourneyHeaderElement } from './journey-header.component.ts';
 
@@ -9,6 +10,7 @@ import '../journey-header.ts';
 
 describe(`sbb-journey-header`, () => {
   let element: SbbJourneyHeaderElement;
+  const elementInternals = elementInternalsSpy();
 
   beforeEach(async () => {
     element = await fixture(html`<sbb-journey-header></sbb-journey-header>`);
@@ -16,5 +18,55 @@ describe(`sbb-journey-header`, () => {
 
   it('renders', async () => {
     assert.instanceOf(element, SbbJourneyHeaderElement);
+  });
+
+  describe('aria label', () => {
+    beforeEach(async () => {
+      element = await fixture(
+        html`<sbb-journey-header origin="Bern" destination="Zurich"></sbb-journey-header>`,
+      );
+    });
+
+    it('should set aria label with origin and destination', () => {
+      expect(elementInternals.get(element)?.ariaLabel).to.include('Bern');
+      expect(elementInternals.get(element)?.ariaLabel).to.include('Zurich');
+    });
+
+    it('should not include round-trip text when roundTrip is false', async () => {
+      // Round-trip suffix (e.g. "and back to") should not be present
+      expect(elementInternals.get(element)?.ariaLabel).not.to.include('back to');
+    });
+
+    it('should update aria label when origin changes', async () => {
+      element.origin = 'Basel';
+
+      expect(elementInternals.get(element)?.ariaLabel).to.include('Basel');
+      expect(elementInternals.get(element)?.ariaLabel).not.to.include('Bern');
+    });
+
+    it('should update aria label when destination changes', async () => {
+      element.destination = 'Luzern';
+
+      expect(elementInternals.get(element)?.ariaLabel).to.include('Luzern');
+      expect(elementInternals.get(element)?.ariaLabel).not.to.include('Zurich');
+    });
+
+    it('should include round-trip text when roundTrip is true', async () => {
+      element.roundTrip = true;
+
+      expect(elementInternals.get(element)?.ariaLabel).to.include('Bern');
+      expect(elementInternals.get(element)?.ariaLabel).to.include('Zurich');
+      expect(elementInternals.get(element)?.ariaLabel).to.include('back to');
+    });
+
+    it('should update aria label on language change to German', async () => {
+      const originalLang = document.documentElement.lang;
+      document.documentElement.lang = 'de';
+      await waitForLitRender(element);
+
+      expect(elementInternals.get(element)?.ariaLabel).to.equal('Verbindung von Bern nach Zurich ');
+
+      document.documentElement.lang = originalLang;
+    });
   });
 });

--- a/src/elements/journey-header/journey-header.stories.ts
+++ b/src/elements/journey-header/journey-header.stories.ts
@@ -5,7 +5,9 @@ import type { InputType } from 'storybook/internal/types';
 
 import { sbbSpread } from '../../storybook/helpers/spread.ts';
 
+import type { SbbJourneyHeaderElement } from './journey-header.component.ts';
 import readme from './readme.md?raw';
+
 import '../journey-header.ts';
 
 const origin: InputType = {
@@ -30,14 +32,14 @@ const level: InputType = {
   control: {
     type: 'inline-radio',
   },
-  options: ['1', '2', '3', '4', '5', '6'],
+  options: ['1', '2', '3', '4', '5', '6'] satisfies SbbJourneyHeaderElement['level'][],
 };
 
-const size: InputType = {
+const visualLevel: InputType = {
   control: {
     type: 'inline-radio',
   },
-  options: ['s', 'm', 'l'],
+  options: ['1', '2', '3', '4', '5', '6'] satisfies SbbJourneyHeaderElement['visualLevel'][],
 };
 
 const negative: InputType = {
@@ -51,7 +53,7 @@ const defaultArgTypes: ArgTypes = {
   destination,
   'round-trip': roundTrip,
   level,
-  size,
+  'visual-level': visualLevel,
   negative,
 };
 
@@ -60,32 +62,44 @@ const defaultArgs: Args = {
   destination: 'Loèche-les-Bains',
   'round-trip': false,
   level: level.options![2],
-  size: size.options![1],
+  'visual-level': visualLevel.options![4],
   negative: false,
 };
 
 const Template = (args: Args): TemplateResult =>
   html`<sbb-journey-header ${sbbSpread(args)}></sbb-journey-header>`;
 
-export const SizeM: StoryObj = {
+export const Default: StoryObj = {
   render: Template,
   argTypes: defaultArgTypes,
   args: { ...defaultArgs },
 };
 
-export const SizeMRoundTrip: StoryObj = {
+export const VisualLevel4: StoryObj = {
+  render: Template,
+  argTypes: defaultArgTypes,
+  args: { ...defaultArgs, 'visual-level': visualLevel.options![3] },
+};
+
+export const VisualLevel6: StoryObj = {
+  render: Template,
+  argTypes: defaultArgTypes,
+  args: { ...defaultArgs, 'visual-level': visualLevel.options![5] },
+};
+
+export const RoundTrip: StoryObj = {
   render: Template,
   argTypes: defaultArgTypes,
   args: { ...defaultArgs, 'round-trip': true },
 };
 
-export const SizeMNegative: StoryObj = {
+export const Negative: StoryObj = {
   render: Template,
   argTypes: defaultArgTypes,
   args: { ...defaultArgs, negative: true },
 };
 
-export const SizeMRoundTripShortText: StoryObj = {
+export const ShortText: StoryObj = {
   render: Template,
   argTypes: defaultArgTypes,
   args: {
@@ -93,42 +107,6 @@ export const SizeMRoundTripShortText: StoryObj = {
     origin: 'Bern',
     destination: 'Thun',
     'round-trip': true,
-  },
-};
-
-export const SizeL: StoryObj = {
-  render: Template,
-  argTypes: defaultArgTypes,
-  args: { ...defaultArgs, size: size.options![2] },
-};
-
-export const SizeLRoundTripShortText: StoryObj = {
-  render: Template,
-  argTypes: defaultArgTypes,
-  args: {
-    ...defaultArgs,
-    origin: 'Bern',
-    destination: 'Thun',
-    'round-trip': true,
-    size: size.options![2],
-  },
-};
-
-export const SizeS: StoryObj = {
-  render: Template,
-  argTypes: defaultArgTypes,
-  args: { ...defaultArgs, size: size.options![0] },
-};
-
-export const SizeSRoundTripShortText: StoryObj = {
-  render: Template,
-  argTypes: defaultArgTypes,
-  args: {
-    ...defaultArgs,
-    origin: 'Bern',
-    destination: 'Thun',
-    'round-trip': true,
-    size: size.options![0],
   },
 };
 

--- a/src/elements/journey-header/journey-header.visual.spec.ts
+++ b/src/elements/journey-header/journey-header.visual.spec.ts
@@ -8,16 +8,24 @@ import {
 } from '../core/testing/private.ts';
 
 import '../journey-header.ts';
+import type { SbbJourneyHeaderElement } from './journey-header.component.ts';
 
 describe(`sbb-journey-header`, () => {
   let root: HTMLElement;
 
   const cases = {
-    negative: [false, true],
-    roundTrip: [false, true],
+    negative: [false, true] satisfies SbbJourneyHeaderElement['negative'][],
+    roundTrip: [false, true] satisfies SbbJourneyHeaderElement['roundTrip'][],
   };
 
-  const sizeCases = ['s', 'm', 'l'];
+  const visualLevelCases = [
+    '1',
+    '2',
+    '3',
+    '4',
+    '5',
+    '6',
+  ] satisfies SbbJourneyHeaderElement['visualLevel'][];
 
   describeViewports({ viewports: ['zero', 'large'] }, () => {
     describeEach(cases, ({ negative, roundTrip }) => {
@@ -41,15 +49,15 @@ describe(`sbb-journey-header`, () => {
       );
     });
 
-    for (const size of sizeCases) {
+    for (const visualLevel of visualLevelCases) {
       it(
-        `size=${size}`,
+        `visualLevel=${visualLevel}`,
         visualDiffDefault.with(async (setup) => {
           await setup.withFixture(
             html`<sbb-journey-header
               origin="Origin"
               destination="Destination"
-              size=${size}
+              visual-level=${visualLevel}
             ></sbb-journey-header>`,
           );
         }),

--- a/src/elements/journey-header/readme.md
+++ b/src/elements/journey-header/readme.md
@@ -1,4 +1,5 @@
-The `<sbb-journey-header>` is a component used to display the journey's details.
+The `<sbb-journey-header>` element inherits from the `<sbb-title>` component,
+which is used to display the title of the journey.
 
 The component has two required properties, named `origin` and `destination`,
 which represents the two ends of the journey.
@@ -17,16 +18,12 @@ The component has a `level` property, which is passed to its inner `<sbb-title>`
 it is rendered as a heading from `h1` to `h6`. Default `level` is `3`.
 It also has a `visualLevel` property, which can be used in scenarios
 where the visual representation needs to be different from the semantic meaning of the title level.
+The default `visualLevel` is `5`.
 
-The component also has three sizes, named `s`, `m` (default) and `l`, and a `negative` background variant.
-
-If not set, the default value of `visualLevel` depends on the value of the `size`,
-respectively `6` for `s`, `5` for `m` and `4` for `l`.
+The component also has a `negative` background variant.
 
 ```html
-<sbb-journey-header origin="Point A" destination="Point B" size="s"></sbb-journey-header>
-
-<sbb-journey-header origin="Point A" destination="Point B" size="l"></sbb-journey-header>
+<sbb-journey-header origin="Point A" destination="Point B" visual-level="4"></sbb-journey-header>
 
 <sbb-journey-header origin="Point A" destination="Point B" level="5"></sbb-journey-header>
 
@@ -35,18 +32,18 @@ respectively `6` for `s`, `5` for `m` and `4` for `l`.
 
 ## Accessibility
 
-The component has some hidden elements in order to be correctly read from a screen-reader.
+The component sets an `aria-label` on its host element which is read by screen readers to provide a description of the journey.
 
-The following example will be read as (locale: ENG): `Connection from Point A to Point B.`.
+The following example will be read as (locale: EN): `Connection from Point A to Point B.`.
 
 ```html
 <sbb-journey-header origin="Point A" destination="Point B"></sbb-journey-header>
 ```
 
-The following one will be read as (locale: ENG): `Connection from Point A to Point B and back to Point A.`.
+The following one will be read as (locale: EN): `Connection from Point A to Point B and back to Point A.`.
 
 ```html
-<sbb-journey-header origin="Point A" destination="Point B" round-trip="true"></sbb-journey-header>
+<sbb-journey-header origin="Point A" destination="Point B" round-trip></sbb-journey-header>
 ```
 
 <!-- Auto Generated Below -->
@@ -57,12 +54,11 @@ The following one will be read as (locale: ENG): `Connection from Point A to Poi
 
 #### Properties
 
-| Name          | Attribute      | Privacy | Type                    | Default            | Description                                                                                     |
-| ------------- | -------------- | ------- | ----------------------- | ------------------ | ----------------------------------------------------------------------------------------------- |
-| `destination` | `destination`  | public  | `string`                | `''`               | Destination location for the journey header.                                                    |
-| `level`       | `level`        | public  | `SbbTitleLevel`         | `'3'`              | Title level                                                                                     |
-| `negative`    | `negative`     | public  | `boolean`               | `false`            | Negative coloring variant flag.                                                                 |
-| `origin`      | `origin`       | public  | `string`                | `''`               | Origin location for the journey header.                                                         |
-| `roundTrip`   | `round-trip`   | public  | `boolean`               | `false`            | Whether the journey is a round trip. If so, the icon changes to a round-trip one.               |
-| `size`        | `size`         | public  | `JourneyHeaderSize`     | `'m' / 's' (lean)` | Journey header size, either s, m or l.<br><strong>Deprecated</strong>: Use visualLevel instead. |
-| `visualLevel` | `visual-level` | public  | `SbbTitleLevel \| null` | `null`             | Visual level for the title.                                                                     |
+| Name          | Attribute      | Privacy | Type                    | Default | Description                                                                       |
+| ------------- | -------------- | ------- | ----------------------- | ------- | --------------------------------------------------------------------------------- |
+| `destination` | `destination`  | public  | `string`                | `''`    | Destination location for the journey header.                                      |
+| `level`       | `level`        | public  | `SbbTitleLevel`         | `'3'`   | Title level                                                                       |
+| `negative`    | `negative`     | public  | `boolean`               | `false` | Negative coloring variant flag.                                                   |
+| `origin`      | `origin`       | public  | `string`                | `''`    | Origin location for the journey header.                                           |
+| `roundTrip`   | `round-trip`   | public  | `boolean`               | `false` | Whether the journey is a round trip. If so, the icon changes to a round-trip one. |
+| `visualLevel` | `visual-level` | public  | `SbbTitleLevel \| null` | `'5'`   | Visual level for the title.                                                       |


### PR DESCRIPTION
BREAKING CHANGE: The `size` property of the `sbb-journey-header` has been removed. Use the `visualLevel` property to set the font-size by using the following mapping from `size` to `visualLevel`: `s` -> 6, `m` -> 5, `l` > 4.