### PR TITLE
refactor(option): remove automatic id assignment

### DIFF
--- a/src/elements-experimental/autocomplete-grid/autocomplete-grid-optgroup/__snapshots__/autocomplete-grid-optgroup.snapshot.spec.snap.js
+++ b/src/elements-experimental/autocomplete-grid/autocomplete-grid-optgroup/__snapshots__/autocomplete-grid-optgroup.snapshot.spec.snap.js
@@ -4,18 +4,12 @@ export const snapshots = {};
 snapshots["sbb-autocomplete-grid-optgroup renders Safari DOM"] = 
 `<sbb-autocomplete-grid-optgroup label="Group">
   <sbb-autocomplete-grid-row id="sbb-autocomplete-grid-row-1">
-    <sbb-autocomplete-grid-option
-      id="sbb-autocomplete-grid-option-0"
-      value="1"
-    >
+    <sbb-autocomplete-grid-option value="1">
       Option 1
     </sbb-autocomplete-grid-option>
   </sbb-autocomplete-grid-row>
   <sbb-autocomplete-grid-row id="sbb-autocomplete-grid-row-2">
-    <sbb-autocomplete-grid-option
-      id="sbb-autocomplete-grid-option-1"
-      value="2"
-    >
+    <sbb-autocomplete-grid-option value="2">
       Option 2
     </sbb-autocomplete-grid-option>
   </sbb-autocomplete-grid-row>

--- a/src/elements-experimental/autocomplete-grid/autocomplete-grid-option/__snapshots__/autocomplete-grid-option.snapshot.spec.snap.js
+++ b/src/elements-experimental/autocomplete-grid/autocomplete-grid-option/__snapshots__/autocomplete-grid-option.snapshot.spec.snap.js
@@ -2,10 +2,7 @@
 export const snapshots = {};
 
 snapshots["sbb-autocomplete-grid-option renders DOM"] = 
-`<sbb-autocomplete-grid-option
-  id="sbb-autocomplete-grid-option-0"
-  value="1"
->
+`<sbb-autocomplete-grid-option value="1">
   Option 1
 </sbb-autocomplete-grid-option>
 `;
@@ -31,7 +28,6 @@ snapshots["sbb-autocomplete-grid-option renders Shadow DOM"] =
 snapshots["sbb-autocomplete-grid-option renders disabled DOM"] = 
 `<sbb-autocomplete-grid-option
   disabled=""
-  id="sbb-autocomplete-grid-option-2"
   value="1"
 >
   Option 1

--- a/src/elements-experimental/autocomplete-grid/autocomplete-grid-option/autocomplete-grid-option.component.ts
+++ b/src/elements-experimental/autocomplete-grid/autocomplete-grid-option/autocomplete-grid-option.component.ts
@@ -20,8 +20,6 @@ export class SbbAutocompleteGridOptionElement<T = string> extends SbbOptionBaseE
   public static override readonly role = 'gridcell';
   public static override styles: CSSResultGroup = [unsafeCSS(style)];
 
-  protected optionId = autocompleteGridOptionId;
-
   public constructor() {
     super();
     this.addController(

--- a/src/elements-experimental/autocomplete-grid/autocomplete-grid-row/__snapshots__/autocomplete-grid-row.snapshot.spec.snap.js
+++ b/src/elements-experimental/autocomplete-grid/autocomplete-grid-row/__snapshots__/autocomplete-grid-row.snapshot.spec.snap.js
@@ -3,10 +3,7 @@ export const snapshots = {};
 
 snapshots["sbb-autocomplete-grid-row renders DOM"] = 
 `<sbb-autocomplete-grid-row id="sbb-autocomplete-grid-row-1">
-  <sbb-autocomplete-grid-option
-    id="sbb-autocomplete-grid-option-0"
-    value="1"
-  >
+  <sbb-autocomplete-grid-option value="1">
     Option 1
   </sbb-autocomplete-grid-option>
   <sbb-autocomplete-grid-cell>

