### PR TITLE
fix(select): fix multiple checkbox styling

### DIFF
--- a/src/elements/container/sticky-bar/sticky-bar.component.ts
+++ b/src/elements/container/sticky-bar/sticky-bar.component.ts
@@ -158,7 +158,7 @@ export class SbbStickyBarElement extends SbbUpdateSchedulerMixin(SbbElement) {
     }
 
     this._state = 'sticking';
-    if (!this.internals.states.has('sticking') || this._isZeroAnimationDuration()) {
+    if (!this.matches?.(':state(sticking)') || this._isZeroAnimationDuration()) {
       this._stickyCallback();
     }
   }
@@ -171,7 +171,7 @@ export class SbbStickyBarElement extends SbbUpdateSchedulerMixin(SbbElement) {
 
     this._state = 'unsticking';
 
-    if (!this.internals.states.has('sticking') || this._isZeroAnimationDuration()) {
+    if (!this.matches?.(':state(sticking)') || this._isZeroAnimationDuration()) {
       this._unstickyCallback();
     }
   }

--- a/src/elements/core/mixins/form-associated-input-mixin.ts
+++ b/src/elements/core/mixins/form-associated-input-mixin.ts
@@ -318,7 +318,7 @@ export const SbbFormAssociatedInputMixin = <
        * changed under the condition that no input event has occurred since creation
        * or the last form reset.
        */
-      if (name !== 'value' || !this.internals.states.has('interacted')) {
+      if (name !== 'value' || !this.matches?.(':state(interacted)')) {
         super.attributeChangedCallback(name, old, value);
       }
     }

--- a/src/elements/expansion-panel/expansion-panel-header/expansion-panel-header.component.ts
+++ b/src/elements/expansion-panel/expansion-panel-header/expansion-panel-header.component.ts
@@ -83,7 +83,7 @@ export class SbbExpansionPanelHeaderElement extends SbbDisabledTabIndexActionMix
    * but after the 'SbbSlotStateController' has run.
    */
   private _setIconState(): void {
-    this.toggleState('icon', !!(this.iconName || this.internals.states.has('icon')));
+    this.toggleState('icon', !!(this.iconName || this.matches?.(':state(icon)')));
   }
 
   protected override renderTemplate(): TemplateResult {

--- a/src/elements/option/option/option.component.ts
+++ b/src/elements/option/option/option.component.ts
@@ -75,7 +75,7 @@ export class SbbOptionElement<T = string> extends SbbOptionBaseElement<T> {
   }
 
   private _isMultiple(): boolean {
-    return !this.hydrationRequired && this.internals.states.has('multiple');
+    return !this.hydrationRequired && this.matches?.(':state(multiple)');
   }
 
   private _handleNegativeChange(ancestor: SbbAutocompleteElement | SbbSelectElement): void {

--- a/src/elements/tabs/tab-group/tab-group.component.ts
+++ b/src/elements/tabs/tab-group/tab-group.component.ts
@@ -171,10 +171,7 @@ export class SbbTabGroupElement extends SbbElement {
   }
 
   private _ensureActiveTab(): void {
-    if (
-      this.internals.states.has('initialized') &&
-      !this.labels.some((tabLabel) => tabLabel.active)
-    ) {
+    if (this.matches?.(':state(initialized)') && !this.labels.some((tabLabel) => tabLabel.active)) {
       this._initSelection();
     }
   }


### PR DESCRIPTION
This PR Closes #4857

Apparently, `internals.states.has('...')` works unreliably on the Safari browser