### PR TITLE
refactor: merge styles in SbbElement

### DIFF
--- a/src/elements-experimental/autocomplete-grid/autocomplete-grid-option/autocomplete-grid-option.component.ts
+++ b/src/elements-experimental/autocomplete-grid/autocomplete-grid-option/autocomplete-grid-option.component.ts
@@ -18,7 +18,7 @@ export const autocompleteGridOptionId: string = `sbb-autocomplete-grid-option`;
 export class SbbAutocompleteGridOptionElement<T = string> extends SbbOptionBaseElement<T> {
   public static override readonly elementName: string = 'sbb-autocomplete-grid-option';
   public static override readonly role = 'gridcell';
-  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
 
   protected optionId = autocompleteGridOptionId;
 

--- a/src/elements/breadcrumb/breadcrumb-group/breadcrumb-group.component.ts
+++ b/src/elements/breadcrumb/breadcrumb-group/breadcrumb-group.component.ts
@@ -40,11 +40,7 @@ export class SbbBreadcrumbGroupElement extends SbbNamedSlotListMixin<
   public static override readonly elementName: string = 'sbb-breadcrumb-group';
   public static override elementDependencies: SbbElementType[] = [SbbIconElement];
   public static override readonly role = 'navigation';
-  public static override styles: CSSResultGroup = [
-    super.styles ?? [],
-    boxSizingStyles,
-    unsafeCSS(style),
-  ];
+  public static override styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
   protected override readonly listChildLocalNames = ['sbb-breadcrumb'];
 
   /** The state of the breadcrumb group. */

--- a/src/elements/button/accent-button-link/accent-button-link.component.ts
+++ b/src/elements/button/accent-button-link/accent-button-link.component.ts
@@ -14,7 +14,7 @@ export class SbbAccentButtonLinkElement extends SbbButtonCommonElementMixin(
   SbbDisabledInteractiveMixin(SbbDisabledMixin(SbbLinkBaseElement)),
 ) {
   public static override readonly elementName: string = 'sbb-accent-button-link';
-  public static override styles: CSSResultGroup = [super.styles ?? [], buttonAccentStyle];
+  public static override styles: CSSResultGroup = [buttonAccentStyle];
 }
 
 declare global {

--- a/src/elements/button/accent-button-static/accent-button-static.component.ts
+++ b/src/elements/button/accent-button-static/accent-button-static.component.ts
@@ -14,7 +14,7 @@ export class SbbAccentButtonStaticElement extends SbbButtonCommonElementMixin(
   SbbDisabledMixin(SbbActionBaseElement),
 ) {
   public static override readonly elementName: string = 'sbb-accent-button-static';
-  public static override styles: CSSResultGroup = [super.styles ?? [], buttonAccentStyle];
+  public static override styles: CSSResultGroup = [buttonAccentStyle];
 }
 
 declare global {

--- a/src/elements/button/accent-button/accent-button.component.ts
+++ b/src/elements/button/accent-button/accent-button.component.ts
@@ -14,7 +14,7 @@ export class SbbAccentButtonElement extends SbbButtonCommonElementMixin(
   SbbDisabledTabIndexActionMixin(SbbButtonBaseElement),
 ) {
   public static override readonly elementName: string = 'sbb-accent-button';
-  public static override styles: CSSResultGroup = [super.styles ?? [], buttonAccentStyle];
+  public static override styles: CSSResultGroup = [buttonAccentStyle];
 }
 
 declare global {

--- a/src/elements/button/button-link/button-link.component.ts
+++ b/src/elements/button/button-link/button-link.component.ts
@@ -14,7 +14,7 @@ export class SbbButtonLinkElement extends SbbButtonCommonElementMixin(
   SbbDisabledInteractiveMixin(SbbDisabledMixin(SbbLinkBaseElement)),
 ) {
   public static override readonly elementName: string = 'sbb-button-link';
-  public static override styles: CSSResultGroup = [super.styles ?? [], buttonPrimaryStyle];
+  public static override styles: CSSResultGroup = [buttonPrimaryStyle];
 }
 
 declare global {

--- a/src/elements/button/button-static/button-static.component.ts
+++ b/src/elements/button/button-static/button-static.component.ts
@@ -14,7 +14,7 @@ export class SbbButtonStaticElement extends SbbButtonCommonElementMixin(
   SbbDisabledMixin(SbbActionBaseElement),
 ) {
   public static override readonly elementName: string = 'sbb-button-static';
-  public static override styles: CSSResultGroup = [super.styles ?? [], buttonPrimaryStyle];
+  public static override styles: CSSResultGroup = [buttonPrimaryStyle];
 }
 
 declare global {

--- a/src/elements/button/button/button.component.ts
+++ b/src/elements/button/button/button.component.ts
@@ -14,7 +14,7 @@ export class SbbButtonElement extends SbbButtonCommonElementMixin(
   SbbDisabledTabIndexActionMixin(SbbButtonBaseElement),
 ) {
   public static override readonly elementName: string = 'sbb-button';
-  public static override styles: CSSResultGroup = [super.styles ?? [], buttonPrimaryStyle];
+  public static override styles: CSSResultGroup = [buttonPrimaryStyle];
 }
 
 declare global {

--- a/src/elements/button/common/button-common.ts
+++ b/src/elements/button/common/button-common.ts
@@ -50,11 +50,7 @@ export const SbbButtonCommonElementMixin = <T extends AbstractConstructor<SbbAct
     extends baseClass
     implements Partial<SbbButtonCommonElementMixinType>
   {
-    public static styles: CSSResultGroup = [
-      (baseClass as unknown as { styles: CSSResultGroup }).styles ?? [],
-      boxSizingStyles,
-      unsafeCSS(style),
-    ];
+    public static styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
     /**
      * Size variant, either l, m or s.
      * @default 'm' / 's' (lean)

--- a/src/elements/button/common/button-common.ts
+++ b/src/elements/button/common/button-common.ts
@@ -44,10 +44,8 @@ export declare class SbbButtonCommonElementMixinType extends SbbNegativeMixin(
 export const SbbButtonCommonElementMixin = <T extends AbstractConstructor<SbbActionBaseElement>>(
   superClass: T,
 ): AbstractConstructor<SbbButtonCommonElementMixinType> & T => {
-  const baseClass = SbbNegativeMixin(SbbIconNameMixin(superClass));
-
   abstract class SbbButtonCommonElementClass
-    extends baseClass
+    extends SbbNegativeMixin(SbbIconNameMixin(superClass))
     implements Partial<SbbButtonCommonElementMixinType>
   {
     public static styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];

--- a/src/elements/button/mini-button-group/mini-button-group.component.ts
+++ b/src/elements/button/mini-button-group/mini-button-group.component.ts
@@ -32,11 +32,7 @@ export class SbbMiniButtonGroupElement extends SbbNegativeMixin(
   SbbNamedSlotListMixin<SbbMiniButtonElement, typeof SbbElement>(SbbElement),
 ) {
   public static override readonly elementName: string = 'sbb-mini-button-group';
-  public static override styles: CSSResultGroup = [
-    super.styles ?? [],
-    boxSizingStyles,
-    unsafeCSS(style),
-  ];
+  public static override styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
   protected override readonly listChildLocalNames = [
     'sbb-mini-button',
     'sbb-mini-button-link',

--- a/src/elements/button/secondary-button-link/secondary-button-link.component.ts
+++ b/src/elements/button/secondary-button-link/secondary-button-link.component.ts
@@ -14,7 +14,7 @@ export class SbbSecondaryButtonLinkElement extends SbbButtonCommonElementMixin(
   SbbDisabledInteractiveMixin(SbbDisabledMixin(SbbLinkBaseElement)),
 ) {
   public static override readonly elementName: string = 'sbb-secondary-button-link';
-  public static override styles: CSSResultGroup = [super.styles ?? [], buttonSecondaryStyle];
+  public static override styles: CSSResultGroup = [buttonSecondaryStyle];
 }
 
 declare global {

--- a/src/elements/button/secondary-button-static/secondary-button-static.component.ts
+++ b/src/elements/button/secondary-button-static/secondary-button-static.component.ts
@@ -14,7 +14,7 @@ export class SbbSecondaryButtonStaticElement extends SbbButtonCommonElementMixin
   SbbDisabledMixin(SbbActionBaseElement),
 ) {
   public static override readonly elementName: string = 'sbb-secondary-button-static';
-  public static override styles: CSSResultGroup = [super.styles ?? [], buttonSecondaryStyle];
+  public static override styles: CSSResultGroup = [buttonSecondaryStyle];
 }
 
 declare global {

--- a/src/elements/button/secondary-button/secondary-button.component.ts
+++ b/src/elements/button/secondary-button/secondary-button.component.ts
@@ -14,7 +14,7 @@ export class SbbSecondaryButtonElement extends SbbButtonCommonElementMixin(
   SbbDisabledTabIndexActionMixin(SbbButtonBaseElement),
 ) {
   public static override readonly elementName: string = 'sbb-secondary-button';
-  public static override styles: CSSResultGroup = [super.styles ?? [], buttonSecondaryStyle];
+  public static override styles: CSSResultGroup = [buttonSecondaryStyle];
 }
 
 declare global {

--- a/src/elements/button/transparent-button-link/transparent-button-link.component.ts
+++ b/src/elements/button/transparent-button-link/transparent-button-link.component.ts
@@ -14,7 +14,7 @@ export class SbbTransparentButtonLinkElement extends SbbButtonCommonElementMixin
   SbbDisabledInteractiveMixin(SbbDisabledMixin(SbbLinkBaseElement)),
 ) {
   public static override readonly elementName: string = 'sbb-transparent-button-link';
-  public static override styles: CSSResultGroup = [super.styles ?? [], buttonTransparentStyle];
+  public static override styles: CSSResultGroup = [buttonTransparentStyle];
 }
 
 declare global {

--- a/src/elements/button/transparent-button-static/transparent-button-static.component.ts
+++ b/src/elements/button/transparent-button-static/transparent-button-static.component.ts
@@ -14,7 +14,7 @@ export class SbbTransparentButtonStaticElement extends SbbButtonCommonElementMix
   SbbDisabledMixin(SbbActionBaseElement),
 ) {
   public static override readonly elementName: string = 'sbb-transparent-button-static';
-  public static override styles: CSSResultGroup = [super.styles ?? [], buttonTransparentStyle];
+  public static override styles: CSSResultGroup = [buttonTransparentStyle];
 }
 
 declare global {

--- a/src/elements/button/transparent-button/transparent-button.component.ts
+++ b/src/elements/button/transparent-button/transparent-button.component.ts
@@ -14,7 +14,7 @@ export class SbbTransparentButtonElement extends SbbButtonCommonElementMixin(
   SbbDisabledTabIndexActionMixin(SbbButtonBaseElement),
 ) {
   public static override readonly elementName: string = 'sbb-transparent-button';
-  public static override styles: CSSResultGroup = [super.styles ?? [], buttonTransparentStyle];
+  public static override styles: CSSResultGroup = [buttonTransparentStyle];
 }
 
 declare global {

--- a/src/elements/calendar/calendar-day/calendar-day.component.ts
+++ b/src/elements/calendar/calendar-day/calendar-day.component.ts
@@ -13,7 +13,7 @@ import style from './calendar-day.scss?inline';
  */
 export class SbbCalendarDayElement<T = Date> extends SbbCalendarCellBaseElement<T> {
   public static override readonly elementName: string = 'sbb-calendar-day';
-  public static override styles: CSSResultGroup = [super.styles ?? [], unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
 
   @property()
   public override set slot(value: string) {

--- a/src/elements/card/common/card-action-common.ts
+++ b/src/elements/card/common/card-action-common.ts
@@ -31,7 +31,6 @@ export const SbbCardActionCommonElementMixin = <
     implements Partial<SbbCardActionCommonElementMixinType>
   {
     public static styles: CSSResultGroup = [
-      (superClass as unknown as { styles: CSSResultGroup }).styles ?? [],
       boxSizingStyles,
       screenReaderOnlyStyles,
       unsafeCSS(style),

--- a/src/elements/checkbox-panel/checkbox-panel.component.ts
+++ b/src/elements/checkbox-panel/checkbox-panel.component.ts
@@ -33,7 +33,7 @@ export class SbbCheckboxPanelElement<T = string> extends SbbPanelMixin(
 ) {
   public static override readonly elementName: string = 'sbb-checkbox-panel';
   public static override elementDependencies: SbbElementType[] = [SbbVisualCheckboxElement];
-  public static override styles: CSSResultGroup = [super.styles ?? [], screenReaderOnlyStyles];
+  public static override styles: CSSResultGroup = [screenReaderOnlyStyles];
 
   /** Value of the form element. */
   @property()

--- a/src/elements/checkbox/checkbox.component.ts
+++ b/src/elements/checkbox/checkbox.component.ts
@@ -28,7 +28,7 @@ export class SbbCheckboxElement<T = string> extends SbbIconNameMixin(
 ) {
   public static override readonly elementName: string = 'sbb-checkbox';
   public static override elementDependencies: SbbElementType[] = [SbbVisualCheckboxElement];
-  public static override styles: CSSResultGroup = [super.styles ?? [], unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
 
   /** Value of the form element. */
   @property()

--- a/src/elements/checkbox/common/checkbox-common.ts
+++ b/src/elements/checkbox/common/checkbox-common.ts
@@ -26,10 +26,8 @@ export declare abstract class SbbCheckboxCommonElementMixinType extends SbbFormA
 export const SbbCheckboxCommonElementMixin = <T extends AbstractConstructor<SbbElement>>(
   superClass: T,
 ): AbstractConstructor<SbbCheckboxCommonElementMixinType> & T => {
-  const baseClass = SbbFormAssociatedCheckboxMixin(superClass);
-
   abstract class SbbCheckboxCommonElement
-    extends baseClass
+    extends SbbFormAssociatedCheckboxMixin(superClass)
     implements Partial<SbbCheckboxCommonElementMixinType>
   {
     public static styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];

--- a/src/elements/checkbox/common/checkbox-common.ts
+++ b/src/elements/checkbox/common/checkbox-common.ts
@@ -32,11 +32,7 @@ export const SbbCheckboxCommonElementMixin = <T extends AbstractConstructor<SbbE
     extends baseClass
     implements Partial<SbbCheckboxCommonElementMixinType>
   {
-    public static styles: CSSResultGroup = [
-      (baseClass as unknown as { styles: CSSResultGroup }).styles ?? [],
-      boxSizingStyles,
-      unsafeCSS(style),
-    ];
+    public static styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
 
     /** Whether the checkbox is indeterminate. */
     @forceType()

--- a/src/elements/core/base-elements/element.ts
+++ b/src/elements/core/base-elements/element.ts
@@ -1,4 +1,6 @@
 import {
+  type CSSResultGroup,
+  type CSSResultOrNative,
   isServer,
   LitElement,
   type PropertyDeclaration,
@@ -458,6 +460,28 @@ export class SbbElement extends LitElement {
         `The custom element with name "${this.elementName}" is already defined. Skipping.`,
       );
     }
+  }
+
+  /**
+   * Collects `styles` from every class in the prototype chain (using `Object.hasOwn`)
+   * and merges them in top-down order. This means each class/mixin only needs to declare
+   * its **own** styles — there is no need to reference `super.styles`.
+   *
+   * Lit's default behaviour already walks the chain, but fails for mixins where
+   * `super.styles` resolves to the wrong class. This override fixes that.
+   */
+  protected static override finalizeStyles(_styles: CSSResultGroup): CSSResultOrNative[] {
+    const collected: CSSResultGroup[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let ctor: typeof SbbElement | null = this;
+    while (ctor && ctor !== LitElement) {
+      if (Object.hasOwn(ctor, 'styles') && ctor.styles) {
+        collected.unshift(ctor.styles);
+      }
+      ctor = Object.getPrototypeOf(ctor) as typeof SbbElement | null;
+    }
+    // Call LitElement.finalizeStyles which handles dedup & adoption
+    return super.finalizeStyles(collected);
   }
 
   protected override createRenderRoot(): HTMLElement | DocumentFragment {

--- a/src/elements/core/mixins/named-slot-list-mixin.ts
+++ b/src/elements/core/mixins/named-slot-list-mixin.ts
@@ -68,10 +68,7 @@ export const SbbNamedSlotListMixin = <
     implements Partial<SbbNamedSlotListMixinType<C>>
   {
     public static override elementDependencies: SbbElementType[] = [];
-    public static styles: CSSResultGroup = [
-      (superClass as unknown as { styles: CSSResultGroup }).styles ?? [],
-      screenReaderOnlyStyles,
-    ];
+    public static styles: CSSResultGroup = [screenReaderOnlyStyles];
     /** A list of lower-cased tag names to match against. (e.g. `sbb-link`) */
     protected abstract readonly listChildLocalNames: string[];
 

--- a/src/elements/core/mixins/panel-mixin.ts
+++ b/src/elements/core/mixins/panel-mixin.ts
@@ -32,11 +32,7 @@ export const SbbPanelMixin = <T extends AbstractConstructor<LitElement & SbbPane
   superClass: T,
 ): AbstractConstructor<SbbPanelMixinType> & T => {
   abstract class SbbPanelElement extends superClass implements SbbPanelMixinType {
-    public static styles: CSSResultGroup = [
-      (superClass as unknown as { styles: CSSResultGroup }).styles ?? [],
-      boxSizingStyles,
-      unsafeCSS(style),
-    ];
+    public static styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
 
     /** The background color of the panel. */
     @property({ reflect: true }) public accessor color: 'white' | 'milk' = 'white';

--- a/src/elements/datepicker/datepicker/datepicker.component.ts
+++ b/src/elements/datepicker/datepicker/datepicker.component.ts
@@ -39,7 +39,7 @@ export class SbbDatepickerElement<T = Date>
 {
   public static override readonly elementName: string = 'sbb-datepicker';
   public static override elementDependencies: SbbElementType[] = [SbbCalendarElement];
-  public static override styles: CSSResultGroup = [super.styles, screenReaderOnlyStyles];
+  public static override styles: CSSResultGroup = [screenReaderOnlyStyles];
   public static readonly sbbDateInputAssociated = true;
 
   /** If set to true, two months are displayed. */

--- a/src/elements/datepicker/datepicker/datepicker.component.ts
+++ b/src/elements/datepicker/datepicker/datepicker.component.ts
@@ -39,10 +39,7 @@ export class SbbDatepickerElement<T = Date>
 {
   public static override readonly elementName: string = 'sbb-datepicker';
   public static override elementDependencies: SbbElementType[] = [SbbCalendarElement];
-  public static override styles: CSSResultGroup = [
-    SbbPopoverBaseElement.styles,
-    screenReaderOnlyStyles,
-  ];
+  public static override styles: CSSResultGroup = [super.styles, screenReaderOnlyStyles];
   public static readonly sbbDateInputAssociated = true;
 
   /** If set to true, two months are displayed. */

--- a/src/elements/dialog/dialog-actions/dialog-actions.component.ts
+++ b/src/elements/dialog/dialog-actions/dialog-actions.component.ts
@@ -11,7 +11,7 @@ import style from './dialog-actions.scss?inline';
  */
 export class SbbDialogActionsElement extends SbbActionGroupElement {
   public static override readonly elementName: string = 'sbb-dialog-actions';
-  public static override styles: CSSResultGroup = [SbbActionGroupElement.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
 }
 
 declare global {

--- a/src/elements/dialog/dialog-actions/dialog-actions.component.ts
+++ b/src/elements/dialog/dialog-actions/dialog-actions.component.ts
@@ -11,7 +11,7 @@ import style from './dialog-actions.scss?inline';
  */
 export class SbbDialogActionsElement extends SbbActionGroupElement {
   public static override readonly elementName: string = 'sbb-dialog-actions';
-  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
 }
 
 declare global {

--- a/src/elements/dialog/dialog-close-button/dialog-close-button.component.ts
+++ b/src/elements/dialog/dialog-close-button/dialog-close-button.component.ts
@@ -13,10 +13,7 @@ import style from './dialog-close-button.scss?inline';
  */
 export class SbbDialogCloseButtonElement extends SbbSecondaryButtonElement {
   public static override readonly elementName: string = 'sbb-dialog-close-button';
-  public static override styles: CSSResultGroup = [
-    SbbSecondaryButtonElement.styles,
-    unsafeCSS(style),
-  ];
+  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
 
   private _languageController = new SbbLanguageController(this);
 

--- a/src/elements/dialog/dialog-close-button/dialog-close-button.component.ts
+++ b/src/elements/dialog/dialog-close-button/dialog-close-button.component.ts
@@ -13,7 +13,7 @@ import style from './dialog-close-button.scss?inline';
  */
 export class SbbDialogCloseButtonElement extends SbbSecondaryButtonElement {
   public static override readonly elementName: string = 'sbb-dialog-close-button';
-  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
 
   private _languageController = new SbbLanguageController(this);
 

--- a/src/elements/dialog/dialog-title/dialog-title.component.ts
+++ b/src/elements/dialog/dialog-title/dialog-title.component.ts
@@ -12,7 +12,7 @@ import style from './dialog-title.scss?inline';
  */
 export class SbbDialogTitleElement extends SbbNegativeMixin(SbbTitleBase) {
   public static override readonly elementName: string = 'sbb-dialog-title';
-  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
 
   public constructor() {
     super();

--- a/src/elements/dialog/dialog-title/dialog-title.component.ts
+++ b/src/elements/dialog/dialog-title/dialog-title.component.ts
@@ -12,7 +12,7 @@ import style from './dialog-title.scss?inline';
  */
 export class SbbDialogTitleElement extends SbbNegativeMixin(SbbTitleBase) {
   public static override readonly elementName: string = 'sbb-dialog-title';
-  public static override styles: CSSResultGroup = [SbbTitleBase.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
 
   public constructor() {
     super();

--- a/src/elements/form-field/form-field-text-counter/form-field-text-counter.component.ts
+++ b/src/elements/form-field/form-field-text-counter/form-field-text-counter.component.ts
@@ -1,4 +1,4 @@
-import type { CSSResultGroup, TemplateResult } from 'lit';
+import type { TemplateResult } from 'lit';
 import { html } from 'lit';
 import { state } from 'lit/decorators.js';
 
@@ -16,7 +16,6 @@ const percentagesToRead = [100, 50, 25, 10, 0];
  */
 export class SbbFormFieldTextCounterElement extends SbbHintElement {
   public static override readonly elementName: string = 'sbb-form-field-text-counter';
-  public static override styles: CSSResultGroup = [super.styles];
 
   @state() private accessor _remainingCharacters: number = 0;
 

--- a/src/elements/header/common/header-action-common.ts
+++ b/src/elements/header/common/header-action-common.ts
@@ -26,11 +26,7 @@ export const SbbHeaderActionCommonElementMixin = <
     extends baseClass
     implements Partial<SbbHeaderActionCommonElementMixinType>
   {
-    public static styles: CSSResultGroup = [
-      (baseClass as unknown as { styles: CSSResultGroup }).styles ?? [],
-      boxSizingStyles,
-      unsafeCSS(style),
-    ];
+    public static styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
 
     /**
      * Used to set the minimum breakpoint from which the text is displayed.

--- a/src/elements/header/common/header-action-common.ts
+++ b/src/elements/header/common/header-action-common.ts
@@ -20,10 +20,8 @@ export const SbbHeaderActionCommonElementMixin = <
 >(
   superClass: T,
 ): AbstractConstructor<SbbHeaderActionCommonElementMixinType> & T => {
-  const baseClass = SbbIconNameMixin(superClass);
-
   abstract class SbbHeaderActionCommonElement
-    extends baseClass
+    extends SbbIconNameMixin(superClass)
     implements Partial<SbbHeaderActionCommonElementMixinType>
   {
     public static styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];

--- a/src/elements/journey-header/journey-header.component.ts
+++ b/src/elements/journey-header/journey-header.component.ts
@@ -28,7 +28,7 @@ import style from './journey-header.scss?inline';
 export class SbbJourneyHeaderElement extends SbbNegativeMixin(SbbTitleBase) {
   public static override readonly elementName: string = 'sbb-journey-header';
   public static override elementDependencies: SbbElementType[] = [SbbIconElement];
-  public static override styles: CSSResultGroup = [super.styles, boxSizingStyles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
 
   /** Origin location for the journey header. */
   @forceType()

--- a/src/elements/journey-header/journey-header.component.ts
+++ b/src/elements/journey-header/journey-header.component.ts
@@ -28,11 +28,7 @@ import style from './journey-header.scss?inline';
 export class SbbJourneyHeaderElement extends SbbNegativeMixin(SbbTitleBase) {
   public static override readonly elementName: string = 'sbb-journey-header';
   public static override elementDependencies: SbbElementType[] = [SbbIconElement];
-  public static override styles: CSSResultGroup = [
-    boxSizingStyles,
-    SbbTitleBase.styles,
-    unsafeCSS(style),
-  ];
+  public static override styles: CSSResultGroup = [super.styles, boxSizingStyles, unsafeCSS(style)];
 
   /** Origin location for the journey header. */
   @forceType()

--- a/src/elements/link-list-anchor/link-list-anchor.component.ts
+++ b/src/elements/link-list-anchor/link-list-anchor.component.ts
@@ -12,7 +12,7 @@ import style from './link-list-anchor.scss?inline';
  */
 export class SbbLinkListAnchorElement extends SbbLinkListBaseElement {
   public static override readonly elementName: string = 'sbb-link-list-anchor';
-  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
 }
 
 declare global {

--- a/src/elements/link-list/common/link-list-base.ts
+++ b/src/elements/link-list/common/link-list-base.ts
@@ -42,11 +42,7 @@ export class SbbLinkListBaseElement extends SbbNegativeMixin(
   >(SbbElement),
 ) {
   public static override elementDependencies: SbbElementType[] = [SbbTitleElement];
-  public static override styles: CSSResultGroup = [
-    super.styles ?? [],
-    boxSizingStyles,
-    unsafeCSS(style),
-  ];
+  public static override styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
   protected override readonly listChildLocalNames = [
     'sbb-block-link',
     'sbb-block-link-button',

--- a/src/elements/link-list/link-list.component.ts
+++ b/src/elements/link-list/link-list.component.ts
@@ -14,7 +14,7 @@ import style from './link-list.scss?inline';
  */
 export class SbbLinkListElement extends SbbLinkListBaseElement {
   public static override readonly elementName: string = 'sbb-link-list';
-  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
 
   /** Selected breakpoint from which the list is rendered horizontally. */
   @property({ attribute: 'horizontal-from', reflect: true })

--- a/src/elements/link/common/block-link-common.ts
+++ b/src/elements/link/common/block-link-common.ts
@@ -26,7 +26,7 @@ export const SbbBlockLinkCommonElementMixin = <T extends AbstractConstructor<Sbb
     extends SbbLinkCommonElementMixin(SbbIconNameMixin(superClass))
     implements Partial<SbbBlockLinkCommonElementMixinType>
   {
-    public static override styles: CSSResultGroup = [super.styles, unsafeCSS(blockStyle)];
+    public static override styles: CSSResultGroup = [unsafeCSS(blockStyle)];
 
     /**
      * Size variant, either xs, s or m.

--- a/src/elements/link/common/inline-link-common.ts
+++ b/src/elements/link/common/inline-link-common.ts
@@ -20,7 +20,7 @@ export const SbbInlineLinkCommonElementMixin = <
     extends SbbLinkCommonElementMixin(superClass)
     implements Partial<SbbInlineLinkCommonElementMixinType>
   {
-    public static override styles: CSSResultGroup = [super.styles, unsafeCSS(inlineStyle)];
+    public static override styles: CSSResultGroup = [unsafeCSS(inlineStyle)];
   }
   return SbbInlineLinkCommonElement as unknown as AbstractConstructor<SbbInlineLinkCommonElementMixinType> &
     T;

--- a/src/elements/link/common/link-common.ts
+++ b/src/elements/link/common/link-common.ts
@@ -28,11 +28,7 @@ export const SbbLinkCommonElementMixin = <T extends AbstractConstructor<SbbActio
     extends baseClass
     implements Partial<SbbLinkCommonElementMixinType>
   {
-    public static styles: CSSResultGroup = [
-      (baseClass as unknown as { styles: CSSResultGroup }).styles ?? [],
-      boxSizingStyles,
-      unsafeCSS(style),
-    ];
+    public static styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
 
     protected constructor() {
       super();

--- a/src/elements/link/common/link-common.ts
+++ b/src/elements/link/common/link-common.ts
@@ -22,10 +22,8 @@ export const SbbLinkCommonElementMixin = <T extends AbstractConstructor<SbbActio
 ): AbstractConstructor<SbbLinkCommonElementMixinType> &
   T &
   SbbLinkCommonElementMixinConstructor => {
-  const baseClass = SbbNegativeMixin(superClass);
-
   abstract class SbbLinkCommonElement
-    extends baseClass
+    extends SbbNegativeMixin(superClass)
     implements Partial<SbbLinkCommonElementMixinType>
   {
     public static styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];

--- a/src/elements/menu/common/menu-action-common.ts
+++ b/src/elements/menu/common/menu-action-common.ts
@@ -20,10 +20,8 @@ export const SbbMenuActionCommonElementMixin = <
 >(
   superClass: T,
 ): AbstractConstructor<SbbMenuActionCommonElementMixinType> & T => {
-  const baseClass = SbbIconNameMixin(SbbDisabledMixin(superClass));
-
   abstract class SbbMenuActionCommonElement
-    extends baseClass
+    extends SbbIconNameMixin(SbbDisabledMixin(superClass))
     implements SbbMenuActionCommonElementMixinType
   {
     public static styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];

--- a/src/elements/menu/common/menu-action-common.ts
+++ b/src/elements/menu/common/menu-action-common.ts
@@ -26,11 +26,7 @@ export const SbbMenuActionCommonElementMixin = <
     extends baseClass
     implements SbbMenuActionCommonElementMixinType
   {
-    public static styles: CSSResultGroup = [
-      (baseClass as unknown as { styles: CSSResultGroup }).styles ?? [],
-      boxSizingStyles,
-      unsafeCSS(style),
-    ];
+    public static styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
 
     protected override renderTemplate(): TemplateResult {
       return html`

--- a/src/elements/navigation/common/navigation-action-common.ts
+++ b/src/elements/navigation/common/navigation-action-common.ts
@@ -37,11 +37,7 @@ export const SbbNavigationActionCommonElementMixin = <
     implements Partial<SbbNavigationActionCommonElementMixinType>
   {
     public static override elementDependencies: SbbElementType[] = [SbbIconElement];
-    public static styles: CSSResultGroup = [
-      (superClass as unknown as { styles: CSSResultGroup }).styles ?? [],
-      boxSizingStyles,
-      unsafeCSS(style),
-    ];
+    public static styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
 
     /**
      * Action size variant, either s, m or l.

--- a/src/elements/navigation/navigation-list/navigation-list.component.ts
+++ b/src/elements/navigation/navigation-list/navigation-list.component.ts
@@ -31,11 +31,7 @@ export class SbbNavigationListElement extends SbbNamedSlotListMixin<
   typeof SbbElement
 >(SbbElement) {
   public static override readonly elementName: string = 'sbb-navigation-list';
-  public static override styles: CSSResultGroup = [
-    super.styles ?? [],
-    boxSizingStyles,
-    unsafeCSS(style),
-  ];
+  public static override styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
   protected override readonly listChildLocalNames = [
     'sbb-navigation-button',
     'sbb-navigation-link',

--- a/src/elements/navigation/navigation-marker/navigation-marker.component.ts
+++ b/src/elements/navigation/navigation-marker/navigation-marker.component.ts
@@ -24,11 +24,7 @@ export class SbbNavigationMarkerElement extends SbbNamedSlotListMixin<
   typeof SbbElement
 >(SbbElement) {
   public static override readonly elementName: string = 'sbb-navigation-marker';
-  public static override styles: CSSResultGroup = [
-    super.styles ?? [],
-    boxSizingStyles,
-    unsafeCSS(style),
-  ];
+  public static override styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
   protected override readonly listChildLocalNames = [
     'sbb-navigation-button',
     'sbb-navigation-link',

--- a/src/elements/option/option/option.component.ts
+++ b/src/elements/option/option/option.component.ts
@@ -24,7 +24,7 @@ export class SbbOptionElement<T = string> extends SbbOptionBaseElement<T> {
   public static override readonly elementName: string = 'sbb-option';
   public static override elementDependencies: SbbElementType[] = [SbbVisualCheckboxElement];
   public static override readonly role = 'option';
-  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
   public static override readonly events = {
     optionselectionchange: 'optionselectionchange',
     optionselected: 'optionselected',

--- a/src/elements/overlay/overlay.component.ts
+++ b/src/elements/overlay/overlay.component.ts
@@ -29,7 +29,7 @@ export class SbbOverlayElement extends SbbOverlayBaseElement {
     SbbSecondaryButtonElement,
     SbbContainerElement,
   ];
-  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
 
   // TODO: fix using ...super.events requires: https://github.com/sbb-design-systems/lyne-components/issues/2600
   public static override readonly events = {

--- a/src/elements/paginator/common/paginator-common.ts
+++ b/src/elements/paginator/common/paginator-common.ts
@@ -66,11 +66,7 @@ export const SbbPaginatorCommonElementMixin = <
     extends baseClass
     implements Partial<SbbPaginatorCommonElementMixinType>
   {
-    public static styles: CSSResultGroup = [
-      (baseClass as unknown as { styles: CSSResultGroup }).styles ?? [],
-      boxSizingStyles,
-      screenReaderOnlyStyles,
-    ];
+    public static styles: CSSResultGroup = [boxSizingStyles, screenReaderOnlyStyles];
     public static override elementDependencies: SbbElementType[] = [
       SbbMiniButtonGroupElement,
       SbbMiniButtonElement,

--- a/src/elements/paginator/common/paginator-common.ts
+++ b/src/elements/paginator/common/paginator-common.ts
@@ -60,10 +60,8 @@ export const SbbPaginatorCommonElementMixin = <
 >(
   superClass: T,
 ): AbstractConstructor<SbbPaginatorCommonElementMixinType> & T => {
-  const baseClass = SbbNegativeMixin(SbbDisabledMixin(superClass));
-
   abstract class SbbPaginatorCommonElement
-    extends baseClass
+    extends SbbNegativeMixin(SbbDisabledMixin(superClass))
     implements Partial<SbbPaginatorCommonElementMixinType>
   {
     public static styles: CSSResultGroup = [boxSizingStyles, screenReaderOnlyStyles];

--- a/src/elements/paginator/compact-paginator/compact-paginator.component.ts
+++ b/src/elements/paginator/compact-paginator/compact-paginator.component.ts
@@ -13,7 +13,7 @@ import style from './compact-paginator.scss?inline';
 export class SbbCompactPaginatorElement extends SbbPaginatorCommonElementMixin(SbbElement) {
   public static override readonly elementName: string = 'sbb-compact-paginator';
   public static override elementDependencies: SbbElementType[] = [SbbDividerElement];
-  public static override styles: CSSResultGroup = [super.styles ?? [], unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
   public static readonly events: Record<string, string> = {
     page: 'page',
   } as const;

--- a/src/elements/paginator/paginator/paginator.component.ts
+++ b/src/elements/paginator/paginator/paginator.component.ts
@@ -36,7 +36,7 @@ export class SbbPaginatorElement extends SbbPaginatorCommonElementMixin(SbbEleme
     SbbSelectElement,
     SbbOptionElement,
   ];
-  public static override styles: CSSResultGroup = [super.styles ?? [], unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
   public static readonly events: Record<string, string> = {
     page: 'page',
   } as const;

--- a/src/elements/radio-button-panel/radio-button-panel.component.ts
+++ b/src/elements/radio-button-panel/radio-button-panel.component.ts
@@ -24,7 +24,7 @@ export class SbbRadioButtonPanelElement<T = string> extends SbbPanelMixin(
   SbbRadioButtonCommonElementMixin(SbbUpdateSchedulerMixin(SbbElement)),
 ) {
   public static override readonly elementName: string = 'sbb-radio-button-panel';
-  public static override styles: CSSResultGroup = [super.styles ?? [], screenReaderOnlyStyles];
+  public static override styles: CSSResultGroup = [screenReaderOnlyStyles];
 
   // TODO: fix using ...super.events requires: https://github.com/sbb-design-systems/lyne-components/issues/2600
   public static readonly events = {

--- a/src/elements/radio-button/common/radio-button-common.ts
+++ b/src/elements/radio-button/common/radio-button-common.ts
@@ -32,11 +32,7 @@ export const SbbRadioButtonCommonElementMixin = <T extends AbstractConstructor<S
     extends baseClass
     implements Partial<SbbRadioButtonCommonElementMixinType>
   {
-    public static styles: CSSResultGroup = [
-      (baseClass as unknown as { styles: CSSResultGroup }).styles ?? [],
-      boxSizingStyles,
-      unsafeCSS(style),
-    ];
+    public static styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
     public static readonly events = {
       change: 'change',
       input: 'input',

--- a/src/elements/radio-button/common/radio-button-common.ts
+++ b/src/elements/radio-button/common/radio-button-common.ts
@@ -26,10 +26,8 @@ export declare abstract class SbbRadioButtonCommonElementMixinType extends SbbFo
 export const SbbRadioButtonCommonElementMixin = <T extends AbstractConstructor<SbbElement>>(
   superClass: T,
 ): AbstractConstructor<SbbRadioButtonCommonElementMixinType> & T => {
-  const baseClass = SbbFormAssociatedRadioButtonMixin(superClass);
-
   abstract class SbbRadioButtonCommonElement
-    extends baseClass
+    extends SbbFormAssociatedRadioButtonMixin(superClass)
     implements Partial<SbbRadioButtonCommonElementMixinType>
   {
     public static styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];

--- a/src/elements/radio-button/radio-button.component.ts
+++ b/src/elements/radio-button/radio-button.component.ts
@@ -21,7 +21,7 @@ export class SbbRadioButtonElement<T = string> extends SbbRadioButtonCommonEleme
   SbbElement,
 ) {
   public static override readonly elementName: string = 'sbb-radio-button';
-  public static override styles: CSSResultGroup = [super.styles ?? [], unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
   public static readonly events = {
     change: 'change',
     input: 'input',

--- a/src/elements/sidebar/sidebar-close-button/sidebar-close-button.component.ts
+++ b/src/elements/sidebar/sidebar-close-button/sidebar-close-button.component.ts
@@ -13,10 +13,7 @@ import style from './sidebar-close-button.scss?inline';
  */
 export class SbbSidebarCloseButtonElement extends SbbSecondaryButtonElement {
   public static override readonly elementName: string = 'sbb-sidebar-close-button';
-  public static override styles: CSSResultGroup = [
-    SbbSecondaryButtonElement.styles,
-    unsafeCSS(style),
-  ];
+  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
 
   private _languageController = new SbbLanguageController(this);
 

--- a/src/elements/sidebar/sidebar-close-button/sidebar-close-button.component.ts
+++ b/src/elements/sidebar/sidebar-close-button/sidebar-close-button.component.ts
@@ -13,7 +13,7 @@ import style from './sidebar-close-button.scss?inline';
  */
 export class SbbSidebarCloseButtonElement extends SbbSecondaryButtonElement {
   public static override readonly elementName: string = 'sbb-sidebar-close-button';
-  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
 
   private _languageController = new SbbLanguageController(this);
 

--- a/src/elements/sidebar/sidebar-title/sidebar-title.component.ts
+++ b/src/elements/sidebar/sidebar-title/sidebar-title.component.ts
@@ -12,7 +12,7 @@ import style from './sidebar-title.scss?inline';
  */
 export class SbbSidebarTitleElement extends SbbTitleBase {
   public static override readonly elementName: string = 'sbb-sidebar-title';
-  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
 
   /** Title level */
   @property({ reflect: true }) public override accessor level: SbbTitleLevel = '2';

--- a/src/elements/sidebar/sidebar-title/sidebar-title.component.ts
+++ b/src/elements/sidebar/sidebar-title/sidebar-title.component.ts
@@ -12,7 +12,7 @@ import style from './sidebar-title.scss?inline';
  */
 export class SbbSidebarTitleElement extends SbbTitleBase {
   public static override readonly elementName: string = 'sbb-sidebar-title';
-  public static override styles: CSSResultGroup = [SbbTitleBase.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
 
   /** Title level */
   @property({ reflect: true }) public override accessor level: SbbTitleLevel = '2';

--- a/src/elements/skiplink-list/skiplink-list.component.ts
+++ b/src/elements/skiplink-list/skiplink-list.component.ts
@@ -31,11 +31,7 @@ export class SbbSkiplinkListElement extends SbbNamedSlotListMixin<
   typeof SbbElement
 >(SbbElement) {
   public static override readonly elementName: string = 'sbb-skiplink-list';
-  public static override styles: CSSResultGroup = [
-    super.styles ?? [],
-    boxSizingStyles,
-    unsafeCSS(style),
-  ];
+  public static override styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
   protected override readonly listChildLocalNames = ['sbb-block-link', 'sbb-block-link-button'];
 
   /** The title text we want to place before the list. */

--- a/src/elements/tabs/tab-nav-bar/tab-nav-bar.component.ts
+++ b/src/elements/tabs/tab-nav-bar/tab-nav-bar.component.ts
@@ -15,7 +15,6 @@ import style from './tab-nav-bar.scss?inline';
 export class SbbTabNavBarElement extends SbbNamedSlotListMixin(SbbElement) {
   public static override readonly elementName: string = 'sbb-tab-nav-bar';
   public static override styles: CSSResultGroup = [
-    super.styles ?? [],
     boxSizingStyles,
     tabLabelCommonStyles,
     tabGroupCommonStyles,

--- a/src/elements/tag/tag-group/tag-group.component.ts
+++ b/src/elements/tag/tag-group/tag-group.component.ts
@@ -32,11 +32,7 @@ export class SbbTagGroupElement<T = string> extends SbbDisabledMixin(
   SbbNamedSlotListMixin<SbbTagElement, typeof SbbElement>(SbbElement),
 ) {
   public static override readonly elementName: string = 'sbb-tag-group';
-  public static override styles: CSSResultGroup = [
-    super.styles ?? [],
-    boxSizingStyles,
-    unsafeCSS(style),
-  ];
+  public static override styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
   // DIV is added here due to special requirements from sbb.ch.
   protected override readonly listChildLocalNames = ['sbb-tag', 'div'];
 

--- a/src/elements/teaser-product/common/teaser-product-common.ts
+++ b/src/elements/teaser-product/common/teaser-product-common.ts
@@ -22,10 +22,8 @@ export const SbbTeaserProductCommonElementMixin = <
 >(
   superClass: T,
 ): AbstractConstructor<SbbTeaserProductCommonElementMixinType> & T => {
-  const baseClass = SbbNegativeMixin(superClass);
-
   abstract class SbbTeaserProductCommonElement
-    extends baseClass
+    extends SbbNegativeMixin(superClass)
     implements SbbTeaserProductCommonElementMixinType
   {
     public static styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];

--- a/src/elements/teaser-product/common/teaser-product-common.ts
+++ b/src/elements/teaser-product/common/teaser-product-common.ts
@@ -28,11 +28,7 @@ export const SbbTeaserProductCommonElementMixin = <
     extends baseClass
     implements SbbTeaserProductCommonElementMixinType
   {
-    public static styles: CSSResultGroup = [
-      (baseClass as unknown as { styles: CSSResultGroup }).styles ?? [],
-      boxSizingStyles,
-      unsafeCSS(style),
-    ];
+    public static styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
 
     /**
      * Whether the fully visible part of the image is aligned 'before' or 'after' the content.

--- a/src/elements/teaser-product/teaser-product-static/teaser-product-static.component.ts
+++ b/src/elements/teaser-product/teaser-product-static/teaser-product-static.component.ts
@@ -1,5 +1,3 @@
-import type { CSSResultGroup } from 'lit';
-
 import { SbbActionBaseElement } from '../../core.ts';
 import { SbbTeaserProductCommonElementMixin } from '../common/teaser-product-common.ts';
 
@@ -16,7 +14,6 @@ export class SbbTeaserProductStaticElement extends SbbTeaserProductCommonElement
   SbbActionBaseElement,
 ) {
   public static override readonly elementName: string = 'sbb-teaser-product-static';
-  public static override styles: CSSResultGroup = [super.styles ?? []];
 }
 
 declare global {

--- a/src/elements/teaser-product/teaser-product/teaser-product.component.ts
+++ b/src/elements/teaser-product/teaser-product/teaser-product.component.ts
@@ -19,7 +19,7 @@ export class SbbTeaserProductElement extends SbbTeaserProductCommonElementMixin(
   SbbLinkBaseElement,
 ) {
   public static override readonly elementName: string = 'sbb-teaser-product';
-  public static override styles: CSSResultGroup = [super.styles ?? [], unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
 
   protected override render(): TemplateResult {
     // We render the content outside the anchor tag to allow screen readers to navigate through it

--- a/src/elements/timetable-form/timetable-form-field/timetable-form-field.component.ts
+++ b/src/elements/timetable-form/timetable-form-field/timetable-form-field.component.ts
@@ -9,7 +9,7 @@ import style from './timetable-form-field.scss?inline';
  */
 export class SbbTimetableFormFieldElement extends SbbFormFieldElement {
   public static override readonly elementName: string = 'sbb-timetable-form-field';
-  public static override styles: CSSResultGroup = [SbbFormFieldElement.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
 
   private _routeIcon = false;
 

--- a/src/elements/timetable-form/timetable-form-field/timetable-form-field.component.ts
+++ b/src/elements/timetable-form/timetable-form-field/timetable-form-field.component.ts
@@ -9,7 +9,7 @@ import style from './timetable-form-field.scss?inline';
  */
 export class SbbTimetableFormFieldElement extends SbbFormFieldElement {
   public static override readonly elementName: string = 'sbb-timetable-form-field';
-  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
 
   private _routeIcon = false;
 

--- a/src/elements/timetable-form/timetable-form-swap-button/timetable-form-swap-button.component.ts
+++ b/src/elements/timetable-form/timetable-form-swap-button/timetable-form-swap-button.component.ts
@@ -14,10 +14,7 @@ import style from './timetable-form-swap-button.scss?inline';
  */
 export class SbbTimetableFormSwapButtonElement extends SbbSecondaryButtonElement {
   public static override readonly elementName: string = 'sbb-timetable-form-swap-button';
-  public static override styles: CSSResultGroup = [
-    SbbSecondaryButtonElement.styles,
-    unsafeCSS(style),
-  ];
+  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
 
   private _languageController = new SbbLanguageController(this);
 

--- a/src/elements/timetable-form/timetable-form-swap-button/timetable-form-swap-button.component.ts
+++ b/src/elements/timetable-form/timetable-form-swap-button/timetable-form-swap-button.component.ts
@@ -14,7 +14,7 @@ import style from './timetable-form-swap-button.scss?inline';
  */
 export class SbbTimetableFormSwapButtonElement extends SbbSecondaryButtonElement {
   public static override readonly elementName: string = 'sbb-timetable-form-swap-button';
-  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
 
   private _languageController = new SbbLanguageController(this);
 

--- a/src/elements/timetable-occupancy-icon/timetable-occupancy-icon.component.ts
+++ b/src/elements/timetable-occupancy-icon/timetable-occupancy-icon.component.ts
@@ -19,7 +19,7 @@ import style from './timetable-occupancy-icon.scss?inline';
  */
 export class SbbTimetableOccupancyIconElement extends SbbNegativeMixin(SbbIconBase) {
   public static override readonly elementName: string = 'sbb-timetable-occupancy-icon';
-  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
 
   /** Wagon occupancy. */
   @property() public accessor occupancy: SbbOccupancy = 'none';

--- a/src/elements/timetable-occupancy-icon/timetable-occupancy-icon.component.ts
+++ b/src/elements/timetable-occupancy-icon/timetable-occupancy-icon.component.ts
@@ -19,7 +19,7 @@ import style from './timetable-occupancy-icon.scss?inline';
  */
 export class SbbTimetableOccupancyIconElement extends SbbNegativeMixin(SbbIconBase) {
   public static override readonly elementName: string = 'sbb-timetable-occupancy-icon';
-  public static override styles: CSSResultGroup = [SbbIconBase.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
 
   /** Wagon occupancy. */
   @property() public accessor occupancy: SbbOccupancy = 'none';

--- a/src/elements/title/title.component.ts
+++ b/src/elements/title/title.component.ts
@@ -13,7 +13,7 @@ import style from './title.scss?inline';
  */
 export class SbbTitleElement extends SbbNegativeMixin(SbbTitleBase) {
   public static override readonly elementName: string = 'sbb-title';
-  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [unsafeCSS(style)];
 
   /** Visual level for the title. Optional, if not set, the value of level will be used. */
   @property({ attribute: 'visual-level', reflect: true })

--- a/src/elements/title/title.component.ts
+++ b/src/elements/title/title.component.ts
@@ -13,7 +13,7 @@ import style from './title.scss?inline';
  */
 export class SbbTitleElement extends SbbNegativeMixin(SbbTitleBase) {
   public static override readonly elementName: string = 'sbb-title';
-  public static override styles: CSSResultGroup = [SbbTitleBase.styles, unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [super.styles, unsafeCSS(style)];
 
   /** Visual level for the title. Optional, if not set, the value of level will be used. */
   @property({ attribute: 'visual-level', reflect: true })

--- a/src/elements/train/train-formation/train-formation.component.ts
+++ b/src/elements/train/train-formation/train-formation.component.ts
@@ -45,7 +45,6 @@ export class SbbTrainFormationElement extends SbbNamedSlotListMixin<
 >(SbbElement) {
   public static override readonly elementName: string = 'sbb-train-formation';
   public static override styles: CSSResultGroup = [
-    super.styles ?? [],
     hostScrollbarStyles,
     boxSizingStyles,
     unsafeCSS(style),

--- a/src/elements/train/train-wagon-common.ts
+++ b/src/elements/train/train-wagon-common.ts
@@ -88,12 +88,8 @@ export declare class SbbTrainWagonMixinType extends SbbElement {
 export const SbbTrainWagonMixin = <T extends AbstractConstructor<SbbElement>>(
   superClass: T,
 ): AbstractConstructor<SbbTrainWagonMixinType> & T => {
-  const baseClass = SbbTrainFormationOrientationMixin(
-    SbbNamedSlotListMixin<SbbIconElement, T>(superClass),
-  );
-
   abstract class SbbTrainWagonMixinElement
-    extends baseClass
+    extends SbbTrainFormationOrientationMixin(SbbNamedSlotListMixin<SbbIconElement, T>(superClass))
     implements Partial<SbbTrainWagonMixinType>
   {
     public static elementDependencies: SbbElementType[] = [

--- a/src/elements/train/train-wagon-common.ts
+++ b/src/elements/train/train-wagon-common.ts
@@ -101,11 +101,7 @@ export const SbbTrainWagonMixin = <T extends AbstractConstructor<SbbElement>>(
       SbbTimetableOccupancyIconElement,
       SbbDividerElement,
     ];
-    public static styles: CSSResultGroup = [
-      (baseClass as unknown as { styles: CSSResultGroup }).styles ?? [],
-      boxSizingStyles,
-      unsafeCSS(style),
-    ];
+    public static styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
 
     /**
      * Wagon type.

--- a/src/elements/train/train/train.component.ts
+++ b/src/elements/train/train/train.component.ts
@@ -41,11 +41,7 @@ export class SbbTrainElement extends SbbTrainFormationOrientationMixin(
 ) {
   public static override readonly elementName: string = 'sbb-train';
   public static override elementDependencies: SbbElementType[] = [SbbIconElement];
-  public static override styles: CSSResultGroup = [
-    super.styles ?? [],
-    boxSizingStyles,
-    unsafeCSS(style),
-  ];
+  public static override styles: CSSResultGroup = [boxSizingStyles, unsafeCSS(style)];
 
   protected override readonly listChildLocalNames = [
     'sbb-train-wagon',

--- a/tools/manifest/custom-elements-manifest.config.ts
+++ b/tools/manifest/custom-elements-manifest.config.ts
@@ -3,8 +3,6 @@ import type {
   JSDoc,
   LiteralTypeNode,
   TypeReferenceNode,
-  Node,
-  ClassDeclaration as AnalyzerClassDeclaration,
 } from '@custom-elements-manifest/analyzer/node_modules/typescript';
 import { FEATURES } from '@custom-elements-manifest/analyzer/src/features/index.js';
 import { resolveModuleOrPackageSpecifier } from '@custom-elements-manifest/analyzer/src/utils/index.js';
@@ -25,17 +23,6 @@ import type {
   Reference,
   Type,
 } from 'custom-elements-manifest';
-
-/**
- * Resolves a heritage expression node to its original mixin-call source text,
- * using local variable aliases tracked per module file.
- *
- * For example, `const baseClass = SbbIconNameMixin(superClass)` followed by
- * `extends baseClass` will be resolved to `SbbIconNameMixin(superClass)`.
- *
- * This map is keyed by file path and maps variable name -> initializer source text.
- */
-const localVarAliasMap = new Map<string, Map<string, string>>();
 
 const overrideTypeKey = 'overrideType' as const;
 const classGenericsTypeKey = 'classGenerics' as const;
@@ -166,134 +153,6 @@ export function createManifestConfig(library = '') {
               });
             });
           };
-
-          /**
-           * Patch the CORE-MIXINS plugin to resolve local variable aliases used in
-           * `extends baseClass` where `const baseClass = SomeMixin(superClass)`.
-           * The standard plugin calls `handleHeritage` which sets superclass to the
-           * local variable name, then `turnClassDocIntoMixin` deletes superclass.
-           * We patch the `analyzePhase` to run our fix after the standard one.
-           */
-          const mixinsPlugin = FEATURES.find((p) => p.name === 'CORE - MIXINS');
-          if (mixinsPlugin) {
-            const originalAnalyzePhase = mixinsPlugin.analyzePhase?.bind(mixinsPlugin);
-            mixinsPlugin.analyzePhase = (params) => {
-              const { ts, node, moduleDoc } = params;
-
-              // Step 1: Pre-scan the entire node subtree for local variable aliases
-              // (e.g. `const baseClass = SomeMixin(superClass)` nested inside arrow fns)
-              // This must run BEFORE the original plugin creates the mixin declaration.
-              const filePath = node.getSourceFile?.()?.fileName;
-              if (filePath && ts.isVariableStatement(node)) {
-                const collectAliases = (n: Node): void => {
-                  if (ts.isVariableStatement(n) && n !== node) {
-                    n.declarationList.declarations.forEach((varDecl) => {
-                      if (
-                        varDecl.name &&
-                        ts.isIdentifier(varDecl.name) &&
-                        varDecl.initializer &&
-                        ts.isCallExpression(varDecl.initializer)
-                      ) {
-                        if (!localVarAliasMap.has(filePath)) {
-                          localVarAliasMap.set(filePath, new Map());
-                        }
-                        localVarAliasMap
-                          .get(filePath)!
-                          .set(varDecl.name.text, varDecl.initializer.getText());
-                      }
-                    });
-                  }
-                  ts.forEachChild(n, collectAliases);
-                };
-                collectAliases(node);
-              }
-
-              // Step 2: run original to create mixin declaration
-              originalAnalyzePhase?.(params);
-
-              // Step 3: fix mixin mixins list if inner class extends a local alias
-              if (!filePath || !ts.isVariableStatement(node)) {
-                return;
-              }
-              const aliases = localVarAliasMap.get(filePath);
-              if (!aliases) {
-                return;
-              }
-
-              node.declarationList.declarations.forEach((varDecl) => {
-                if (!varDecl.initializer || !ts.isArrowFunction(varDecl.initializer)) {
-                  return;
-                }
-                const mixinName =
-                  varDecl.name && ts.isIdentifier(varDecl.name) ? varDecl.name.text : null;
-                if (!mixinName) {
-                  return;
-                }
-                const mixinDoc = moduleDoc.declarations?.find(
-                  (d: Declaration) => d.name === mixinName && d.kind === 'mixin',
-                );
-                if (!mixinDoc || mixinDoc.mixins?.length) {
-                  return;
-                }
-
-                const findClass = (n: Node): AnalyzerClassDeclaration | undefined => {
-                  if (ts.isClassDeclaration(n)) {
-                    return n;
-                  }
-                  let found: AnalyzerClassDeclaration | undefined;
-                  ts.forEachChild(n, (child) => {
-                    if (!found) {
-                      found = findClass(child);
-                    }
-                  });
-                  return found;
-                };
-                const innerClass = findClass(varDecl.initializer.body);
-                if (!innerClass) {
-                  return;
-                }
-
-                const extendsClause = innerClass.heritageClauses?.find(
-                  (c) => c.token === ts.SyntaxKind.ExtendsKeyword,
-                );
-                if (!extendsClause) {
-                  return;
-                }
-
-                extendsClause.types.forEach((heritageType) => {
-                  const expr = heritageType.expression;
-                  if (!ts.isIdentifier(expr)) {
-                    return;
-                  }
-                  const aliasName = expr.text;
-                  const initText = aliases.get(aliasName);
-                  if (!initText) {
-                    return;
-                  }
-
-                  const stripGenerics = (s: string): string => s.replace(/[<>]/g, '');
-                  const mixinChain: string[] = [];
-                  let remaining = initText;
-                  const callPattern = /^(\w+)\((.+)\)$/;
-                  while (callPattern.test(stripGenerics(remaining))) {
-                    const parenIdx = remaining.indexOf('(');
-                    const lastParen = remaining.lastIndexOf(')');
-                    const outerName = stripGenerics(remaining.slice(0, parenIdx)).trim();
-                    mixinChain.push(outerName);
-                    remaining = stripGenerics(remaining.slice(parenIdx + 1, lastParen)).trim();
-                  }
-
-                  if (mixinChain.length > 0) {
-                    // Overwrite, deduplicating by name (original plugin may have partially set mixins)
-                    const seen = new Set<string>();
-                    mixinDoc.mixins = mixinChain
-                      .map((name) => ({ name }))
-                      .filter(({ name }) => (seen.has(name) ? false : seen.add(name)));
-                  }
-                });
-              });
-            };
-          }
         },
         analyzePhase({ ts, node, moduleDoc }) {
           if (ts.isClassDeclaration(node)) {
@@ -466,61 +325,6 @@ export function createManifestConfig(library = '') {
             klass.members = klass?.members?.filter(
               (member) => !memberDenyList.includes(member.name),
             );
-          });
-
-          /**
-           * Resolve local variable aliases in superclass/mixins.
-           * When code uses `const baseClass = SomeMixin(superClass)` followed by
-           * `extends baseClass`, the CEM analyzer sets superclass.name to "baseClass"
-           * (an unresolvable local variable). Here we look up the alias map and
-           * re-parse the mixin chain from the initializer expression text.
-           */
-          const modulePath = moduleDoc?.path;
-          if (!modulePath) {
-            return;
-          }
-          // Find the matching file path in the alias map (moduleDoc.path may be relative)
-          const aliasEntry = [...localVarAliasMap.entries()].find(([filePath]) =>
-            filePath.endsWith(modulePath.replace(/\.js$/, '.ts')),
-          );
-          if (!aliasEntry) {
-            return;
-          }
-          const aliases = aliasEntry[1];
-
-          const allDeclarations = moduleDoc?.declarations as
-            | undefined
-            | (ClassDeclaration & {
-                mixins?: { name: string }[];
-                superclass?: { name: string };
-              })[];
-
-          allDeclarations?.forEach((decl) => {
-            if (decl.kind !== 'class' && decl.kind !== 'mixin') {
-              return;
-            }
-            const superclassName = decl.superclass?.name;
-            if (superclassName && aliases.has(superclassName)) {
-              // Parse the mixin chain from the alias initializer
-              // e.g. "SbbIconNameMixin(superClass)" -> mixin: SbbIconNameMixin, superClass: superClass
-              const initText = aliases.get(superclassName)!;
-              const mixinChain: string[] = [];
-              let remaining = initText;
-              // Unwrap nested calls: OuterMixin(InnerMixin(base)) -> [OuterMixin, InnerMixin], base
-              const callPattern = /^(\w+)\((.+)\)$/;
-              while (callPattern.test(remaining)) {
-                const match = remaining.match(callPattern)!;
-                mixinChain.push(match[1]);
-                remaining = match[2];
-              }
-              // remaining is now the final superClass argument
-              if (mixinChain.length > 0) {
-                decl.superclass = { name: remaining };
-                const existingMixins = decl.mixins ?? [];
-                // Prepend newly discovered mixins (outermost first)
-                decl.mixins = [...mixinChain.map((name) => ({ name })), ...existingMixins];
-              }
-            }
           });
         },
         packageLinkPhase({ customElementsManifest }) {


### PR DESCRIPTION
With this change, every class, base class or mixin can just declare it's own styles and it is then merged together in the SbbElement. So no need of referencing super.styles anymore.

Closes #4647