--- a/src/elements-experimental/autocomplete-grid/autocomplete-grid/autocomplete-grid.component.ts
+++ b/src/elements-experimental/autocomplete-grid/autocomplete-grid/autocomplete-grid.component.ts
@@ -111,7 +111,7 @@ export class SbbAutocompleteGridElement<T = string> extends SbbAutocompleteBaseE
 
     // Reset potentially active option
     this.activeOption?.setActive(false);
-    this.triggerElement?.removeAttribute('aria-activedescendant');
+    this.triggerElement!.ariaActiveDescendantElement = null;
     Array.from(
       this.querySelectorAll?.('sbb-autocomplete-grid-row :state(focus-visible)') ?? [],
     ).forEach((row) => ɵstateController(row).delete('focus-visible'));
@@ -130,7 +130,7 @@ export class SbbAutocompleteGridElement<T = string> extends SbbAutocompleteBaseE
     const next = getNextElementIndex(event, activeItemIndex, enabledOptions.length);
     this.activeOption = enabledOptions[next];
     this.activeOption.setActive(true);
-    this.triggerElement?.setAttribute('aria-activedescendant', this.activeOption.id);
+    this.triggerElement!.ariaActiveDescendantElement = this.activeOption;
     this.activeOption.scrollIntoView({ block: 'nearest' });
 
     // Moving the active option should not move the input cursor (caret)
@@ -176,7 +176,7 @@ export class SbbAutocompleteGridElement<T = string> extends SbbAutocompleteBaseE
     } else {
       ɵstateController(lastActiveElement).delete('focus-visible');
     }
-    this.triggerElement?.setAttribute('aria-activedescendant', nextElement.id);
+    this.triggerElement!.ariaActiveDescendantElement = nextElement;
     nextElement.scrollIntoView({ block: 'nearest' });
     this._activeColumnIndex = next;
   }
@@ -191,7 +191,10 @@ export class SbbAutocompleteGridElement<T = string> extends SbbAutocompleteBaseE
     this.activeOption?.setActive(false);
     this.activeOption = null;
     this._activeColumnIndex = 0;
