### PR TITLE
feat(stepper): add `active` event to step element

### DIFF
--- a/src/elements/stepper/readme.md
+++ b/src/elements/stepper/readme.md
@@ -157,6 +157,7 @@ If important content needs to be announced when a step is changed, use the `aria
 
 | Name       | Type                                       | Description                                                                                                 | Inherited From |
 | ---------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------- | -------------- |
+| `active`   | `Event`                                    | The active event is dispatched when a step is activated.                                                    |                |
 | `validate` | `CustomEvent<SbbStepValidateEventDetails>` | The validate event is dispatched when a step change is triggered. Can be canceled to abort the step change. |                |
 
 #### Slots

--- a/src/elements/stepper/step/step.component.ts
+++ b/src/elements/stepper/step/step.component.ts
@@ -37,6 +37,7 @@ export class SbbStepElement extends SbbElement {
   public static readonly events = {
     validate: 'validate',
     resizechange: 'resizechange',
+    active: 'active',
   } as const;
 
   // We use a timeout as a workaround to the "ResizeObserver loop completed with undelivered notifications" error.
@@ -90,6 +91,11 @@ export class SbbStepElement extends SbbElement {
     }
     this.internals.states.add('selected');
     this.label.select();
+    /**
+     * @type {Event}
+     * The active event is dispatched when a step is activated.
+     */
+    this.dispatchEvent(new Event('active', { bubbles: true, composed: true }));
   }
 
   /**

--- a/src/elements/stepper/stepper/stepper.spec.ts
+++ b/src/elements/stepper/stepper/stepper.spec.ts
@@ -839,6 +839,21 @@ describe('sbb-stepper', () => {
     expect(stepLabels.every((l) => l.matches(`:state(size-${element.size})`))).to.be.true;
   });
 
+  it('should dispatch active event when a step is activated', async () => {
+    const stepLabelTwo = element.querySelector<SbbStepLabelElement>(
+      'sbb-step-label:nth-of-type(2)',
+    )!;
+    const activeSpy = new EventSpy<SbbStepChangeEvent>(
+      SbbStepElement.events.active,
+      stepLabelTwo.step,
+    );
+    // Change to step 2
+    stepLabelTwo.click();
+    await waitForLitRender(element);
+
+    await activeSpy.calledOnce();
+  });
+
   describe('stepchange event', () => {
     it('should emit multiple stepchange events when changing steps multiple times', async () => {
       const stepChangeSpy = new EventSpy<SbbStepChangeEvent>(


### PR DESCRIPTION
This PR adds a `active` event to `<sbb-step>`, which is dispatched on step activation.
This enables us to implement lazy loading in lyne-angular for steps.