-    this.triggerElement?.removeAttribute('aria-activedescendant');
+
+    if (this.triggerElement) {
+      this.triggerElement.ariaActiveDescendantElement = null;
+    }
   }
 
   protected setTriggerAttributes(element: HTMLInputElement): void {

--- a/src/elements-experimental/autocomplete-grid/autocomplete-grid/autocomplete-grid.spec.ts
+++ b/src/elements-experimental/autocomplete-grid/autocomplete-grid/autocomplete-grid.spec.ts
@@ -313,21 +313,21 @@ describe(`sbb-autocomplete-grid`, () => {
       expect(optTwo).to.match(':state(active)');
       expect(buttonTwo).not.to.match(':state(focus-visible)');
       expect(buttonThree).not.to.match(':state(focus-visible)');
-      expect(input).to.have.attribute('aria-activedescendant', 'option-2');
+      expect(input.ariaActiveDescendantElement).to.be.equal(optTwo);
 
       await sendKeys({ press: 'ArrowRight' });
       await waitForLitRender(element);
       expect(optTwo).not.to.match(':state(active)');
       expect(buttonTwo).to.match(':state(focus-visible)');
       expect(buttonThree).not.to.match(':state(focus-visible)');
-      expect(input).to.have.attribute('aria-activedescendant', 'button-2');
+      expect(input.ariaActiveDescendantElement).to.be.equal(buttonTwo);
 
       await sendKeys({ press: 'ArrowRight' });
       await waitForLitRender(element);
       expect(optTwo).not.to.match(':state(active)');
       expect(buttonTwo).not.to.match(':state(focus-visible)');
       expect(buttonThree).to.match(':state(focus-visible)');
-      expect(input).to.have.attribute('aria-activedescendant', 'button-3');
+      expect(input.ariaActiveDescendantElement).to.be.equal(buttonThree);
 
       await sendKeys({ press: 'ArrowDown' });
       await waitForLitRender(element);
@@ -336,7 +336,7 @@ describe(`sbb-autocomplete-grid`, () => {
       expect(optTwo).not.to.match(':state(active)');
       expect(buttonTwo).not.to.match(':state(focus-visible)');
       expect(buttonThree).not.to.match(':state(focus-visible)');
-      expect(input).to.have.attribute('aria-activedescendant', 'option-1');
+      expect(input.ariaActiveDescendantElement).to.be.equal(optOne);
     });
 
     it('opens and select with keyboard', async () => {
@@ -362,7 +362,7 @@ describe(`sbb-autocomplete-grid`, () => {
       expect(optOne).not.to.have.attribute('selected');
       expect(optTwo).to.match(':state(active)');
       expect(optTwo).not.to.have.attribute('selected');
-      expect(input).to.have.attribute('aria-activedescendant', 'option-2');
+      expect(input.ariaActiveDescendantElement).to.be.equal(optTwo);
 
       await sendKeys({ press: 'Enter' });
       await closeSpy.calledOnce();
@@ -375,20 +375,20 @@ describe(`sbb-autocomplete-grid`, () => {
       expect(changeEventSpy.count).to.be.equal(1);
       expect(optionSelectedEventSpy.count).to.be.equal(1);
       expect(input).to.have.attribute('aria-expanded', 'false');
-      expect(input).not.to.have.attribute('aria-activedescendant');
+      expect(input.ariaActiveDescendantElement).to.be.null;
     });
 
     describe('autoActiveFirstOption', () => {
       function assertActiveOption(option: SbbAutocompleteGridOptionElement): void {
         expect(option).to.match(':state(active)');
         expect(option).not.to.have.attribute('selected');
-        expect(input).to.have.attribute('aria-activedescendant', option.id);
+        expect(input.ariaActiveDescendantElement).to.be.equal(option);
       }
 
       function assertInactiveOption(option: SbbAutocompleteGridOptionElement): void {
         expect(option).not.to.match(':state(active)');
         expect(option).not.to.have.attribute('selected');
-        expect(input).not.to.have.attribute('aria-activedescendant', option.id);
+        expect(input.ariaActiveDescendantElement).not.to.be.equal(option);
       }
 
       beforeEach(async () => {
@@ -493,7 +493,7 @@ describe(`sbb-autocomplete-grid`, () => {
 
         // Set the pending selection
         expect(optOne).to.match(':state(active)');
-        expect(input).to.have.attribute('aria-activedescendant', 'option-1');
+        expect(input.ariaActiveDescendantElement).to.be.equal(optOne);
         expect(input).to.have.attribute('aria-expanded', 'true');
         expect(optOne).not.to.have.attribute('selected');
         expect(input.value).to.be.equal('1');
@@ -505,7 +505,7 @@ describe(`sbb-autocomplete-grid`, () => {
         await waitForLitRender(element);
         expect(optOne).not.to.match(':state(active)');
         expect(optTwo).to.match(':state(active)');
-        expect(input).to.have.attribute('aria-activedescendant', 'option-2');
+        expect(input.ariaActiveDescendantElement).to.be.equal(optTwo);
         expect(input).to.have.attribute('aria-expanded', 'true');
         expect(optTwo).not.to.have.attribute('selected');
         expect(input.value).to.be.equal('2');
@@ -631,7 +631,7 @@ describe(`sbb-autocomplete-grid`, () => {
         await waitForLitRender(element);
 
         expect(optOne).to.match(':state(active)');
-        expect(input).to.have.attribute('aria-activedescendant', 'option-1');
+        expect(input.ariaActiveDescendantElement).to.be.equal(optOne);
         expect(input).to.have.attribute('aria-expanded', 'true');
         expect(optOne).not.to.have.attribute('selected');
         expect(input.value).to.be.equal('a');
@@ -743,7 +743,7 @@ describe(`sbb-autocomplete-grid`, () => {
       await sendKeys({ press: 'ArrowRight' });
       expect(optOne).not.to.match(':state(active)');
       expect(buttonOne).to.match(':state(focus-visible)');
-      expect(input).to.have.attribute('aria-activedescendant', 'button-1');
+      expect(input.ariaActiveDescendantElement).to.be.equal(buttonOne);
       await sendKeys({ press: 'Enter' });
       await clickSpy.calledOnce();
       expect(clickSpy.count).to.be.equal(1);
@@ -754,7 +754,7 @@ describe(`sbb-autocomplete-grid`, () => {
       expect(optOne).not.to.match(':state(active)');
       expect(buttonOne).not.to.match(':state(focus-visible)');
       expect(buttonTwo).to.match(':state(focus-visible)');
-      expect(input).to.have.attribute('aria-activedescendant', 'button-2');
+      expect(input.ariaActiveDescendantElement).to.be.equal(buttonTwo);
       await sendKeys({ press: 'Enter' });
       await clickSpy.calledTimes(2);
       expect(clickSpy.count).to.be.equal(2);

--- a/src/elements/autocomplete/__snapshots__/autocomplete.snapshot.spec.snap.js
+++ b/src/elements/autocomplete/__snapshots__/autocomplete.snapshot.spec.snap.js
@@ -8,16 +8,10 @@ snapshots["sbb-autocomplete renders standalone Safari DOM"] =
   popover="manual"
   trigger="trigger"
 >
-  <sbb-option
-    id="sbb-option-0"
-    value="1"
-  >
+  <sbb-option value="1">
     1
   </sbb-option>
-  <sbb-option
-    id="sbb-option-1"
-    value="2"
-  >
+  <sbb-option value="2">
     2
   </sbb-option>
 </sbb-autocomplete>
@@ -55,16 +49,10 @@ snapshots["sbb-autocomplete renders in form field Safari DOM"] =
     id="sbb-autocomplete-3"
     popover="manual"
   >
-    <sbb-option
-      id="sbb-option-4"
-      value="1"
-    >
+    <sbb-option value="1">
       1
     </sbb-option>
-    <sbb-option
-      id="sbb-option-5"
-      value="2"
-    >
+    <sbb-option value="2">
       2
     </sbb-option>
   </sbb-autocomplete>

--- a/src/elements/autocomplete/autocomplete-base-element.ts
+++ b/src/elements/autocomplete/autocomplete-base-element.ts
@@ -371,7 +371,7 @@ export abstract class SbbAutocompleteBaseElement<T = string> extends SbbNegative
   ): void {
     // Deselect the previous options
     this.options
-      .filter((option) => option.id !== selectedOption.id && option.selected)
+      .filter((option) => option !== selectedOption && option.selected)
       .forEach((option) => (option.selected = false));
     this.pendingAutoSelectedOption = null;
 

--- a/src/elements/autocomplete/autocomplete.component.ts
+++ b/src/elements/autocomplete/autocomplete.component.ts
@@ -68,7 +68,7 @@ export class SbbAutocompleteElement<T = string> extends SbbAutocompleteBaseEleme
 
     // Reset potentially active option
     this.activeOption?.setActive(false);
-    this.triggerElement?.removeAttribute('aria-activedescendant');
+    this.triggerElement!.ariaActiveDescendantElement = null;
 
     if (!enabledOptions.length) {
       this.activeOption = null;
@@ -83,7 +83,7 @@ export class SbbAutocompleteElement<T = string> extends SbbAutocompleteBaseEleme
     const next = getNextElementIndex(event, activeItemIndex, enabledOptions.length);
     this.activeOption = enabledOptions[next];
     this.activeOption.setActive(true);
-    this.triggerElement?.setAttribute('aria-activedescendant', this.activeOption.id);
+    this.triggerElement!.ariaActiveDescendantElement = this.activeOption;
     this.activeOption.scrollIntoView({ block: 'nearest' });
 
     // Moving the active option should not move the input cursor (caret)
@@ -99,8 +99,11 @@ export class SbbAutocompleteElement<T = string> extends SbbAutocompleteBaseEleme
 
   protected resetActiveElement(): void {
     this.activeOption?.setActive(false);
-    this.triggerElement?.removeAttribute('aria-activedescendant');
     this.activeOption = null;
+
+    if (this.triggerElement) {
+      this.triggerElement.ariaActiveDescendantElement = null;
+    }
   }
 
   protected setTriggerAttributes(element: HTMLInputElement): void {

--- a/src/elements/autocomplete/autocomplete.component.ts
+++ b/src/elements/autocomplete/autocomplete.component.ts
@@ -107,6 +107,7 @@ export class SbbAutocompleteElement<T = string> extends SbbAutocompleteBaseEleme
   }
 
   protected setTriggerAttributes(element: HTMLInputElement): void {
+    // autocomplete cannot use aria properties because they do not pierce shadow DOM
     setAriaComboBoxAttributes(element, ariaRoleOnHost ? this.id : this.overlayId, false);
   }
 }

--- a/src/elements/autocomplete/autocomplete.spec.ts
+++ b/src/elements/autocomplete/autocomplete.spec.ts
@@ -257,7 +257,7 @@ describe(`sbb-autocomplete`, () => {
       expect(optOne).not.to.have.attribute('selected');
       expect(optTwo).to.match(':state(active)');
       expect(optTwo).not.to.have.attribute('selected');
-      expect(input).to.have.attribute('aria-activedescendant', 'option-2');
+      expect(input.ariaActiveDescendantElement).to.be.equal(optTwo);
 
       await sendKeys({ press: 'Enter' });
       await closeSpy.calledOnce();
@@ -271,20 +271,20 @@ describe(`sbb-autocomplete`, () => {
       expect(inputAutocompleteSpy.count).to.be.equal(1);
       expect(optionSelectedSpy.count).to.be.equal(1);
       expect(input).to.have.attribute('aria-expanded', 'false');
-      expect(input).not.to.have.attribute('aria-activedescendant');
+      expect(input.ariaActiveDescendantElement).to.be.null;
     });
 
     describe('autoActiveFirstOption', () => {
       function assertActiveOption(option: SbbOptionElement): void {
         expect(option).to.match(':state(active)');
         expect(option).not.to.have.attribute('selected');
-        expect(input).to.have.attribute('aria-activedescendant', option.id);
+        expect(input.ariaActiveDescendantElement).to.be.equal(option);
       }
 
       function assertInactiveOption(option: SbbOptionElement): void {
         expect(option).not.to.match(':state(active)');
         expect(option).not.to.have.attribute('selected');
-        expect(input).not.to.have.attribute('aria-activedescendant', option.id);
+        expect(input.ariaActiveDescendantElement).not.to.be.equal(option);
       }
 
       beforeEach(async () => {
@@ -389,7 +389,7 @@ describe(`sbb-autocomplete`, () => {
 
         // Set the pending selection
         expect(optOne).to.match(':state(active)');
-        expect(input).to.have.attribute('aria-activedescendant', 'option-1');
+        expect(input.ariaActiveDescendantElement).to.be.equal(optOne);
         expect(input).to.have.attribute('aria-expanded', 'true');
         expect(optOne).not.to.have.attribute('selected');
         expect(input.value).to.be.equal('1');
@@ -401,7 +401,7 @@ describe(`sbb-autocomplete`, () => {
         await waitForLitRender(element);
         expect(optOne).not.to.match(':state(active)');
         expect(optTwo).to.match(':state(active)');
-        expect(input).to.have.attribute('aria-activedescendant', 'option-2');
+        expect(input.ariaActiveDescendantElement).to.be.equal(optTwo);
         expect(input).to.have.attribute('aria-expanded', 'true');
         expect(optTwo).not.to.have.attribute('selected');
         expect(input.value).to.be.equal('2');
@@ -552,7 +552,7 @@ describe(`sbb-autocomplete`, () => {
         await waitForLitRender(element);
 
         expect(optOne).to.match(':state(active)');
-        expect(input).to.have.attribute('aria-activedescendant', 'option-1');
+        expect(input.ariaActiveDescendantElement).to.be.equal(optOne);
         expect(input).to.have.attribute('aria-expanded', 'true');
         expect(optOne).not.to.have.attribute('selected');
         expect(input.value).to.be.equal('a');
@@ -761,7 +761,7 @@ describe(`sbb-autocomplete`, () => {
         await waitForLitRender(element);
         expect(optOne).to.match(':state(active)');
         expect(optOne).not.to.have.attribute('selected');
-        expect(input).to.have.attribute('aria-activedescendant', 'option-1');
+        expect(input.ariaActiveDescendantElement).to.be.equal(optOne);
 
         await sendKeys({ press: 'Enter' });
         await closeSpy.calledOnce();

--- a/src/elements/option/optgroup/__snapshots__/optgroup.snapshot.spec.snap.js
+++ b/src/elements/option/optgroup/__snapshots__/optgroup.snapshot.spec.snap.js
@@ -3,16 +3,10 @@ export const snapshots = {};
 
 snapshots["sbb-optgroup autocomplete renders Safari DOM"] = 
 `<sbb-optgroup label="Label">
-  <sbb-option
-    id="sbb-option-0"
-    value="1"
-  >
+  <sbb-option value="1">
     1
   </sbb-option>
-  <sbb-option
-    id="sbb-option-1"
-    value="2"
-  >
+  <sbb-option value="2">
     2
   </sbb-option>
 </sbb-optgroup>
@@ -40,16 +34,10 @@ snapshots["sbb-optgroup autocomplete renders disabled Safari DOM"] =
   disabled=""
   label="Label"
 >
-  <sbb-option
-    id="sbb-option-4"
-    value="1"
-  >
+  <sbb-option value="1">
     1
   </sbb-option>
-  <sbb-option
-    id="sbb-option-5"
-    value="2"
-  >
+  <sbb-option value="2">
     2
   </sbb-option>
 </sbb-optgroup>

--- a/src/elements/option/option/__snapshots__/option.snapshot.spec.snap.js
+++ b/src/elements/option/option/__snapshots__/option.snapshot.spec.snap.js
@@ -3,7 +3,6 @@ export const snapshots = {};
 
 snapshots["sbb-option autocomplete renders selected DOM"] = 
 `<sbb-option
-  id="sbb-option-0"
   selected=""
   value="1"
 >
@@ -32,7 +31,6 @@ snapshots["sbb-option autocomplete renders selected Shadow DOM"] =
 snapshots["sbb-option autocomplete renders disabled DOM"] = 
 `<sbb-option
   disabled=""
-  id="sbb-option-2"
   value="1"
 >
   Option 1

--- a/src/elements/option/option/option-base-element.ts
+++ b/src/elements/option/option/option-base-element.ts
@@ -23,8 +23,6 @@ import {
 import { SbbIconNameMixin } from '../../icon.pure.ts';
 import type { SbbSelectElement } from '../../select.pure.ts';
 
-let nextId = 0;
-
 /**
  * On Safari, the groups labels are not read by VoiceOver.
  * To solve the problem, we remove the role="group" and add an hidden span containing the group name
@@ -46,8 +44,6 @@ export abstract class SbbOptionBaseElement<T = string> extends SbbDisabledMixin(
     optionselected: 'optionselected',
   } as const;
   public static override styles: CSSResultGroup = [screenReaderOnlyStyles];
-
-  protected abstract optionId: string;
 
   /**
    * Value of the option.
@@ -178,11 +174,6 @@ export abstract class SbbOptionBaseElement<T = string> extends SbbDisabledMixin(
       /** Emits when an option was selected by user. */
       this.dispatchEvent(new Event('optionselected', { bubbles: true, composed: true }));
     }
-  }
-
-  public override connectedCallback(): void {
-    super.connectedCallback();
-    this.id ||= `${this.optionId}-${nextId++}`;
   }
 
   public override requestUpdate(

--- a/src/elements/option/option/option.component.ts
+++ b/src/elements/option/option/option.component.ts
@@ -30,8 +30,6 @@ export class SbbOptionElement<T = string> extends SbbOptionBaseElement<T> {
     optionselected: 'optionselected',
   } as const;
 
-  protected optionId = `sbb-option`;
-
   private set _variant(variant: SbbOptionVariant) {
     if (this._variantInternal) {
       this.internals.states.delete(`variant-${this._variantInternal}`);

--- a/src/elements/paginator/paginator/__snapshots__/paginator.snapshot.spec.snap.js
+++ b/src/elements/paginator/paginator/__snapshots__/paginator.snapshot.spec.snap.js
@@ -682,22 +682,15 @@ snapshots["sbb-paginator renders with options and accessibility labels Safari Sh
         value="10"
       >
         <sbb-option
-          id="sbb-option-3"
           selected=""
           value="10"
         >
           10
         </sbb-option>
-        <sbb-option
-          id="sbb-option-4"
-          value="25"
-        >
+        <sbb-option value="25">
           25
         </sbb-option>
-        <sbb-option
-          id="sbb-option-5"
-          value="50"
-        >
+        <sbb-option value="50">
           50
         </sbb-option>
       </sbb-select>

--- a/src/elements/select/__snapshots__/select.snapshot.spec.snap.js
+++ b/src/elements/select/__snapshots__/select.snapshot.spec.snap.js
@@ -3,22 +3,13 @@ export const snapshots = {};
 
 snapshots["sbb-select renders Safari DOM"] = 
 `<sbb-select id="sbb-select-1">
-  <sbb-option
-    id="sbb-option-0"
-    value="1"
-  >
+  <sbb-option value="1">
     Option 1
   </sbb-option>
-  <sbb-option
-    id="sbb-option-1"
-    value="2"
-  >
+  <sbb-option value="2">
     Option 2
   </sbb-option>
-  <sbb-option
-    id="sbb-option-2"
-    value="3"
-  >
+  <sbb-option value="3">
     Option 3
   </sbb-option>
 </sbb-select>
@@ -51,22 +42,13 @@ snapshots["sbb-select renders multiple Safari DOM"] =
   id="sbb-select-3"
   multiple=""
 >
-  <sbb-option
-    id="sbb-option-6"
-    value="1"
-  >
+  <sbb-option value="1">
     Option 1
   </sbb-option>
-  <sbb-option
-    id="sbb-option-7"
-    value="2"
-  >
+  <sbb-option value="2">
     Option 2
   </sbb-option>
-  <sbb-option
-    id="sbb-option-8"
-    value="3"
-  >
+  <sbb-option value="3">
     Option 3
   </sbb-option>
 </sbb-select>

--- a/src/elements/select/select.component.ts
+++ b/src/elements/select/select.component.ts
@@ -862,7 +862,7 @@ export class SbbSelectElement<T = string> extends SbbUpdateSchedulerMixin(
     nextActiveOption.scrollIntoView({ block: 'nearest' });
 
     if (setActiveDescendant) {
-      this._triggerElement?.setAttribute('aria-activedescendant', nextActiveOption.id);
+      this._triggerElement!.ariaActiveDescendantElement = nextActiveOption;
     }
 
     // Reset the previous
@@ -889,7 +889,10 @@ export class SbbSelectElement<T = string> extends SbbUpdateSchedulerMixin(
       activeElement.setActive(false);
     }
     this._activeItemIndex = -1;
-    this._triggerElement?.removeAttribute('aria-activedescendant');
+
+    if (this._triggerElement) {
+      this._triggerElement.ariaActiveDescendantElement = null;
+    }
   }
 
   // Check if the pointerdown event target is triggered on the menu.


### PR DESCRIPTION
BREAKING CHANGE: `sbb-option` does not automatically assign an ID anymore