### PR TITLE
feat(calendar): add property `amount` to enable displaying multiple months

### DIFF
--- a/src/elements/calendar/_calendar.global.scss
+++ b/src/elements/calendar/_calendar.global.scss
@@ -25,10 +25,14 @@ $theme: 'standard' !default;
   --sbb-calendar-control-gap: var(--sbb-spacing-fixed-2x);
   --sbb-calendar-control-margin-block-end: var(--sbb-spacing-fixed-4x);
   --sbb-calendar-control-view-change-height: #{sbb.px-to-rem-build(44)};
+
+  // TODO
   --sbb-calendar-control-view-change-color: var(--sbb-color-3);
   --sbb-calendar-control-view-change-background: var(--sbb-background-color-1);
   --sbb-calendar-control-view-change-padding-inline: var(--sbb-spacing-fixed-5x)
     var(--sbb-spacing-fixed-2x);
+
+  // /TODO
   --sbb-calendar-header-color: light-dark(var(--sbb-color-granite), var(--sbb-color-smoke));
 
   // While changing views, there would be a few frames where the height of the calendar collapses to just

--- a/src/elements/calendar/_calendar.global.scss
+++ b/src/elements/calendar/_calendar.global.scss
@@ -16,6 +16,7 @@ $theme: 'standard' !default;
   --sbb-calendar-cell-cursor: var(--sbb-cursor-pointer);
   --sbb-calendar-cell-font-size: var(--sbb-text-font-size-s);
   --sbb-calendar-cell-margin: #{sbb.px-to-rem-build(1)};
+  --sbb-calendar-cell-size: #{sbb.px-to-rem-build(44)};
 
   // Actual full height is 73, but with margin this comes down to 71
   --sbb-calendar-cell-year-month-width: #{sbb.px-to-rem-build(71)};
@@ -25,12 +26,6 @@ $theme: 'standard' !default;
   --sbb-calendar-control-gap: var(--sbb-spacing-fixed-1x);
   --sbb-calendar-control-view-change-color: var(--sbb-color-3);
   --sbb-calendar-header-color: light-dark(var(--sbb-color-granite), var(--sbb-color-smoke));
-
-  // While changing views, there would be a few frames where the height of the calendar collapses to just
-  // the height of the controls and then grow back to the height of the next view.
-  // By using 0.1ms this can be avoided.
-  --sbb-calendar-table-animation-duration: 0.1ms;
-  --sbb-calendar-table-animation-shift: #{sbb.px-to-rem-build(0.1)};
   --sbb-calendar-tables-gap: var(--sbb-spacing-fixed-10x);
 
   // Actual full width is 44, but with margin this comes down to 42

--- a/src/elements/calendar/_calendar.global.scss
+++ b/src/elements/calendar/_calendar.global.scss
@@ -24,15 +24,8 @@ $theme: 'standard' !default;
   --sbb-calendar-cell-year-month-height: #{sbb.px-to-rem-build(44)};
   --sbb-calendar-control-gap: var(--sbb-spacing-fixed-2x);
   --sbb-calendar-control-margin-block-end: var(--sbb-spacing-fixed-4x);
-  --sbb-calendar-control-view-change-height: #{sbb.px-to-rem-build(44)};
-
-  // TODO
   --sbb-calendar-control-view-change-color: var(--sbb-color-3);
-  --sbb-calendar-control-view-change-background: var(--sbb-background-color-1);
-  --sbb-calendar-control-view-change-padding-inline: var(--sbb-spacing-fixed-5x)
-    var(--sbb-spacing-fixed-2x);
-
-  // /TODO
+  --sbb-calendar-control-view-change-height: #{sbb.px-to-rem-build(44)};
   --sbb-calendar-header-color: light-dark(var(--sbb-color-granite), var(--sbb-color-smoke));
 
   // While changing views, there would be a few frames where the height of the calendar collapses to just

--- a/src/elements/calendar/_calendar.global.scss
+++ b/src/elements/calendar/_calendar.global.scss
@@ -38,8 +38,6 @@ $theme: 'standard' !default;
   --sbb-calendar-day-value-height: var(--sbb-spacing-fixed-6x);
   --sbb-calendar-day-extra-display: block;
   --sbb-calendar-day-extra-height: #{sbb.px-to-rem-build(18)};
-  --sbb-calendar-day-crossed-out-top: 33%;
-  --sbb-calendar-day-crossed-out-translate: translate(-50%, -33%) rotate(-45deg);
 }
 
 @mixin forced-colors {

--- a/src/elements/calendar/_calendar.global.scss
+++ b/src/elements/calendar/_calendar.global.scss
@@ -3,29 +3,27 @@
 $theme: 'standard' !default;
 
 @mixin base {
-  --sbb-calendar-cell-background-color: transparent;
   --sbb-calendar-cell-background-color-hover: var(--sbb-background-color-3);
   --sbb-calendar-cell-background-color-active: var(--sbb-background-color-4);
   --sbb-calendar-cell-padding: #{sbb.px-to-rem-build(2)};
   --sbb-calendar-cell-border-width: var(--sbb-border-width-2x);
+  --sbb-calendar-cell-border-color-selected: var(--sbb-border-color-2);
   --sbb-calendar-cell-disabled-height: #{sbb.px-to-rem-build(1.5)};
   --sbb-calendar-cell-disabled-width: #{sbb.px-to-rem-build(25.5)};
   --sbb-calendar-cell-disabled-color: light-dark(var(--sbb-color-granite), var(--sbb-color-smoke));
   --sbb-calendar-cell-transition-easing-function: var(--sbb-animation-easing);
-  --sbb-calendar-cell-border: var(--sbb-calendar-cell-border-width) solid
-    var(--sbb-border-color-1-inverted);
   --sbb-calendar-cell-color: var(--sbb-color-2);
   --sbb-calendar-cell-cursor: var(--sbb-cursor-pointer);
-  --sbb-calendar-cell-justify-content: normal;
-  --sbb-calendar-cell-inset: #{sbb.px-to-rem-build(1)};
   --sbb-calendar-cell-font-size: var(--sbb-text-font-size-s);
-  --sbb-calendar-cell-font-weight: unset;
-  --sbb-calendar-cell-year-month-width: #{sbb.px-to-rem-build(77)};
-  --sbb-calendar-cell-year-month-height: #{sbb.px-to-rem-build(44)};
-  --sbb-calendar-control-gap: var(--sbb-spacing-fixed-2x);
-  --sbb-calendar-control-margin-block-end: var(--sbb-spacing-fixed-4x);
+  --sbb-calendar-cell-margin: #{sbb.px-to-rem-build(1)};
+
+  // Actual full height is 73, but with margin this comes down to 71
+  --sbb-calendar-cell-year-month-width: #{sbb.px-to-rem-build(71)};
+
+  // Actual full height is 40, but with margin this comes down to 38
+  --sbb-calendar-cell-year-month-height: #{sbb.px-to-rem-build(38)};
+  --sbb-calendar-control-gap: var(--sbb-spacing-fixed-1x);
   --sbb-calendar-control-view-change-color: var(--sbb-color-3);
-  --sbb-calendar-control-view-change-height: #{sbb.px-to-rem-build(44)};
   --sbb-calendar-header-color: light-dark(var(--sbb-color-granite), var(--sbb-color-smoke));
 
   // While changing views, there would be a few frames where the height of the calendar collapses to just
@@ -33,12 +31,23 @@ $theme: 'standard' !default;
   // By using 0.1ms this can be avoided.
   --sbb-calendar-table-animation-duration: 0.1ms;
   --sbb-calendar-table-animation-shift: #{sbb.px-to-rem-build(0.1)};
-  --sbb-calendar-table-column-spaces: 12;
   --sbb-calendar-tables-gap: var(--sbb-spacing-fixed-10x);
-  --sbb-calendar-day-width: #{sbb.px-to-rem-build(44)};
-  --sbb-calendar-day-height: #{sbb.px-to-rem-build(48)};
+
+  // Actual full width is 44, but with margin this comes down to 42
+  --sbb-calendar-day-size: #{sbb.px-to-rem-build(42)};
+  --sbb-calendar-day-width: var(--sbb-calendar-day-size);
+
+  // Actual full height is 48, but with margin this comes down to 46
+  --sbb-calendar-day-height: #{sbb.px-to-rem-build(46)};
+  --sbb-calendar-day-justify-content: start;
+  --sbb-calendar-day-value-height: var(--sbb-spacing-fixed-6x);
   --sbb-calendar-day-extra-display: block;
-  --sbb-calendar-day-extra-height: var(--sbb-spacing-fixed-4x);
+  --sbb-calendar-day-extra-height: #{sbb.px-to-rem-build(18)};
   --sbb-calendar-day-crossed-out-top: 33%;
   --sbb-calendar-day-crossed-out-translate: translate(-50%, -33%) rotate(-45deg);
+}
+
+@mixin forced-colors {
+  --sbb-calendar-cell-background-color-hover: transparent;
+  --sbb-calendar-cell-background-color-active: transparent;
 }

--- a/src/elements/calendar/calendar-day/calendar-day.component.ts
+++ b/src/elements/calendar/calendar-day/calendar-day.component.ts
@@ -64,8 +64,8 @@ export class SbbCalendarDayElement<T = Date> extends SbbCalendarCellBaseElement<
 
   protected setSelectedState(parent: SbbCalendarElement<T>): void {
     const selected = parent.multiple
-      ? (parent.selected as Date[]).some((selDay) => this.dateAdapter.sameDate(this.value, selDay))
-      : !!parent.selected && this.dateAdapter.compareDate(this.value, parent.selected) === 0;
+      ? (parent.value as Date[]).some((selDay) => this.dateAdapter.sameDate(this.value, selDay))
+      : !!parent.value && this.dateAdapter.compareDate(this.value, parent.value) === 0;
     this.toggleState('selected', selected);
     this.internals.ariaPressed = String(selected);
   }

--- a/src/elements/calendar/calendar-day/calendar-day.scss
+++ b/src/elements/calendar/calendar-day/calendar-day.scss
@@ -1,15 +1,7 @@
 @use '../../core/styles' as sbb;
 
-:host {
-  --sbb-calendar-day-value-height: var(--sbb-spacing-fixed-6x);
-}
-
 .sbb-calendar-day {
-  flex-direction: column;
-  justify-content: var(--sbb-calendar-cell-justify-content);
-  height: var(--sbb-calendar-day-height);
-  width: var(--sbb-calendar-day-width);
-  padding: var(--sbb-calendar-cell-padding);
+  justify-content: var(--sbb-calendar-day-justify-content);
 }
 
 .sbb-calendar-day__value {
@@ -32,7 +24,6 @@
 .sbb-calendar-day__extra {
   display: var(--sbb-calendar-day-extra-display);
   height: var(--sbb-calendar-day-extra-height);
-  padding: var(--sbb-calendar-cell-padding);
 }
 
 ::slotted(*) {

--- a/src/elements/calendar/calendar-day/calendar-day.scss
+++ b/src/elements/calendar/calendar-day/calendar-day.scss
@@ -9,19 +9,7 @@
   height: var(--sbb-calendar-day-value-height);
   align-items: center;
   justify-content: center;
-
-  :host(:state(crossed-out)) & {
-    &::after {
-      content: '';
-      height: var(--sbb-calendar-cell-disabled-height);
-      width: var(--sbb-calendar-cell-disabled-width);
-      position: absolute;
-      background-color: var(--sbb-calendar-cell-disabled-color);
-      inset-block-start: var(--sbb-calendar-day-crossed-out-top);
-      inset-inline-start: 50%;
-      transform: var(--sbb-calendar-day-crossed-out-translate);
-    }
-  }
+  position: relative;
 }
 
 .sbb-calendar-day__extra {

--- a/src/elements/calendar/calendar-day/calendar-day.scss
+++ b/src/elements/calendar/calendar-day/calendar-day.scss
@@ -5,7 +5,10 @@
 }
 
 .sbb-calendar-day__value {
+  display: flex;
   height: var(--sbb-calendar-day-value-height);
+  align-items: center;
+  justify-content: center;
 
   :host(:state(crossed-out)) & {
     &::after {

--- a/src/elements/calendar/calendar-day/calendar-day.spec.ts
+++ b/src/elements/calendar/calendar-day/calendar-day.spec.ts
@@ -38,12 +38,12 @@ describe('sbb-calendar-day', () => {
   });
 
   it('should react to calendar property changes', async () => {
-    root.selected = new Date(`${year}-${month}-15`);
+    root.value = new Date(`${year}-${month}-15`);
     root.min = new Date(`${year}-${month}-10`);
     root.max = new Date(`${year}-${month}-20`);
     root.dateFilter = (d: Date | null): boolean => !!d && d.getDate() % 2 === 1;
     await waitForLitRender(root);
-    const selectedDaySelector = `sbb-calendar-day[slot="${defaultDateAdapter.toIso8601(root.selected)}"]`;
+    const selectedDaySelector = `sbb-calendar-day[slot="${defaultDateAdapter.toIso8601(root.value)}"]`;
     const selectedElement = root.querySelector<SbbCalendarDayElement>(selectedDaySelector)!;
     expect(selectedElement).to.match(':state(selected)');
     expect(elementInternals.get(selectedElement)!.ariaPressed).to.be.equal('true');

--- a/src/elements/calendar/calendar-day/calendar-day.visual.spec.ts
+++ b/src/elements/calendar/calendar-day/calendar-day.visual.spec.ts
@@ -1,4 +1,4 @@
-import { html, nothing } from 'lit';
+import { html } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 import { type SinonStub, stub } from 'sinon';
 
@@ -8,10 +8,35 @@ import {
   visualDiffDefault,
   visualDiffFocus,
   visualDiffHover,
+  visualDiffStandardStates,
 } from '../../core/testing/private.ts';
 import { defaultDateAdapter } from '../../core.ts';
 
 import '../../calendar.ts';
+
+const calendarWithDays = (value?: Date): ReturnType<typeof html> => html`
+  <sbb-calendar .value=${value}>
+    ${repeat(new Array(31), (_, index) => {
+      const slotName = defaultDateAdapter.toIso8601(new Date(`2025-01-${index + 1}`));
+      return html`<sbb-calendar-day slot=${slotName}></sbb-calendar-day>`;
+    })}
+  </sbb-calendar>
+`;
+
+const calendarWithDaysAndContent = (value?: Date): ReturnType<typeof html> => html`
+  <sbb-calendar .value=${value}>
+    ${repeat(new Array(31), (_, index) => {
+      const slotName = defaultDateAdapter.toIso8601(new Date(`2025-01-${index + 1}`));
+      return html`<sbb-calendar-day slot=${slotName}>
+        <span
+          class="sbb-text-xxs"
+          style="display: flex; flex-direction: column; justify-content: center; color: light-dark(var(--sbb-color-metal), var(--sbb-color-smoke));"
+          >99.-</span
+        >
+      </sbb-calendar-day>`;
+    })}
+  </sbb-calendar>
+`;
 
 describe('sbb-calendar-day', () => {
   let todayStub: SinonStub;
@@ -24,12 +49,12 @@ describe('sbb-calendar-day', () => {
     todayStub.restore();
   });
 
-  describeViewports(() => {
+  describeViewports({ viewports: ['zero', 'large'] }, () => {
     it(
       'default',
       visualDiffDefault.with(async (setup) => {
         await setup.withFixture(
-          html` <sbb-calendar
+          html`<sbb-calendar
             .min=${defaultDateAdapter.toIso8601(new Date(2025, 0, 9))}
             .value=${defaultDateAdapter.toIso8601(new Date(2025, 0, 15))}
             .dateFilter=${(d: Date): boolean => d.getDate() % 2 === 1}
@@ -44,57 +69,76 @@ describe('sbb-calendar-day', () => {
     );
 
     for (const content of [false, true]) {
-      for (const state of [visualDiffHover, visualDiffActive, visualDiffFocus]) {
-        it(
-          `today state=${state.name} content=${content}`,
-          state.with(async (setup) => {
-            await setup.withFixture(
-              html` <sbb-calendar>
-                ${repeat(new Array(31), (_, index) => {
-                  const slotName = defaultDateAdapter.toIso8601(new Date(`2025-01-${index + 1}`));
-                  return html` <sbb-calendar-day slot=${slotName}>
-                    ${content
-                      ? html` <span
-                          class="sbb-text-xxs"
-                          style="display: flex; flex-direction: column; justify-content: center; color: light-dark(var(--sbb-color-metal), var(--sbb-color-smoke));"
-                          >99.-</span
-                        >`
-                      : nothing}
-                  </sbb-calendar-day>`;
-                })}
-              </sbb-calendar>`,
+      describe(`content=${content}`, () => {
+        for (const state of [visualDiffHover, visualDiffActive, visualDiffFocus]) {
+          describe(`state=${state.name}`, () => {
+            it(
+              `today`,
+              state.with(async (setup) => {
+                await setup.withFixture(
+                  content ? calendarWithDaysAndContent() : calendarWithDays(),
+                );
+                setup.withStateElement(
+                  setup.snapshotElement.querySelector('sbb-calendar-day[slot="2025-01-01"]')!,
+                );
+              }),
             );
-            setup.withStateElement(
-              setup.snapshotElement.querySelector('sbb-calendar-day[slot="2025-01-01"]')!,
-            );
-          }),
-        );
 
-        it(
-          `selected state=${state.name} content=${content}`,
-          state.with(async (setup) => {
-            await setup.withFixture(
-              html` <sbb-calendar .value=${new Date('2025-01-15')}>
-                ${repeat(new Array(31), (_, index) => {
-                  const slotName = defaultDateAdapter.toIso8601(new Date(`2025-01-${index + 1}`));
-                  return html` <sbb-calendar-day slot=${slotName}>
-                    ${content
-                      ? html` <span
-                          class="sbb-text-xxs"
-                          style="display: flex; flex-direction: column; justify-content: center; color: light-dark(var(--sbb-color-metal), var(--sbb-color-smoke));"
-                          >99.-</span
-                        >`
-                      : nothing}
-                  </sbb-calendar-day>`;
-                })}
-              </sbb-calendar>`,
+            it(
+              `selected`,
+              state.with(async (setup) => {
+                await setup.withFixture(
+                  content
+                    ? calendarWithDaysAndContent(new Date('2025-01-15'))
+                    : calendarWithDays(new Date('2025-01-15')),
+                );
+                setup.withStateElement(
+                  setup.snapshotElement.querySelector('sbb-calendar-day[slot="2025-01-15"]')!,
+                );
+              }),
             );
-            setup.withStateElement(
-              setup.snapshotElement.querySelector('sbb-calendar-day[slot="2025-01-15"]')!,
+          });
+        }
+      });
+    }
+  });
+
+  describeViewports({ viewports: ['zero'] }, () => {
+    for (const { forcedColors, darkMode } of [
+      { forcedColors: false, darkMode: true },
+      { forcedColors: true, darkMode: false },
+    ]) {
+      describe(`forcedColors=${forcedColors} darkMode=${darkMode}`, () => {
+        for (const state of visualDiffStandardStates) {
+          describe(`state=${state.name}`, () => {
+            it(
+              `today`,
+              state.with(async (setup) => {
+                await setup.withFixture(calendarWithDays(), {
+                  darkMode,
+                  forcedColors,
+                });
+                setup.withStateElement(
+                  setup.snapshotElement.querySelector('sbb-calendar-day[slot="2025-01-01"]')!,
+                );
+              }),
             );
-          }),
-        );
-      }
+
+            it(
+              `selected`,
+              state.with(async (setup) => {
+                await setup.withFixture(calendarWithDays(new Date('2025-01-15')), {
+                  darkMode,
+                  forcedColors,
+                });
+                setup.withStateElement(
+                  setup.snapshotElement.querySelector('sbb-calendar-day[slot="2025-01-15"]')!,
+                );
+              }),
+            );
+          });
+        }
+      });
     }
   });
 });

--- a/src/elements/calendar/calendar-day/calendar-day.visual.spec.ts
+++ b/src/elements/calendar/calendar-day/calendar-day.visual.spec.ts
@@ -31,7 +31,7 @@ describe('sbb-calendar-day', () => {
         await setup.withFixture(
           html` <sbb-calendar
             .min=${defaultDateAdapter.toIso8601(new Date(2025, 0, 9))}
-            .selected=${defaultDateAdapter.toIso8601(new Date(2025, 0, 15))}
+            .value=${defaultDateAdapter.toIso8601(new Date(2025, 0, 15))}
             .dateFilter=${(d: Date): boolean => d.getDate() % 2 === 1}
           >
             ${repeat(new Array(31), (_, index) => {
@@ -74,7 +74,7 @@ describe('sbb-calendar-day', () => {
           `selected state=${state.name} content=${content}`,
           state.with(async (setup) => {
             await setup.withFixture(
-              html` <sbb-calendar .selected=${new Date('2025-01-15')}>
+              html` <sbb-calendar .value=${new Date('2025-01-15')}>
                 ${repeat(new Array(31), (_, index) => {
                   const slotName = defaultDateAdapter.toIso8601(new Date(`2025-01-${index + 1}`));
                   return html` <sbb-calendar-day slot=${slotName}>

--- a/src/elements/calendar/calendar-month/calendar-month.component.ts
+++ b/src/elements/calendar/calendar-month/calendar-month.component.ts
@@ -52,14 +52,14 @@ export class SbbCalendarMonthElement<T = Date> extends SbbCalendarCellBaseElemen
 
   protected override setSelectedState(parent: SbbCalendarElement<T>): void {
     const selected = parent.multiple
-      ? ((parent.selected as Date[])?.some(
+      ? ((parent.value as Date[])?.some(
           (date: Date) =>
             this._yearValue === this.dateAdapter.getYear(date) &&
             this._monthValue === this.dateAdapter.getMonth(date),
         ) ?? false)
-      : !!parent.selected &&
-        this.dateAdapter.getYear(parent.selected) === this._yearValue &&
-        this.dateAdapter.getMonth(parent.selected) === this._monthValue;
+      : !!parent.value &&
+        this.dateAdapter.getYear(parent.value) === this._yearValue &&
+        this.dateAdapter.getMonth(parent.value) === this._monthValue;
     this.toggleState('selected', selected);
     this.internals.ariaPressed = String(selected);
   }

--- a/src/elements/calendar/calendar-month/calendar-month.spec.ts
+++ b/src/elements/calendar/calendar-month/calendar-month.spec.ts
@@ -38,7 +38,7 @@ describe('sbb-calendar-month', () => {
   });
 
   it('should react to calendar property changes', async () => {
-    root.selected = new Date(`${year}-06-15`);
+    root.value = new Date(`${year}-06-15`);
     root.min = new Date(`${year}-03-15`);
     root.max = new Date(`${year}-09-15`);
     root.dateFilter = (d: Date | null): boolean => !!d && d.getMonth() % 2 === 1;

--- a/src/elements/calendar/calendar-month/calendar-month.visual.spec.ts
+++ b/src/elements/calendar/calendar-month/calendar-month.visual.spec.ts
@@ -36,7 +36,7 @@ describe('sbb-calendar-month', () => {
         <sbb-calendar
           view="month"
           .min=${defaultDateAdapter.toIso8601(new Date(2025, 2, 1))}
-          .selected=${defaultDateAdapter.toIso8601(new Date(2025, 11, 1))}
+          .value=${defaultDateAdapter.toIso8601(new Date(2025, 11, 1))}
           .dateFilter=${(d: Date): boolean => d.getMonth() !== 3 && d.getFullYear() !== 8}
         >
         </sbb-calendar>
@@ -54,7 +54,7 @@ describe('sbb-calendar-month', () => {
       `multiple`,
       visualDiffDefault.with(async (setup) => {
         await setup.withFixture(html`
-          <sbb-calendar view="month" multiple .selected=${selectedDate}></sbb-calendar>
+          <sbb-calendar view="month" multiple .value=${selectedDate}></sbb-calendar>
         `);
       }),
     );

--- a/src/elements/calendar/calendar-year/calendar-year.component.ts
+++ b/src/elements/calendar/calendar-year/calendar-year.component.ts
@@ -42,10 +42,10 @@ export class SbbCalendarYearElement<T = Date> extends SbbCalendarCellBaseElement
 
   protected override setSelectedState(parent: SbbCalendarElement<T>): void {
     const selected = parent.multiple
-      ? ((parent.selected as Date[])?.some(
+      ? ((parent.value as Date[])?.some(
           (date: Date) => Number(this.value) === this.dateAdapter.getYear(date),
         ) ?? false)
-      : !!parent.selected && this.dateAdapter.getYear(parent.selected) === Number(this.value);
+      : !!parent.value && this.dateAdapter.getYear(parent.value) === Number(this.value);
     this.toggleState('selected', selected);
     this.internals.ariaPressed = String(selected);
   }

--- a/src/elements/calendar/calendar-year/calendar-year.spec.ts
+++ b/src/elements/calendar/calendar-year/calendar-year.spec.ts
@@ -37,7 +37,7 @@ describe('sbb-calendar-year', () => {
   });
 
   it('should react to calendar property changes', async () => {
-    root.selected = new Date(`${year}-06-15`);
+    root.value = new Date(`${year}-06-15`);
     root.min = new Date(`${year - 2}-06-15`);
     root.max = new Date(`${year + 1}-06-15`);
     root.dateFilter = (d: Date | null): boolean =>

--- a/src/elements/calendar/calendar-year/calendar-year.visual.spec.ts
+++ b/src/elements/calendar/calendar-year/calendar-year.visual.spec.ts
@@ -36,7 +36,7 @@ describe('sbb-calendar-year', () => {
         <sbb-calendar
           view="year"
           .min=${defaultDateAdapter.toIso8601(new Date(2023, 0, 9))}
-          .selected=${defaultDateAdapter.toIso8601(new Date(2027, 0, 15))}
+          .value=${defaultDateAdapter.toIso8601(new Date(2027, 0, 15))}
           .dateFilter=${(d: Date): boolean => d.getFullYear() !== 2030 && d.getFullYear() !== 2031}
         >
         </sbb-calendar>
@@ -54,7 +54,7 @@ describe('sbb-calendar-year', () => {
       `multiple`,
       visualDiffDefault.with(async (setup) => {
         await setup.withFixture(html`
-          <sbb-calendar view="year" multiple .selected=${selectedDate}></sbb-calendar>
+          <sbb-calendar view="year" multiple .value=${selectedDate}></sbb-calendar>
         `);
       }),
     );

--- a/src/elements/calendar/calendar.stories.ts
+++ b/src/elements/calendar/calendar.stories.ts
@@ -18,20 +18,15 @@ import readme from './readme.md?raw';
 const today = new Date();
 today.setDate(today.getDate() >= 15 ? 8 : 18);
 
-const createDays = (wide: boolean, withPrice: boolean): TemplateResult => {
-  const year = defaultDateAdapter.getYear(today);
-  const month = defaultDateAdapter.getMonth(today);
-  if (wide) {
-    const todayNextMonth = defaultDateAdapter.addCalendarMonths(today, 1);
-    const yearNextMonth = defaultDateAdapter.getYear(todayNextMonth);
-    const nextMonth = defaultDateAdapter.getMonth(todayNextMonth);
-    return html`
-      ${createSlottedDays(year, month, withPrice)}
-      ${createSlottedDays(yearNextMonth, nextMonth, withPrice)}
-    `;
-  } else {
-    return createSlottedDays(year, month, withPrice);
-  }
+const createDays = (amount: number, withPrice: boolean): TemplateResult => {
+  return html`${Array.from({ length: amount }, (_, i) => {
+    const date = defaultDateAdapter.addCalendarMonths(today, i);
+    return createSlottedDays(
+      defaultDateAdapter.getYear(date),
+      defaultDateAdapter.getMonth(date),
+      withPrice,
+    );
+  })}`;
 };
 
 const getCalendarAttr = (min: number | string, max: number | string): Record<string, string> => {
@@ -62,15 +57,24 @@ const setSelectedForTemplate = (multiple: boolean, selected: Date | Date[]): Dat
   return selected;
 };
 
-const Template = ({ min, max, multiple, selected, dateFilter, ...args }: Args): TemplateResult => {
+const Template = ({
+  min,
+  max,
+  multiple,
+  selected,
+  dateFilter,
+  amount,
+  ...args
+}: Args): TemplateResult => {
   if (selected) {
     selected = setSelectedForTemplate(multiple, selected);
   }
   return html`
     <sbb-calendar
       ?multiple=${multiple}
-      .selected=${selected}
+      .value=${selected}
       .dateFilter="${dateFilter}"
+      amount=${amount}
       ${sbbSpread(getCalendarAttr(min, max))}
       ${sbbSpread(args)}
     ></sbb-calendar>
@@ -84,6 +88,7 @@ const EnhancedTemplate = ({
   selected,
   dateFilter,
   withPrice,
+  amount,
   ...args
 }: Args): TemplateResult => {
   if (selected) {
@@ -92,12 +97,13 @@ const EnhancedTemplate = ({
   return html`
     <sbb-calendar
       ?multiple=${multiple}
-      .selected=${selected}
+      .value=${selected}
       .dateFilter="${dateFilter}"
+      amount=${amount}
       ${sbbSpread(getCalendarAttr(min, max))}
       ${sbbSpread(args)}
       @monthchange=${(e: SbbMonthChangeEvent) => monthChangeHandler(e, withPrice)}
-      >${createDays(args.wide, withPrice)}</sbb-calendar
+      >${createDays(amount, withPrice)}</sbb-calendar
     >
   `;
 };
@@ -109,6 +115,7 @@ const MixedTemplate = ({
   selected,
   dateFilter,
   withPrice,
+  amount,
   ...args
 }: Args): TemplateResult => {
   if (selected) {
@@ -117,8 +124,9 @@ const MixedTemplate = ({
   return html`
     <sbb-calendar
       ?multiple=${multiple}
-      .selected=${selected}
+      .value=${selected}
       .dateFilter="${dateFilter}"
+      amount=${amount}
       ${sbbSpread(getCalendarAttr(min, max))}
       ${sbbSpread(args)}
     >
@@ -139,9 +147,9 @@ const MixedTemplate = ({
   `;
 };
 
-const wide: InputType = {
+const amount: InputType = {
   control: {
-    type: 'boolean',
+    type: 'number',
   },
   table: {
     category: 'Calendar',
@@ -243,7 +251,7 @@ const withPrice: InputType = {
 };
 
 const defaultArgTypes: ArgTypes = {
-  wide,
+  amount,
   'week-numbers': weekNumbers,
   multiple,
   orientation,
@@ -256,7 +264,7 @@ const defaultArgTypes: ArgTypes = {
 };
 
 const defaultArgs: Args = {
-  wide: false,
+  amount: 1,
   orientation: orientation.options![0],
   selected: today,
   view: view.options![0],
@@ -316,19 +324,19 @@ export const CalendarWeekNumbersMultiple: StoryObj = {
 export const CalendarWide: StoryObj = {
   render: Template,
   argTypes: { ...defaultArgTypes },
-  args: { ...defaultArgs, wide: true },
+  args: { ...defaultArgs, amount: 2 },
 };
 
 export const CalendarWideWeekNumbers: StoryObj = {
   render: Template,
   argTypes: { ...defaultArgTypes },
-  args: { ...defaultArgs, wide: true, 'week-numbers': true },
+  args: { ...defaultArgs, amount: 2, 'week-numbers': true },
 };
 
 export const CalendarWideWeekNumbersMultiple: StoryObj = {
   render: Template,
   argTypes: { ...defaultArgTypes },
-  args: { ...defaultArgs, wide: true, 'week-numbers': true, multiple: true, selected: [today] },
+  args: { ...defaultArgs, amount: 2, 'week-numbers': true, multiple: true, selected: [today] },
 };
 
 export const CalendarVertical: StoryObj = {
@@ -358,13 +366,13 @@ export const CalendarVerticalWeekNumbersMultiple: StoryObj = {
 export const CalendarVerticalWide: StoryObj = {
   render: Template,
   argTypes: { ...defaultArgTypes },
-  args: { ...defaultArgs, orientation: orientation.options![1], wide: true },
+  args: { ...defaultArgs, orientation: orientation.options![1], amount: 2 },
 };
 
 export const CalendarVerticalWideWeekNumbers: StoryObj = {
   render: Template,
   argTypes: { ...defaultArgTypes },
-  args: { ...defaultArgs, orientation: orientation.options![1], wide: true, 'week-numbers': true },
+  args: { ...defaultArgs, orientation: orientation.options![1], amount: 2, 'week-numbers': true },
 };
 
 export const CalendarVerticalWideWeekNumbersMultiple: StoryObj = {
@@ -373,7 +381,7 @@ export const CalendarVerticalWideWeekNumbersMultiple: StoryObj = {
   args: {
     ...defaultArgs,
     orientation: orientation.options![1],
-    wide: true,
+    amount: 2,
     'week-numbers': true,
     multiple: true,
     selected: [today],
@@ -407,13 +415,13 @@ export const CalendarEnhancedVertical: StoryObj = {
 export const CalendarEnhancedWide: StoryObj = {
   render: EnhancedTemplate,
   argTypes: { ...defaultArgTypes },
-  args: { ...defaultArgsEnhanced, wide: true },
+  args: { ...defaultArgsEnhanced, amount: 2 },
 };
 
 export const CalendarEnhancedWideWeekNumbers: StoryObj = {
   render: EnhancedTemplate,
   argTypes: { ...defaultArgTypes },
-  args: { ...defaultArgsEnhanced, wide: true, 'week-numbers': true },
+  args: { ...defaultArgsEnhanced, amount: 2, 'week-numbers': true },
 };
 
 export const CalendarEnhancedWideWeekNumbersMultiple: StoryObj = {
@@ -421,7 +429,7 @@ export const CalendarEnhancedWideWeekNumbersMultiple: StoryObj = {
   argTypes: { ...defaultArgTypes },
   args: {
     ...defaultArgsEnhanced,
-    wide: true,
+    amount: 2,
     'week-numbers': true,
     multiple: true,
     selected: [today],

--- a/src/elements/calendar/calendar.stories.ts
+++ b/src/elements/calendar/calendar.stories.ts
@@ -178,7 +178,7 @@ const orientation: InputType = {
   control: {
     type: 'inline-radio',
   },
-  options: ['horizontal', 'vertical'],
+  options: ['horizontal', 'vertical'] satisfies SbbCalendarElement['orientation'][],
   table: {
     category: 'Calendar',
   },
@@ -215,7 +215,7 @@ const view: InputType = {
   control: {
     type: 'inline-radio',
   },
-  options: ['day', 'month', 'year'],
+  options: ['day', 'month', 'year'] satisfies SbbCalendarElement['view'][],
 };
 
 const filterFunctions = [
@@ -260,7 +260,6 @@ const defaultArgTypes: ArgTypes = {
   max,
   dateFilter,
   view,
-  withPrice,
 };
 
 const defaultArgs: Args = {
@@ -270,7 +269,11 @@ const defaultArgs: Args = {
   view: view.options![0],
   'week-numbers': false,
   multiple: false,
-  withPrice: false,
+};
+
+const defaultArgTypesEnhanced: Args = {
+  ...defaultArgTypes,
+  withPrice,
 };
 
 const defaultArgsEnhanced: Args = {
@@ -390,43 +393,43 @@ export const CalendarVerticalWideWeekNumbersMultiple: StoryObj = {
 
 export const CalendarMixed: StoryObj = {
   render: MixedTemplate,
-  argTypes: { ...defaultArgTypes },
-  args: { ...defaultArgs, withPrice: true },
+  argTypes: { ...defaultArgTypesEnhanced },
+  args: { ...defaultArgsEnhanced, withPrice: true },
 };
 
 export const CalendarEnhanced: StoryObj = {
   render: EnhancedTemplate,
-  argTypes: { ...defaultArgTypes },
+  argTypes: { ...defaultArgTypesEnhanced },
   args: { ...defaultArgsEnhanced },
 };
 
 export const CalendarEnhancedNoExtraContent: StoryObj = {
   render: EnhancedTemplate,
-  argTypes: { ...defaultArgTypes },
+  argTypes: { ...defaultArgTypesEnhanced },
   args: { ...defaultArgs },
 };
 
 export const CalendarEnhancedVertical: StoryObj = {
   render: EnhancedTemplate,
-  argTypes: { ...defaultArgTypes },
+  argTypes: { ...defaultArgTypesEnhanced },
   args: { ...defaultArgsEnhanced, orientation: orientation.options![1] },
 };
 
 export const CalendarEnhancedWide: StoryObj = {
   render: EnhancedTemplate,
-  argTypes: { ...defaultArgTypes },
+  argTypes: { ...defaultArgTypesEnhanced },
   args: { ...defaultArgsEnhanced, amount: 2 },
 };
 
 export const CalendarEnhancedWideWeekNumbers: StoryObj = {
   render: EnhancedTemplate,
-  argTypes: { ...defaultArgTypes },
+  argTypes: { ...defaultArgTypesEnhanced },
   args: { ...defaultArgsEnhanced, amount: 2, 'week-numbers': true },
 };
 
 export const CalendarEnhancedWideWeekNumbersMultiple: StoryObj = {
   render: EnhancedTemplate,
-  argTypes: { ...defaultArgTypes },
+  argTypes: { ...defaultArgTypesEnhanced },
   args: {
     ...defaultArgsEnhanced,
     amount: 2,

--- a/src/elements/calendar/calendar.stories.ts
+++ b/src/elements/calendar/calendar.stories.ts
@@ -40,39 +40,39 @@ const getCalendarAttr = (min: number | string, max: number | string): Record<str
   return attr;
 };
 
-const setSelectedForTemplate = (multiple: boolean, selected: Date | Date[]): Date | Date[] => {
+const getValueForTemplate = (multiple: boolean, value: Date | Date[]): Date | Date[] => {
   if (multiple) {
-    if (!Array.isArray(selected)) {
-      selected = [new Date(selected)];
+    if (!Array.isArray(value)) {
+      value = [new Date(value)];
     } else {
-      selected = selected.map((e) => new Date(e));
+      value = value.map((e) => new Date(e));
     }
   } else {
-    if (Array.isArray(selected)) {
-      selected = new Date(selected[0]);
+    if (Array.isArray(value)) {
+      value = new Date(value[0]);
     } else {
-      selected = new Date(selected);
+      value = new Date(value);
     }
   }
-  return selected;
+  return value;
 };
 
 const Template = ({
   min,
   max,
   multiple,
-  selected,
+  value,
   dateFilter,
   amount,
   ...args
 }: Args): TemplateResult => {
-  if (selected) {
-    selected = setSelectedForTemplate(multiple, selected);
+  if (value) {
+    value = getValueForTemplate(multiple, value);
   }
   return html`
     <sbb-calendar
       ?multiple=${multiple}
-      .value=${selected}
+      .value=${value}
       .dateFilter="${dateFilter}"
       amount=${amount}
       ${sbbSpread(getCalendarAttr(min, max))}
@@ -85,19 +85,19 @@ const EnhancedTemplate = ({
   min,
   max,
   multiple,
-  selected,
+  value,
   dateFilter,
   withPrice,
   amount,
   ...args
 }: Args): TemplateResult => {
-  if (selected) {
-    selected = setSelectedForTemplate(multiple, selected);
+  if (value) {
+    value = getValueForTemplate(multiple, value);
   }
   return html`
     <sbb-calendar
       ?multiple=${multiple}
-      .value=${selected}
+      .value=${value}
       .dateFilter="${dateFilter}"
       amount=${amount}
       ${sbbSpread(getCalendarAttr(min, max))}
@@ -112,19 +112,19 @@ const MixedTemplate = ({
   min,
   max,
   multiple,
-  selected,
+  value,
   dateFilter,
   withPrice,
   amount,
   ...args
 }: Args): TemplateResult => {
-  if (selected) {
-    selected = setSelectedForTemplate(multiple, selected);
+  if (value) {
+    value = getValueForTemplate(multiple, value);
   }
   return html`
     <sbb-calendar
       ?multiple=${multiple}
-      .value=${selected}
+      .value=${value}
       .dateFilter="${dateFilter}"
       amount=${amount}
       ${sbbSpread(getCalendarAttr(min, max))}
@@ -184,7 +184,7 @@ const orientation: InputType = {
   },
 };
 
-const selected: InputType = {
+const value: InputType = {
   control: {
     type: 'date',
   },
@@ -255,7 +255,7 @@ const defaultArgTypes: ArgTypes = {
   'week-numbers': weekNumbers,
   multiple,
   orientation,
-  selected,
+  value,
   min,
   max,
   dateFilter,
@@ -265,7 +265,7 @@ const defaultArgTypes: ArgTypes = {
 const defaultArgs: Args = {
   amount: 1,
   orientation: orientation.options![0],
-  selected: today,
+  value: today,
   view: view.options![0],
   'week-numbers': false,
   multiple: false,
@@ -321,7 +321,7 @@ export const CalendarWeekNumbers: StoryObj = {
 export const CalendarWeekNumbersMultiple: StoryObj = {
   render: Template,
   argTypes: { ...defaultArgTypes },
-  args: { ...defaultArgs, 'week-numbers': true, multiple: true, selected: [today] },
+  args: { ...defaultArgs, 'week-numbers': true, multiple: true, value: [today] },
 };
 
 export const CalendarWide: StoryObj = {
@@ -339,7 +339,7 @@ export const CalendarWideWeekNumbers: StoryObj = {
 export const CalendarWideWeekNumbersMultiple: StoryObj = {
   render: Template,
   argTypes: { ...defaultArgTypes },
-  args: { ...defaultArgs, amount: 2, 'week-numbers': true, multiple: true, selected: [today] },
+  args: { ...defaultArgs, amount: 2, 'week-numbers': true, multiple: true, value: [today] },
 };
 
 export const CalendarVertical: StoryObj = {
@@ -362,7 +362,7 @@ export const CalendarVerticalWeekNumbersMultiple: StoryObj = {
     orientation: orientation.options![1],
     'week-numbers': true,
     multiple: true,
-    selected: [today],
+    value: [today],
   },
 };
 
@@ -387,7 +387,7 @@ export const CalendarVerticalWideWeekNumbersMultiple: StoryObj = {
     amount: 2,
     'week-numbers': true,
     multiple: true,
-    selected: [today],
+    value: [today],
   },
 };
 
@@ -435,7 +435,7 @@ export const CalendarEnhancedWideWeekNumbersMultiple: StoryObj = {
     amount: 2,
     'week-numbers': true,
     multiple: true,
-    selected: [today],
+    value: [today],
   },
 };
 

--- a/src/elements/calendar/calendar/__snapshots__/calendar.snapshot.spec.snap.js
+++ b/src/elements/calendar/calendar/__snapshots__/calendar.snapshot.spec.snap.js
@@ -4,7 +4,7 @@ export const snapshots = {};
 snapshots["sbb-calendar default renders DOM"] = 
 `<sbb-calendar
   orientation="horizontal"
-  selected="2023-01-20T00:00:00"
+  value="2023-01-20T00:00:00"
 >
 </sbb-calendar>
 `;
@@ -12,411 +12,403 @@ snapshots["sbb-calendar default renders DOM"] =
 
 snapshots["sbb-calendar default renders Shadow DOM"] = 
 `<div class="sbb-calendar__wrapper">
-  <div class="sbb-calendar__controls">
-    <sbb-secondary-button
-      aria-label="Change to the previous month"
-      icon-name="chevron-small-left-small"
-      id="sbb-calendar__controls-previous"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-    <div class="sbb-calendar__controls-month">
-      <button
-        aria-label="Choose year and month January 2023"
-        class="sbb-calendar__controls-change-date sbb-calendar__date-selection"
-        type="button"
-      >
-        January 2023
-        <sbb-icon name="chevron-small-down-small">
-        </sbb-icon>
-      </button>
-      <span
-        class="sbb-screen-reader-only"
-        role="status"
-      >
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
         January 2023
       </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose year and month January 2023"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-up-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Change to the next month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
     </div>
-    <sbb-secondary-button
-      aria-label="Change to the next month"
-      icon-name="chevron-small-right-small"
-      id="sbb-calendar__controls-next"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-  </div>
-  <div class="sbb-calendar__table-overflow-break">
-    <div class="sbb-calendar__table-container sbb-calendar__table-day-view">
-      <table class="sbb-calendar__table">
-        <thead class="sbb-calendar__table-header">
-          <tr>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Monday
-              </span>
-              <span aria-hidden="true">
-                M
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Tuesday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Wednesday
-              </span>
-              <span aria-hidden="true">
-                W
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Thursday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Friday
-              </span>
-              <span aria-hidden="true">
-                F
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Saturday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Sunday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-01">
-                <sbb-calendar-day
-                  slot="2023-01-01"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-02">
-                <sbb-calendar-day
-                  slot="2023-01-02"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-03">
-                <sbb-calendar-day
-                  slot="2023-01-03"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-04">
-                <sbb-calendar-day
-                  slot="2023-01-04"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-05">
-                <sbb-calendar-day
-                  slot="2023-01-05"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-06">
-                <sbb-calendar-day
-                  slot="2023-01-06"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-07">
-                <sbb-calendar-day
-                  slot="2023-01-07"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-08">
-                <sbb-calendar-day
-                  slot="2023-01-08"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-09">
-                <sbb-calendar-day
-                  slot="2023-01-09"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-10">
-                <sbb-calendar-day
-                  slot="2023-01-10"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-11">
-                <sbb-calendar-day
-                  slot="2023-01-11"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-12">
-                <sbb-calendar-day
-                  slot="2023-01-12"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-13">
-                <sbb-calendar-day
-                  slot="2023-01-13"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-14">
-                <sbb-calendar-day
-                  slot="2023-01-14"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-15">
-                <sbb-calendar-day
-                  slot="2023-01-15"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-16">
-                <sbb-calendar-day
-                  slot="2023-01-16"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-17">
-                <sbb-calendar-day
-                  slot="2023-01-17"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-18">
-                <sbb-calendar-day
-                  slot="2023-01-18"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-19">
-                <sbb-calendar-day
-                  slot="2023-01-19"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-20">
-                <sbb-calendar-day
-                  slot="2023-01-20"
-                  tabindex="0"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-21">
-                <sbb-calendar-day
-                  slot="2023-01-21"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-22">
-                <sbb-calendar-day
-                  slot="2023-01-22"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-23">
-                <sbb-calendar-day
-                  slot="2023-01-23"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-24">
-                <sbb-calendar-day
-                  slot="2023-01-24"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-25">
-                <sbb-calendar-day
-                  slot="2023-01-25"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-26">
-                <sbb-calendar-day
-                  slot="2023-01-26"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-27">
-                <sbb-calendar-day
-                  slot="2023-01-27"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-28">
-                <sbb-calendar-day
-                  slot="2023-01-28"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-29">
-                <sbb-calendar-day
-                  slot="2023-01-29"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-30">
-                <sbb-calendar-day
-                  slot="2023-01-30"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-31">
-                <sbb-calendar-day
-                  slot="2023-01-31"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <table class="sbb-calendar__table">
+      <thead>
+        <tr>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Monday
+            </span>
+            <span aria-hidden="true">
+              M
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Tuesday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Wednesday
+            </span>
+            <span aria-hidden="true">
+              W
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Thursday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Friday
+            </span>
+            <span aria-hidden="true">
+              F
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Saturday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Sunday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-01">
+              <sbb-calendar-day
+                slot="2023-01-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-02">
+              <sbb-calendar-day
+                slot="2023-01-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-03">
+              <sbb-calendar-day
+                slot="2023-01-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-04">
+              <sbb-calendar-day
+                slot="2023-01-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-05">
+              <sbb-calendar-day
+                slot="2023-01-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-06">
+              <sbb-calendar-day
+                slot="2023-01-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-07">
+              <sbb-calendar-day
+                slot="2023-01-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-08">
+              <sbb-calendar-day
+                slot="2023-01-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-09">
+              <sbb-calendar-day
+                slot="2023-01-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-10">
+              <sbb-calendar-day
+                slot="2023-01-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-11">
+              <sbb-calendar-day
+                slot="2023-01-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-12">
+              <sbb-calendar-day
+                slot="2023-01-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-13">
+              <sbb-calendar-day
+                slot="2023-01-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-14">
+              <sbb-calendar-day
+                slot="2023-01-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-15">
+              <sbb-calendar-day
+                slot="2023-01-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-16">
+              <sbb-calendar-day
+                slot="2023-01-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-17">
+              <sbb-calendar-day
+                slot="2023-01-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-18">
+              <sbb-calendar-day
+                slot="2023-01-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-19">
+              <sbb-calendar-day
+                slot="2023-01-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-20">
+              <sbb-calendar-day
+                slot="2023-01-20"
+                tabindex="0"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-21">
+              <sbb-calendar-day
+                slot="2023-01-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-22">
+              <sbb-calendar-day
+                slot="2023-01-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-23">
+              <sbb-calendar-day
+                slot="2023-01-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-24">
+              <sbb-calendar-day
+                slot="2023-01-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-25">
+              <sbb-calendar-day
+                slot="2023-01-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-26">
+              <sbb-calendar-day
+                slot="2023-01-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-27">
+              <sbb-calendar-day
+                slot="2023-01-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-28">
+              <sbb-calendar-day
+                slot="2023-01-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-29">
+              <sbb-calendar-day
+                slot="2023-01-29"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-30">
+              <sbb-calendar-day
+                slot="2023-01-30"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-31">
+              <sbb-calendar-day
+                slot="2023-01-31"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -425,7 +417,7 @@ snapshots["sbb-calendar default renders Shadow DOM"] =
 snapshots["sbb-calendar default renders vertical DOM"] = 
 `<sbb-calendar
   orientation="vertical"
-  selected="2023-01-20T00:00:00"
+  value="2023-01-20T00:00:00"
 >
 </sbb-calendar>
 `;
@@ -433,409 +425,401 @@ snapshots["sbb-calendar default renders vertical DOM"] =
 
 snapshots["sbb-calendar default renders vertical Shadow DOM"] = 
 `<div class="sbb-calendar__wrapper">
-  <div class="sbb-calendar__controls">
-    <sbb-secondary-button
-      aria-label="Change to the previous month"
-      icon-name="chevron-small-left-small"
-      id="sbb-calendar__controls-previous"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-    <div class="sbb-calendar__controls-month">
-      <button
-        aria-label="Choose year and month January 2023"
-        class="sbb-calendar__controls-change-date sbb-calendar__date-selection"
-        type="button"
-      >
-        January 2023
-        <sbb-icon name="chevron-small-down-small">
-        </sbb-icon>
-      </button>
-      <span
-        class="sbb-screen-reader-only"
-        role="status"
-      >
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
         January 2023
       </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose year and month January 2023"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-up-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Change to the next month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
     </div>
-    <sbb-secondary-button
-      aria-label="Change to the next month"
-      icon-name="chevron-small-right-small"
-      id="sbb-calendar__controls-next"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-  </div>
-  <div class="sbb-calendar__table-overflow-break">
-    <div class="sbb-calendar__table-container sbb-calendar__table-day-view">
-      <table class="sbb-calendar__table">
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Monday
-              </span>
-              <span aria-hidden="true">
-                M
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-02">
-                <sbb-calendar-day
-                  slot="2023-01-02"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-09">
-                <sbb-calendar-day
-                  slot="2023-01-09"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-16">
-                <sbb-calendar-day
-                  slot="2023-01-16"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-23">
-                <sbb-calendar-day
-                  slot="2023-01-23"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-30">
-                <sbb-calendar-day
-                  slot="2023-01-30"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Tuesday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-03">
-                <sbb-calendar-day
-                  slot="2023-01-03"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-10">
-                <sbb-calendar-day
-                  slot="2023-01-10"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-17">
-                <sbb-calendar-day
-                  slot="2023-01-17"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-24">
-                <sbb-calendar-day
-                  slot="2023-01-24"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-31">
-                <sbb-calendar-day
-                  slot="2023-01-31"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Wednesday
-              </span>
-              <span aria-hidden="true">
-                W
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-04">
-                <sbb-calendar-day
-                  slot="2023-01-04"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-11">
-                <sbb-calendar-day
-                  slot="2023-01-11"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-18">
-                <sbb-calendar-day
-                  slot="2023-01-18"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-25">
-                <sbb-calendar-day
-                  slot="2023-01-25"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Thursday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-05">
-                <sbb-calendar-day
-                  slot="2023-01-05"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-12">
-                <sbb-calendar-day
-                  slot="2023-01-12"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-19">
-                <sbb-calendar-day
-                  slot="2023-01-19"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-26">
-                <sbb-calendar-day
-                  slot="2023-01-26"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Friday
-              </span>
-              <span aria-hidden="true">
-                F
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-06">
-                <sbb-calendar-day
-                  slot="2023-01-06"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-13">
-                <sbb-calendar-day
-                  slot="2023-01-13"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-20">
-                <sbb-calendar-day
-                  slot="2023-01-20"
-                  tabindex="0"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-27">
-                <sbb-calendar-day
-                  slot="2023-01-27"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Saturday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-07">
-                <sbb-calendar-day
-                  slot="2023-01-07"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-14">
-                <sbb-calendar-day
-                  slot="2023-01-14"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-21">
-                <sbb-calendar-day
-                  slot="2023-01-21"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-28">
-                <sbb-calendar-day
-                  slot="2023-01-28"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Sunday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-01">
-                <sbb-calendar-day
-                  slot="2023-01-01"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-08">
-                <sbb-calendar-day
-                  slot="2023-01-08"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-15">
-                <sbb-calendar-day
-                  slot="2023-01-15"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-22">
-                <sbb-calendar-day
-                  slot="2023-01-22"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-29">
-                <sbb-calendar-day
-                  slot="2023-01-29"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <table class="sbb-calendar__table">
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Monday
+            </span>
+            <span aria-hidden="true">
+              M
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-02">
+              <sbb-calendar-day
+                slot="2023-01-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-09">
+              <sbb-calendar-day
+                slot="2023-01-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-16">
+              <sbb-calendar-day
+                slot="2023-01-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-23">
+              <sbb-calendar-day
+                slot="2023-01-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-30">
+              <sbb-calendar-day
+                slot="2023-01-30"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Tuesday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-03">
+              <sbb-calendar-day
+                slot="2023-01-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-10">
+              <sbb-calendar-day
+                slot="2023-01-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-17">
+              <sbb-calendar-day
+                slot="2023-01-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-24">
+              <sbb-calendar-day
+                slot="2023-01-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-31">
+              <sbb-calendar-day
+                slot="2023-01-31"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Wednesday
+            </span>
+            <span aria-hidden="true">
+              W
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-04">
+              <sbb-calendar-day
+                slot="2023-01-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-11">
+              <sbb-calendar-day
+                slot="2023-01-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-18">
+              <sbb-calendar-day
+                slot="2023-01-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-25">
+              <sbb-calendar-day
+                slot="2023-01-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Thursday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-05">
+              <sbb-calendar-day
+                slot="2023-01-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-12">
+              <sbb-calendar-day
+                slot="2023-01-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-19">
+              <sbb-calendar-day
+                slot="2023-01-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-26">
+              <sbb-calendar-day
+                slot="2023-01-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Friday
+            </span>
+            <span aria-hidden="true">
+              F
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-06">
+              <sbb-calendar-day
+                slot="2023-01-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-13">
+              <sbb-calendar-day
+                slot="2023-01-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-20">
+              <sbb-calendar-day
+                slot="2023-01-20"
+                tabindex="0"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-27">
+              <sbb-calendar-day
+                slot="2023-01-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Saturday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-07">
+              <sbb-calendar-day
+                slot="2023-01-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-14">
+              <sbb-calendar-day
+                slot="2023-01-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-21">
+              <sbb-calendar-day
+                slot="2023-01-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-28">
+              <sbb-calendar-day
+                slot="2023-01-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Sunday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-01">
+              <sbb-calendar-day
+                slot="2023-01-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-08">
+              <sbb-calendar-day
+                slot="2023-01-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-15">
+              <sbb-calendar-day
+                slot="2023-01-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-22">
+              <sbb-calendar-day
+                slot="2023-01-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-29">
+              <sbb-calendar-day
+                slot="2023-01-29"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -844,7 +828,7 @@ snapshots["sbb-calendar default renders vertical Shadow DOM"] =
 snapshots["sbb-calendar default renders in year view DOM"] = 
 `<sbb-calendar
   orientation="horizontal"
-  selected="2023-01-20T00:00:00"
+  value="2023-01-20T00:00:00"
   view="year"
 >
 </sbb-calendar>
@@ -859,7 +843,8 @@ snapshots["sbb-calendar default renders A11y tree Chrome"] =
   "children": [
     {
       "role": "generic",
-      "name": ""
+      "name": "",
+      "invalid": false
     }
   ]
 }
@@ -869,157 +854,552 @@ snapshots["sbb-calendar default renders A11y tree Chrome"] =
 
 snapshots["sbb-calendar default renders in year view Shadow DOM"] = 
 `<div class="sbb-calendar__wrapper">
-  <div class="sbb-calendar__controls">
-    <sbb-secondary-button
-      aria-label="Change to the previous 24 years"
-      icon-name="chevron-small-left-small"
-      id="sbb-calendar__controls-previous"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-    <div class="sbb-calendar__controls-month">
-      <button
-        aria-label="Choose date 2016 - 2039"
-        class="sbb-calendar__controls-change-date"
-        id="sbb-calendar__year-selection"
-        type="button"
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
+        January 2023
+      </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
       >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose year and month January 2023"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-up-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Change to the next month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+    </div>
+    <table class="sbb-calendar__table">
+      <thead>
+        <tr>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Monday
+            </span>
+            <span aria-hidden="true">
+              M
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Tuesday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Wednesday
+            </span>
+            <span aria-hidden="true">
+              W
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Thursday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Friday
+            </span>
+            <span aria-hidden="true">
+              F
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Saturday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Sunday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-01">
+              <sbb-calendar-day
+                slot="2023-01-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-02">
+              <sbb-calendar-day
+                slot="2023-01-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-03">
+              <sbb-calendar-day
+                slot="2023-01-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-04">
+              <sbb-calendar-day
+                slot="2023-01-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-05">
+              <sbb-calendar-day
+                slot="2023-01-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-06">
+              <sbb-calendar-day
+                slot="2023-01-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-07">
+              <sbb-calendar-day
+                slot="2023-01-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-08">
+              <sbb-calendar-day
+                slot="2023-01-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-09">
+              <sbb-calendar-day
+                slot="2023-01-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-10">
+              <sbb-calendar-day
+                slot="2023-01-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-11">
+              <sbb-calendar-day
+                slot="2023-01-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-12">
+              <sbb-calendar-day
+                slot="2023-01-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-13">
+              <sbb-calendar-day
+                slot="2023-01-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-14">
+              <sbb-calendar-day
+                slot="2023-01-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-15">
+              <sbb-calendar-day
+                slot="2023-01-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-16">
+              <sbb-calendar-day
+                slot="2023-01-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-17">
+              <sbb-calendar-day
+                slot="2023-01-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-18">
+              <sbb-calendar-day
+                slot="2023-01-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-19">
+              <sbb-calendar-day
+                slot="2023-01-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-20">
+              <sbb-calendar-day
+                slot="2023-01-20"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-21">
+              <sbb-calendar-day
+                slot="2023-01-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-22">
+              <sbb-calendar-day
+                slot="2023-01-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-23">
+              <sbb-calendar-day
+                slot="2023-01-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-24">
+              <sbb-calendar-day
+                slot="2023-01-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-25">
+              <sbb-calendar-day
+                slot="2023-01-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-26">
+              <sbb-calendar-day
+                slot="2023-01-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-27">
+              <sbb-calendar-day
+                slot="2023-01-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-28">
+              <sbb-calendar-day
+                slot="2023-01-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-29">
+              <sbb-calendar-day
+                slot="2023-01-29"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-30">
+              <sbb-calendar-day
+                slot="2023-01-30"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-31">
+              <sbb-calendar-day
+                slot="2023-01-31"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="sbb-calendar__table-wrapper sbb-calendar__year-view">
+    <div class="sbb-calendar__table-header">
+      <span>
         2016 - 2039
-        <sbb-icon name="chevron-small-up-small">
-        </sbb-icon>
-      </button>
+      </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous 24 years"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose date 2016 - 2039"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-down-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
       <span
         class="sbb-screen-reader-only"
         role="status"
       >
         2016 - 2039
       </span>
+      <sbb-secondary-button
+        aria-label="Change to the next 24 years"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
     </div>
-    <sbb-secondary-button
-      aria-label="Change to the next 24 years"
-      icon-name="chevron-small-right-small"
-      id="sbb-calendar__controls-next"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-  </div>
-  <div class="sbb-calendar__table-overflow-break">
-    <div class="sbb-calendar__table-container sbb-calendar__table-year-view">
-      <table class="sbb-calendar__table">
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="0">
-              </sbb-calendar-year>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <table class="sbb-calendar__table">
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="0">
+            </sbb-calendar-year>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -1028,7 +1408,7 @@ snapshots["sbb-calendar default renders in year view Shadow DOM"] =
 snapshots["sbb-calendar default renders in month view DOM"] = 
 `<sbb-calendar
   orientation="horizontal"
-  selected="2023-01-20T00:00:00"
+  value="2023-01-20T00:00:00"
   view="month"
 >
 </sbb-calendar>
@@ -1037,103 +1417,498 @@ snapshots["sbb-calendar default renders in month view DOM"] =
 
 snapshots["sbb-calendar default renders in month view Shadow DOM"] = 
 `<div class="sbb-calendar__wrapper">
-  <div class="sbb-calendar__controls">
-    <sbb-secondary-button
-      aria-label="Change to the previous year"
-      icon-name="chevron-small-left-small"
-      id="sbb-calendar__controls-previous"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-    <div class="sbb-calendar__controls-month">
-      <button
-        aria-label="Choose date 2023"
-        class="sbb-calendar__controls-change-date"
-        id="sbb-calendar__month-selection"
-        type="button"
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
+        January 2023
+      </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
       >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose year and month January 2023"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-up-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Change to the next month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+    </div>
+    <table class="sbb-calendar__table">
+      <thead>
+        <tr>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Monday
+            </span>
+            <span aria-hidden="true">
+              M
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Tuesday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Wednesday
+            </span>
+            <span aria-hidden="true">
+              W
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Thursday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Friday
+            </span>
+            <span aria-hidden="true">
+              F
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Saturday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Sunday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-01">
+              <sbb-calendar-day
+                slot="2023-01-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-02">
+              <sbb-calendar-day
+                slot="2023-01-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-03">
+              <sbb-calendar-day
+                slot="2023-01-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-04">
+              <sbb-calendar-day
+                slot="2023-01-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-05">
+              <sbb-calendar-day
+                slot="2023-01-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-06">
+              <sbb-calendar-day
+                slot="2023-01-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-07">
+              <sbb-calendar-day
+                slot="2023-01-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-08">
+              <sbb-calendar-day
+                slot="2023-01-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-09">
+              <sbb-calendar-day
+                slot="2023-01-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-10">
+              <sbb-calendar-day
+                slot="2023-01-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-11">
+              <sbb-calendar-day
+                slot="2023-01-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-12">
+              <sbb-calendar-day
+                slot="2023-01-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-13">
+              <sbb-calendar-day
+                slot="2023-01-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-14">
+              <sbb-calendar-day
+                slot="2023-01-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-15">
+              <sbb-calendar-day
+                slot="2023-01-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-16">
+              <sbb-calendar-day
+                slot="2023-01-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-17">
+              <sbb-calendar-day
+                slot="2023-01-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-18">
+              <sbb-calendar-day
+                slot="2023-01-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-19">
+              <sbb-calendar-day
+                slot="2023-01-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-20">
+              <sbb-calendar-day
+                slot="2023-01-20"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-21">
+              <sbb-calendar-day
+                slot="2023-01-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-22">
+              <sbb-calendar-day
+                slot="2023-01-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-23">
+              <sbb-calendar-day
+                slot="2023-01-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-24">
+              <sbb-calendar-day
+                slot="2023-01-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-25">
+              <sbb-calendar-day
+                slot="2023-01-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-26">
+              <sbb-calendar-day
+                slot="2023-01-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-27">
+              <sbb-calendar-day
+                slot="2023-01-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-28">
+              <sbb-calendar-day
+                slot="2023-01-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-29">
+              <sbb-calendar-day
+                slot="2023-01-29"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-30">
+              <sbb-calendar-day
+                slot="2023-01-30"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-31">
+              <sbb-calendar-day
+                slot="2023-01-31"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="sbb-calendar__month-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
         2023
-        <sbb-icon name="chevron-small-up-small">
-        </sbb-icon>
-      </button>
+      </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous year"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose date 2023"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-down-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
       <span
         class="sbb-screen-reader-only"
         role="status"
       >
         2023
       </span>
+      <sbb-secondary-button
+        aria-label="Change to the next year"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
     </div>
-    <sbb-secondary-button
-      aria-label="Change to the next year"
-      icon-name="chevron-small-right-small"
-      id="sbb-calendar__controls-next"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-  </div>
-  <div class="sbb-calendar__table-overflow-break">
-    <div class="sbb-calendar__table-container sbb-calendar__table-month-view">
-      <table class="sbb-calendar__table">
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="0">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <table class="sbb-calendar__table">
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="0">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -1143,7 +1918,7 @@ snapshots["sbb-calendar default renders multiple DOM"] =
 `<sbb-calendar
   multiple=""
   orientation="horizontal"
-  selected="2023-01-20T00:00:00"
+  value="2023-01-20T00:00:00"
 >
 </sbb-calendar>
 `;
@@ -1151,383 +1926,375 @@ snapshots["sbb-calendar default renders multiple DOM"] =
 
 snapshots["sbb-calendar default renders multiple Shadow DOM"] = 
 `<div class="sbb-calendar__wrapper">
-  <div class="sbb-calendar__controls">
-    <sbb-secondary-button
-      aria-label="Change to the previous month"
-      icon-name="chevron-small-left-small"
-      id="sbb-calendar__controls-previous"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-    <div class="sbb-calendar__controls-month">
-      <button
-        aria-label="Choose year and month January 2023"
-        class="sbb-calendar__controls-change-date sbb-calendar__date-selection"
-        type="button"
-      >
-        January 2023
-        <sbb-icon name="chevron-small-down-small">
-        </sbb-icon>
-      </button>
-      <span
-        class="sbb-screen-reader-only"
-        role="status"
-      >
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
         January 2023
       </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose year and month January 2023"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-up-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Change to the next month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
     </div>
-    <sbb-secondary-button
-      aria-label="Change to the next month"
-      icon-name="chevron-small-right-small"
-      id="sbb-calendar__controls-next"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-  </div>
-  <div class="sbb-calendar__table-overflow-break">
-    <div class="sbb-calendar__table-container sbb-calendar__table-day-view">
-      <table class="sbb-calendar__table">
-        <thead class="sbb-calendar__table-header">
-          <tr>
-            <th class="sbb-calendar__table-header-cell">
-              <sbb-calendar-weekday tabindex="0">
-              </sbb-calendar-weekday>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <sbb-calendar-weekday tabindex="0">
-              </sbb-calendar-weekday>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <sbb-calendar-weekday tabindex="0">
-              </sbb-calendar-weekday>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <sbb-calendar-weekday tabindex="0">
-              </sbb-calendar-weekday>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <sbb-calendar-weekday tabindex="0">
-              </sbb-calendar-weekday>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <sbb-calendar-weekday tabindex="0">
-              </sbb-calendar-weekday>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <sbb-calendar-weekday tabindex="0">
-              </sbb-calendar-weekday>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-01">
-                <sbb-calendar-day
-                  slot="2023-01-01"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-02">
-                <sbb-calendar-day
-                  slot="2023-01-02"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-03">
-                <sbb-calendar-day
-                  slot="2023-01-03"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-04">
-                <sbb-calendar-day
-                  slot="2023-01-04"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-05">
-                <sbb-calendar-day
-                  slot="2023-01-05"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-06">
-                <sbb-calendar-day
-                  slot="2023-01-06"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-07">
-                <sbb-calendar-day
-                  slot="2023-01-07"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-08">
-                <sbb-calendar-day
-                  slot="2023-01-08"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-09">
-                <sbb-calendar-day
-                  slot="2023-01-09"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-10">
-                <sbb-calendar-day
-                  slot="2023-01-10"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-11">
-                <sbb-calendar-day
-                  slot="2023-01-11"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-12">
-                <sbb-calendar-day
-                  slot="2023-01-12"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-13">
-                <sbb-calendar-day
-                  slot="2023-01-13"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-14">
-                <sbb-calendar-day
-                  slot="2023-01-14"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-15">
-                <sbb-calendar-day
-                  slot="2023-01-15"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-16">
-                <sbb-calendar-day
-                  slot="2023-01-16"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-17">
-                <sbb-calendar-day
-                  slot="2023-01-17"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-18">
-                <sbb-calendar-day
-                  slot="2023-01-18"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-19">
-                <sbb-calendar-day
-                  slot="2023-01-19"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-20">
-                <sbb-calendar-day
-                  slot="2023-01-20"
-                  tabindex="0"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-21">
-                <sbb-calendar-day
-                  slot="2023-01-21"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-22">
-                <sbb-calendar-day
-                  slot="2023-01-22"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-23">
-                <sbb-calendar-day
-                  slot="2023-01-23"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-24">
-                <sbb-calendar-day
-                  slot="2023-01-24"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-25">
-                <sbb-calendar-day
-                  slot="2023-01-25"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-26">
-                <sbb-calendar-day
-                  slot="2023-01-26"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-27">
-                <sbb-calendar-day
-                  slot="2023-01-27"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-28">
-                <sbb-calendar-day
-                  slot="2023-01-28"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-29">
-                <sbb-calendar-day
-                  slot="2023-01-29"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-30">
-                <sbb-calendar-day
-                  slot="2023-01-30"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-31">
-                <sbb-calendar-day
-                  slot="2023-01-31"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <table class="sbb-calendar__table">
+      <thead>
+        <tr>
+          <th class="sbb-calendar__table-header-cell">
+            <sbb-calendar-weekday tabindex="0">
+            </sbb-calendar-weekday>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <sbb-calendar-weekday tabindex="0">
+            </sbb-calendar-weekday>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <sbb-calendar-weekday tabindex="0">
+            </sbb-calendar-weekday>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <sbb-calendar-weekday tabindex="0">
+            </sbb-calendar-weekday>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <sbb-calendar-weekday tabindex="0">
+            </sbb-calendar-weekday>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <sbb-calendar-weekday tabindex="0">
+            </sbb-calendar-weekday>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <sbb-calendar-weekday tabindex="0">
+            </sbb-calendar-weekday>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-01">
+              <sbb-calendar-day
+                slot="2023-01-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-02">
+              <sbb-calendar-day
+                slot="2023-01-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-03">
+              <sbb-calendar-day
+                slot="2023-01-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-04">
+              <sbb-calendar-day
+                slot="2023-01-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-05">
+              <sbb-calendar-day
+                slot="2023-01-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-06">
+              <sbb-calendar-day
+                slot="2023-01-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-07">
+              <sbb-calendar-day
+                slot="2023-01-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-08">
+              <sbb-calendar-day
+                slot="2023-01-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-09">
+              <sbb-calendar-day
+                slot="2023-01-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-10">
+              <sbb-calendar-day
+                slot="2023-01-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-11">
+              <sbb-calendar-day
+                slot="2023-01-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-12">
+              <sbb-calendar-day
+                slot="2023-01-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-13">
+              <sbb-calendar-day
+                slot="2023-01-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-14">
+              <sbb-calendar-day
+                slot="2023-01-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-15">
+              <sbb-calendar-day
+                slot="2023-01-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-16">
+              <sbb-calendar-day
+                slot="2023-01-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-17">
+              <sbb-calendar-day
+                slot="2023-01-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-18">
+              <sbb-calendar-day
+                slot="2023-01-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-19">
+              <sbb-calendar-day
+                slot="2023-01-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-20">
+              <sbb-calendar-day
+                slot="2023-01-20"
+                tabindex="0"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-21">
+              <sbb-calendar-day
+                slot="2023-01-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-22">
+              <sbb-calendar-day
+                slot="2023-01-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-23">
+              <sbb-calendar-day
+                slot="2023-01-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-24">
+              <sbb-calendar-day
+                slot="2023-01-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-25">
+              <sbb-calendar-day
+                slot="2023-01-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-26">
+              <sbb-calendar-day
+                slot="2023-01-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-27">
+              <sbb-calendar-day
+                slot="2023-01-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-28">
+              <sbb-calendar-day
+                slot="2023-01-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-29">
+              <sbb-calendar-day
+                slot="2023-01-29"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-30">
+              <sbb-calendar-day
+                slot="2023-01-30"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-31">
+              <sbb-calendar-day
+                slot="2023-01-31"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -1535,10 +2302,10 @@ snapshots["sbb-calendar default renders multiple Shadow DOM"] =
 
 snapshots["sbb-calendar default renders horizontal wide with week numbers DOM"] = 
 `<sbb-calendar
+  amount="2"
   orientation="horizontal"
-  selected="2023-01-20T00:00:00"
+  value="2023-01-20T00:00:00"
   week-numbers=""
-  wide=""
 >
 </sbb-calendar>
 `;
@@ -1546,842 +2313,832 @@ snapshots["sbb-calendar default renders horizontal wide with week numbers DOM"] 
 
 snapshots["sbb-calendar default renders horizontal wide with week numbers Shadow DOM"] = 
 `<div class="sbb-calendar__wrapper">
-  <div class="sbb-calendar__controls">
-    <sbb-secondary-button
-      aria-label="Change to the previous month"
-      icon-name="chevron-small-left-small"
-      id="sbb-calendar__controls-previous"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-    <div class="sbb-calendar__controls-month">
-      <button
-        aria-label="Choose year and month January 2023"
-        class="sbb-calendar__controls-change-date sbb-calendar__date-selection"
-        type="button"
-      >
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
         January 2023
-        <sbb-icon name="chevron-small-down-small">
-        </sbb-icon>
-      </button>
-      <button
-        aria-label="Choose year and month February 2023"
-        class="sbb-calendar__controls-change-date sbb-calendar__date-selection"
-        type="button"
+      </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
       >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose year and month January 2023"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-up-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Change to the next month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+    </div>
+    <table class="sbb-calendar__table">
+      <thead>
+        <tr>
+          <th class="sbb-calendar__table-header-cell">
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Monday
+            </span>
+            <span aria-hidden="true">
+              M
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Tuesday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Wednesday
+            </span>
+            <span aria-hidden="true">
+              W
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Thursday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Friday
+            </span>
+            <span aria-hidden="true">
+              F
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Saturday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Sunday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 52
+            </span>
+            <span aria-hidden="true">
+              52
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-01">
+              <sbb-calendar-day
+                slot="2023-01-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 1
+            </span>
+            <span aria-hidden="true">
+              1
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-02">
+              <sbb-calendar-day
+                slot="2023-01-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-03">
+              <sbb-calendar-day
+                slot="2023-01-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-04">
+              <sbb-calendar-day
+                slot="2023-01-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-05">
+              <sbb-calendar-day
+                slot="2023-01-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-06">
+              <sbb-calendar-day
+                slot="2023-01-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-07">
+              <sbb-calendar-day
+                slot="2023-01-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-08">
+              <sbb-calendar-day
+                slot="2023-01-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 2
+            </span>
+            <span aria-hidden="true">
+              2
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-09">
+              <sbb-calendar-day
+                slot="2023-01-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-10">
+              <sbb-calendar-day
+                slot="2023-01-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-11">
+              <sbb-calendar-day
+                slot="2023-01-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-12">
+              <sbb-calendar-day
+                slot="2023-01-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-13">
+              <sbb-calendar-day
+                slot="2023-01-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-14">
+              <sbb-calendar-day
+                slot="2023-01-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-15">
+              <sbb-calendar-day
+                slot="2023-01-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 3
+            </span>
+            <span aria-hidden="true">
+              3
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-16">
+              <sbb-calendar-day
+                slot="2023-01-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-17">
+              <sbb-calendar-day
+                slot="2023-01-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-18">
+              <sbb-calendar-day
+                slot="2023-01-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-19">
+              <sbb-calendar-day
+                slot="2023-01-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-20">
+              <sbb-calendar-day
+                slot="2023-01-20"
+                tabindex="0"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-21">
+              <sbb-calendar-day
+                slot="2023-01-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-22">
+              <sbb-calendar-day
+                slot="2023-01-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 4
+            </span>
+            <span aria-hidden="true">
+              4
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-23">
+              <sbb-calendar-day
+                slot="2023-01-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-24">
+              <sbb-calendar-day
+                slot="2023-01-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-25">
+              <sbb-calendar-day
+                slot="2023-01-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-26">
+              <sbb-calendar-day
+                slot="2023-01-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-27">
+              <sbb-calendar-day
+                slot="2023-01-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-28">
+              <sbb-calendar-day
+                slot="2023-01-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-29">
+              <sbb-calendar-day
+                slot="2023-01-29"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 5
+            </span>
+            <span aria-hidden="true">
+              5
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-30">
+              <sbb-calendar-day
+                slot="2023-01-30"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-31">
+              <sbb-calendar-day
+                slot="2023-01-31"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
         February 2023
-        <sbb-icon name="chevron-small-down-small">
-        </sbb-icon>
-      </button>
-      <span
-        class="sbb-screen-reader-only"
-        role="status"
-      >
-        January 2023 February 2023
       </span>
     </div>
-    <sbb-secondary-button
-      aria-label="Change to the next month"
-      icon-name="chevron-small-right-small"
-      id="sbb-calendar__controls-next"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-  </div>
-  <div class="sbb-calendar__table-overflow-break">
-    <div class="sbb-calendar__table-container sbb-calendar__table-day-view">
-      <table class="sbb-calendar__table">
-        <thead class="sbb-calendar__table-header">
-          <tr>
-            <th class="sbb-calendar__table-header-cell">
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Monday
-              </span>
-              <span aria-hidden="true">
-                M
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Tuesday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Wednesday
-              </span>
-              <span aria-hidden="true">
-                W
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Thursday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Friday
-              </span>
-              <span aria-hidden="true">
-                F
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Saturday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Sunday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 52
-              </span>
-              <span aria-hidden="true">
-                52
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-01">
-                <sbb-calendar-day
-                  slot="2023-01-01"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 1
-              </span>
-              <span aria-hidden="true">
-                1
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-02">
-                <sbb-calendar-day
-                  slot="2023-01-02"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-03">
-                <sbb-calendar-day
-                  slot="2023-01-03"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-04">
-                <sbb-calendar-day
-                  slot="2023-01-04"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-05">
-                <sbb-calendar-day
-                  slot="2023-01-05"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-06">
-                <sbb-calendar-day
-                  slot="2023-01-06"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-07">
-                <sbb-calendar-day
-                  slot="2023-01-07"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-08">
-                <sbb-calendar-day
-                  slot="2023-01-08"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 2
-              </span>
-              <span aria-hidden="true">
-                2
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-09">
-                <sbb-calendar-day
-                  slot="2023-01-09"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-10">
-                <sbb-calendar-day
-                  slot="2023-01-10"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-11">
-                <sbb-calendar-day
-                  slot="2023-01-11"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-12">
-                <sbb-calendar-day
-                  slot="2023-01-12"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-13">
-                <sbb-calendar-day
-                  slot="2023-01-13"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-14">
-                <sbb-calendar-day
-                  slot="2023-01-14"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-15">
-                <sbb-calendar-day
-                  slot="2023-01-15"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 3
-              </span>
-              <span aria-hidden="true">
-                3
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-16">
-                <sbb-calendar-day
-                  slot="2023-01-16"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-17">
-                <sbb-calendar-day
-                  slot="2023-01-17"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-18">
-                <sbb-calendar-day
-                  slot="2023-01-18"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-19">
-                <sbb-calendar-day
-                  slot="2023-01-19"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-20">
-                <sbb-calendar-day
-                  slot="2023-01-20"
-                  tabindex="0"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-21">
-                <sbb-calendar-day
-                  slot="2023-01-21"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-22">
-                <sbb-calendar-day
-                  slot="2023-01-22"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 4
-              </span>
-              <span aria-hidden="true">
-                4
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-23">
-                <sbb-calendar-day
-                  slot="2023-01-23"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-24">
-                <sbb-calendar-day
-                  slot="2023-01-24"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-25">
-                <sbb-calendar-day
-                  slot="2023-01-25"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-26">
-                <sbb-calendar-day
-                  slot="2023-01-26"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-27">
-                <sbb-calendar-day
-                  slot="2023-01-27"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-28">
-                <sbb-calendar-day
-                  slot="2023-01-28"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-29">
-                <sbb-calendar-day
-                  slot="2023-01-29"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 5
-              </span>
-              <span aria-hidden="true">
-                5
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-30">
-                <sbb-calendar-day
-                  slot="2023-01-30"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-31">
-                <sbb-calendar-day
-                  slot="2023-01-31"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <table class="sbb-calendar__table">
-        <thead class="sbb-calendar__table-header">
-          <tr>
-            <th class="sbb-calendar__table-header-cell">
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Monday
-              </span>
-              <span aria-hidden="true">
-                M
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Tuesday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Wednesday
-              </span>
-              <span aria-hidden="true">
-                W
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Thursday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Friday
-              </span>
-              <span aria-hidden="true">
-                F
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Saturday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Sunday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 5
-              </span>
-              <span aria-hidden="true">
-                5
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-01">
-                <sbb-calendar-day
-                  slot="2023-02-01"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-02">
-                <sbb-calendar-day
-                  slot="2023-02-02"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-03">
-                <sbb-calendar-day
-                  slot="2023-02-03"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-04">
-                <sbb-calendar-day
-                  slot="2023-02-04"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-05">
-                <sbb-calendar-day
-                  slot="2023-02-05"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 6
-              </span>
-              <span aria-hidden="true">
-                6
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-06">
-                <sbb-calendar-day
-                  slot="2023-02-06"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-07">
-                <sbb-calendar-day
-                  slot="2023-02-07"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-08">
-                <sbb-calendar-day
-                  slot="2023-02-08"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-09">
-                <sbb-calendar-day
-                  slot="2023-02-09"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-10">
-                <sbb-calendar-day
-                  slot="2023-02-10"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-11">
-                <sbb-calendar-day
-                  slot="2023-02-11"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-12">
-                <sbb-calendar-day
-                  slot="2023-02-12"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 7
-              </span>
-              <span aria-hidden="true">
-                7
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-13">
-                <sbb-calendar-day
-                  slot="2023-02-13"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-14">
-                <sbb-calendar-day
-                  slot="2023-02-14"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-15">
-                <sbb-calendar-day
-                  slot="2023-02-15"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-16">
-                <sbb-calendar-day
-                  slot="2023-02-16"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-17">
-                <sbb-calendar-day
-                  slot="2023-02-17"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-18">
-                <sbb-calendar-day
-                  slot="2023-02-18"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-19">
-                <sbb-calendar-day
-                  slot="2023-02-19"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 8
-              </span>
-              <span aria-hidden="true">
-                8
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-20">
-                <sbb-calendar-day
-                  slot="2023-02-20"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-21">
-                <sbb-calendar-day
-                  slot="2023-02-21"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-22">
-                <sbb-calendar-day
-                  slot="2023-02-22"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-23">
-                <sbb-calendar-day
-                  slot="2023-02-23"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-24">
-                <sbb-calendar-day
-                  slot="2023-02-24"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-25">
-                <sbb-calendar-day
-                  slot="2023-02-25"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-26">
-                <sbb-calendar-day
-                  slot="2023-02-26"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 9
-              </span>
-              <span aria-hidden="true">
-                9
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-27">
-                <sbb-calendar-day
-                  slot="2023-02-27"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-28">
-                <sbb-calendar-day
-                  slot="2023-02-28"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <table class="sbb-calendar__table">
+      <thead>
+        <tr>
+          <th class="sbb-calendar__table-header-cell">
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Monday
+            </span>
+            <span aria-hidden="true">
+              M
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Tuesday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Wednesday
+            </span>
+            <span aria-hidden="true">
+              W
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Thursday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Friday
+            </span>
+            <span aria-hidden="true">
+              F
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Saturday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Sunday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 5
+            </span>
+            <span aria-hidden="true">
+              5
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-01">
+              <sbb-calendar-day
+                slot="2023-02-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-02">
+              <sbb-calendar-day
+                slot="2023-02-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-03">
+              <sbb-calendar-day
+                slot="2023-02-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-04">
+              <sbb-calendar-day
+                slot="2023-02-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-05">
+              <sbb-calendar-day
+                slot="2023-02-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 6
+            </span>
+            <span aria-hidden="true">
+              6
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-06">
+              <sbb-calendar-day
+                slot="2023-02-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-07">
+              <sbb-calendar-day
+                slot="2023-02-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-08">
+              <sbb-calendar-day
+                slot="2023-02-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-09">
+              <sbb-calendar-day
+                slot="2023-02-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-10">
+              <sbb-calendar-day
+                slot="2023-02-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-11">
+              <sbb-calendar-day
+                slot="2023-02-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-12">
+              <sbb-calendar-day
+                slot="2023-02-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 7
+            </span>
+            <span aria-hidden="true">
+              7
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-13">
+              <sbb-calendar-day
+                slot="2023-02-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-14">
+              <sbb-calendar-day
+                slot="2023-02-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-15">
+              <sbb-calendar-day
+                slot="2023-02-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-16">
+              <sbb-calendar-day
+                slot="2023-02-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-17">
+              <sbb-calendar-day
+                slot="2023-02-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-18">
+              <sbb-calendar-day
+                slot="2023-02-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-19">
+              <sbb-calendar-day
+                slot="2023-02-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 8
+            </span>
+            <span aria-hidden="true">
+              8
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-20">
+              <sbb-calendar-day
+                slot="2023-02-20"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-21">
+              <sbb-calendar-day
+                slot="2023-02-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-22">
+              <sbb-calendar-day
+                slot="2023-02-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-23">
+              <sbb-calendar-day
+                slot="2023-02-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-24">
+              <sbb-calendar-day
+                slot="2023-02-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-25">
+              <sbb-calendar-day
+                slot="2023-02-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-26">
+              <sbb-calendar-day
+                slot="2023-02-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 9
+            </span>
+            <span aria-hidden="true">
+              9
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-27">
+              <sbb-calendar-day
+                slot="2023-02-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-28">
+              <sbb-calendar-day
+                slot="2023-02-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -2389,10 +3146,10 @@ snapshots["sbb-calendar default renders horizontal wide with week numbers Shadow
 
 snapshots["sbb-calendar default renders vertical wide with week numbers DOM"] = 
 `<sbb-calendar
+  amount="2"
   orientation="vertical"
-  selected="2023-01-20T00:00:00"
+  value="2023-01-20T00:00:00"
   week-numbers=""
-  wide=""
 >
 </sbb-calendar>
 `;
@@ -2400,790 +3157,838 @@ snapshots["sbb-calendar default renders vertical wide with week numbers DOM"] =
 
 snapshots["sbb-calendar default renders vertical wide with week numbers Shadow DOM"] = 
 `<div class="sbb-calendar__wrapper">
-  <div class="sbb-calendar__controls">
-    <sbb-secondary-button
-      aria-label="Change to the previous month"
-      icon-name="chevron-small-left-small"
-      id="sbb-calendar__controls-previous"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-    <div class="sbb-calendar__controls-month">
-      <button
-        aria-label="Choose year and month January 2023"
-        class="sbb-calendar__controls-change-date sbb-calendar__date-selection"
-        type="button"
-      >
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
         January 2023
-        <sbb-icon name="chevron-small-down-small">
-        </sbb-icon>
-      </button>
-      <button
-        aria-label="Choose year and month February 2023"
-        class="sbb-calendar__controls-change-date sbb-calendar__date-selection"
-        type="button"
+      </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
       >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose year and month January 2023"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-up-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Change to the next month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+    </div>
+    <table class="sbb-calendar__table">
+      <thead>
+        <tr>
+          <th class="sbb-calendar__table-data">
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 52
+            </span>
+            <span aria-hidden="true">
+              52
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 1
+            </span>
+            <span aria-hidden="true">
+              1
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 2
+            </span>
+            <span aria-hidden="true">
+              2
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 3
+            </span>
+            <span aria-hidden="true">
+              3
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 4
+            </span>
+            <span aria-hidden="true">
+              4
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 5
+            </span>
+            <span aria-hidden="true">
+              5
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Monday
+            </span>
+            <span aria-hidden="true">
+              M
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-02">
+              <sbb-calendar-day
+                slot="2023-01-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-09">
+              <sbb-calendar-day
+                slot="2023-01-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-16">
+              <sbb-calendar-day
+                slot="2023-01-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-23">
+              <sbb-calendar-day
+                slot="2023-01-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-30">
+              <sbb-calendar-day
+                slot="2023-01-30"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Tuesday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-03">
+              <sbb-calendar-day
+                slot="2023-01-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-10">
+              <sbb-calendar-day
+                slot="2023-01-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-17">
+              <sbb-calendar-day
+                slot="2023-01-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-24">
+              <sbb-calendar-day
+                slot="2023-01-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-31">
+              <sbb-calendar-day
+                slot="2023-01-31"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Wednesday
+            </span>
+            <span aria-hidden="true">
+              W
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-04">
+              <sbb-calendar-day
+                slot="2023-01-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-11">
+              <sbb-calendar-day
+                slot="2023-01-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-18">
+              <sbb-calendar-day
+                slot="2023-01-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-25">
+              <sbb-calendar-day
+                slot="2023-01-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Thursday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-05">
+              <sbb-calendar-day
+                slot="2023-01-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-12">
+              <sbb-calendar-day
+                slot="2023-01-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-19">
+              <sbb-calendar-day
+                slot="2023-01-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-26">
+              <sbb-calendar-day
+                slot="2023-01-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Friday
+            </span>
+            <span aria-hidden="true">
+              F
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-06">
+              <sbb-calendar-day
+                slot="2023-01-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-13">
+              <sbb-calendar-day
+                slot="2023-01-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-20">
+              <sbb-calendar-day
+                slot="2023-01-20"
+                tabindex="0"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-27">
+              <sbb-calendar-day
+                slot="2023-01-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Saturday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-07">
+              <sbb-calendar-day
+                slot="2023-01-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-14">
+              <sbb-calendar-day
+                slot="2023-01-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-21">
+              <sbb-calendar-day
+                slot="2023-01-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-28">
+              <sbb-calendar-day
+                slot="2023-01-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Sunday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-01">
+              <sbb-calendar-day
+                slot="2023-01-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-08">
+              <sbb-calendar-day
+                slot="2023-01-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-15">
+              <sbb-calendar-day
+                slot="2023-01-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-22">
+              <sbb-calendar-day
+                slot="2023-01-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-29">
+              <sbb-calendar-day
+                slot="2023-01-29"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
         February 2023
-        <sbb-icon name="chevron-small-down-small">
-        </sbb-icon>
-      </button>
-      <span
-        class="sbb-screen-reader-only"
-        role="status"
-      >
-        January 2023 February 2023
       </span>
     </div>
-    <sbb-secondary-button
-      aria-label="Change to the next month"
-      icon-name="chevron-small-right-small"
-      id="sbb-calendar__controls-next"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-  </div>
-  <div class="sbb-calendar__table-overflow-break">
-    <div class="sbb-calendar__table-container sbb-calendar__table-day-view">
-      <table class="sbb-calendar__table">
-        <thead class="sbb-calendar__table-header">
-          <tr>
-            <th class="sbb-calendar__table-data">
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 52
-              </span>
-              <span aria-hidden="true">
-                52
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 1
-              </span>
-              <span aria-hidden="true">
-                1
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 2
-              </span>
-              <span aria-hidden="true">
-                2
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 3
-              </span>
-              <span aria-hidden="true">
-                3
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 4
-              </span>
-              <span aria-hidden="true">
-                4
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 5
-              </span>
-              <span aria-hidden="true">
-                5
-              </span>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Monday
-              </span>
-              <span aria-hidden="true">
-                M
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-02">
-                <sbb-calendar-day
-                  slot="2023-01-02"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-09">
-                <sbb-calendar-day
-                  slot="2023-01-09"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-16">
-                <sbb-calendar-day
-                  slot="2023-01-16"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-23">
-                <sbb-calendar-day
-                  slot="2023-01-23"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-30">
-                <sbb-calendar-day
-                  slot="2023-01-30"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Tuesday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-03">
-                <sbb-calendar-day
-                  slot="2023-01-03"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-10">
-                <sbb-calendar-day
-                  slot="2023-01-10"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-17">
-                <sbb-calendar-day
-                  slot="2023-01-17"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-24">
-                <sbb-calendar-day
-                  slot="2023-01-24"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-31">
-                <sbb-calendar-day
-                  slot="2023-01-31"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Wednesday
-              </span>
-              <span aria-hidden="true">
-                W
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-04">
-                <sbb-calendar-day
-                  slot="2023-01-04"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-11">
-                <sbb-calendar-day
-                  slot="2023-01-11"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-18">
-                <sbb-calendar-day
-                  slot="2023-01-18"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-25">
-                <sbb-calendar-day
-                  slot="2023-01-25"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Thursday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-05">
-                <sbb-calendar-day
-                  slot="2023-01-05"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-12">
-                <sbb-calendar-day
-                  slot="2023-01-12"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-19">
-                <sbb-calendar-day
-                  slot="2023-01-19"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-26">
-                <sbb-calendar-day
-                  slot="2023-01-26"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Friday
-              </span>
-              <span aria-hidden="true">
-                F
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-06">
-                <sbb-calendar-day
-                  slot="2023-01-06"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-13">
-                <sbb-calendar-day
-                  slot="2023-01-13"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-20">
-                <sbb-calendar-day
-                  slot="2023-01-20"
-                  tabindex="0"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-27">
-                <sbb-calendar-day
-                  slot="2023-01-27"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Saturday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-07">
-                <sbb-calendar-day
-                  slot="2023-01-07"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-14">
-                <sbb-calendar-day
-                  slot="2023-01-14"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-21">
-                <sbb-calendar-day
-                  slot="2023-01-21"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-28">
-                <sbb-calendar-day
-                  slot="2023-01-28"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Sunday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-01">
-                <sbb-calendar-day
-                  slot="2023-01-01"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-08">
-                <sbb-calendar-day
-                  slot="2023-01-08"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-15">
-                <sbb-calendar-day
-                  slot="2023-01-15"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-22">
-                <sbb-calendar-day
-                  slot="2023-01-22"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-29">
-                <sbb-calendar-day
-                  slot="2023-01-29"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <table class="sbb-calendar__table">
-        <thead class="sbb-calendar__table-header">
-          <tr>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 5
-              </span>
-              <span aria-hidden="true">
-                5
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 6
-              </span>
-              <span aria-hidden="true">
-                6
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 7
-              </span>
-              <span aria-hidden="true">
-                7
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 8
-              </span>
-              <span aria-hidden="true">
-                8
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 9
-              </span>
-              <span aria-hidden="true">
-                9
-              </span>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-06">
-                <sbb-calendar-day
-                  slot="2023-02-06"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-13">
-                <sbb-calendar-day
-                  slot="2023-02-13"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-20">
-                <sbb-calendar-day
-                  slot="2023-02-20"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-27">
-                <sbb-calendar-day
-                  slot="2023-02-27"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-07">
-                <sbb-calendar-day
-                  slot="2023-02-07"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-14">
-                <sbb-calendar-day
-                  slot="2023-02-14"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-21">
-                <sbb-calendar-day
-                  slot="2023-02-21"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-28">
-                <sbb-calendar-day
-                  slot="2023-02-28"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-01">
-                <sbb-calendar-day
-                  slot="2023-02-01"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-08">
-                <sbb-calendar-day
-                  slot="2023-02-08"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-15">
-                <sbb-calendar-day
-                  slot="2023-02-15"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-22">
-                <sbb-calendar-day
-                  slot="2023-02-22"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-02">
-                <sbb-calendar-day
-                  slot="2023-02-02"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-09">
-                <sbb-calendar-day
-                  slot="2023-02-09"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-16">
-                <sbb-calendar-day
-                  slot="2023-02-16"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-23">
-                <sbb-calendar-day
-                  slot="2023-02-23"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-03">
-                <sbb-calendar-day
-                  slot="2023-02-03"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-10">
-                <sbb-calendar-day
-                  slot="2023-02-10"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-17">
-                <sbb-calendar-day
-                  slot="2023-02-17"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-24">
-                <sbb-calendar-day
-                  slot="2023-02-24"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-04">
-                <sbb-calendar-day
-                  slot="2023-02-04"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-11">
-                <sbb-calendar-day
-                  slot="2023-02-11"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-18">
-                <sbb-calendar-day
-                  slot="2023-02-18"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-25">
-                <sbb-calendar-day
-                  slot="2023-02-25"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-05">
-                <sbb-calendar-day
-                  slot="2023-02-05"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-12">
-                <sbb-calendar-day
-                  slot="2023-02-12"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-19">
-                <sbb-calendar-day
-                  slot="2023-02-19"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-26">
-                <sbb-calendar-day
-                  slot="2023-02-26"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <table class="sbb-calendar__table">
+      <thead>
+        <tr>
+          <th class="sbb-calendar__table-data">
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 5
+            </span>
+            <span aria-hidden="true">
+              5
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 6
+            </span>
+            <span aria-hidden="true">
+              6
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 7
+            </span>
+            <span aria-hidden="true">
+              7
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 8
+            </span>
+            <span aria-hidden="true">
+              8
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 9
+            </span>
+            <span aria-hidden="true">
+              9
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Monday
+            </span>
+            <span aria-hidden="true">
+              M
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-06">
+              <sbb-calendar-day
+                slot="2023-02-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-13">
+              <sbb-calendar-day
+                slot="2023-02-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-20">
+              <sbb-calendar-day
+                slot="2023-02-20"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-27">
+              <sbb-calendar-day
+                slot="2023-02-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Tuesday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-07">
+              <sbb-calendar-day
+                slot="2023-02-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-14">
+              <sbb-calendar-day
+                slot="2023-02-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-21">
+              <sbb-calendar-day
+                slot="2023-02-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-28">
+              <sbb-calendar-day
+                slot="2023-02-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Wednesday
+            </span>
+            <span aria-hidden="true">
+              W
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-01">
+              <sbb-calendar-day
+                slot="2023-02-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-08">
+              <sbb-calendar-day
+                slot="2023-02-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-15">
+              <sbb-calendar-day
+                slot="2023-02-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-22">
+              <sbb-calendar-day
+                slot="2023-02-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Thursday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-02">
+              <sbb-calendar-day
+                slot="2023-02-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-09">
+              <sbb-calendar-day
+                slot="2023-02-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-16">
+              <sbb-calendar-day
+                slot="2023-02-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-23">
+              <sbb-calendar-day
+                slot="2023-02-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Friday
+            </span>
+            <span aria-hidden="true">
+              F
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-03">
+              <sbb-calendar-day
+                slot="2023-02-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-10">
+              <sbb-calendar-day
+                slot="2023-02-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-17">
+              <sbb-calendar-day
+                slot="2023-02-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-24">
+              <sbb-calendar-day
+                slot="2023-02-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Saturday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-04">
+              <sbb-calendar-day
+                slot="2023-02-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-11">
+              <sbb-calendar-day
+                slot="2023-02-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-18">
+              <sbb-calendar-day
+                slot="2023-02-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-25">
+              <sbb-calendar-day
+                slot="2023-02-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Sunday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-05">
+              <sbb-calendar-day
+                slot="2023-02-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-12">
+              <sbb-calendar-day
+                slot="2023-02-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-19">
+              <sbb-calendar-day
+                slot="2023-02-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-26">
+              <sbb-calendar-day
+                slot="2023-02-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -3192,7 +3997,7 @@ snapshots["sbb-calendar default renders vertical wide with week numbers Shadow D
 snapshots["sbb-calendar enhanced renders DOM"] = 
 `<sbb-calendar
   orientation="horizontal"
-  selected="2023-01-20T00:00:00"
+  value="2023-01-20T00:00:00"
 >
   <sbb-calendar-day
     slot="2023-01-01"
@@ -3355,411 +4160,403 @@ snapshots["sbb-calendar enhanced renders DOM"] =
 
 snapshots["sbb-calendar enhanced renders Shadow DOM"] = 
 `<div class="sbb-calendar__wrapper">
-  <div class="sbb-calendar__controls">
-    <sbb-secondary-button
-      aria-label="Change to the previous month"
-      icon-name="chevron-small-left-small"
-      id="sbb-calendar__controls-previous"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-    <div class="sbb-calendar__controls-month">
-      <button
-        aria-label="Choose year and month January 2023"
-        class="sbb-calendar__controls-change-date sbb-calendar__date-selection"
-        type="button"
-      >
-        January 2023
-        <sbb-icon name="chevron-small-down-small">
-        </sbb-icon>
-      </button>
-      <span
-        class="sbb-screen-reader-only"
-        role="status"
-      >
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
         January 2023
       </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose year and month January 2023"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-up-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Change to the next month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
     </div>
-    <sbb-secondary-button
-      aria-label="Change to the next month"
-      icon-name="chevron-small-right-small"
-      id="sbb-calendar__controls-next"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-  </div>
-  <div class="sbb-calendar__table-overflow-break">
-    <div class="sbb-calendar__table-container sbb-calendar__table-day-view">
-      <table class="sbb-calendar__table">
-        <thead class="sbb-calendar__table-header">
-          <tr>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Monday
-              </span>
-              <span aria-hidden="true">
-                M
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Tuesday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Wednesday
-              </span>
-              <span aria-hidden="true">
-                W
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Thursday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Friday
-              </span>
-              <span aria-hidden="true">
-                F
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Saturday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Sunday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-01">
-                <sbb-calendar-day
-                  slot="2023-01-01"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-02">
-                <sbb-calendar-day
-                  slot="2023-01-02"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-03">
-                <sbb-calendar-day
-                  slot="2023-01-03"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-04">
-                <sbb-calendar-day
-                  slot="2023-01-04"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-05">
-                <sbb-calendar-day
-                  slot="2023-01-05"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-06">
-                <sbb-calendar-day
-                  slot="2023-01-06"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-07">
-                <sbb-calendar-day
-                  slot="2023-01-07"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-08">
-                <sbb-calendar-day
-                  slot="2023-01-08"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-09">
-                <sbb-calendar-day
-                  slot="2023-01-09"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-10">
-                <sbb-calendar-day
-                  slot="2023-01-10"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-11">
-                <sbb-calendar-day
-                  slot="2023-01-11"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-12">
-                <sbb-calendar-day
-                  slot="2023-01-12"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-13">
-                <sbb-calendar-day
-                  slot="2023-01-13"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-14">
-                <sbb-calendar-day
-                  slot="2023-01-14"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-15">
-                <sbb-calendar-day
-                  slot="2023-01-15"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-16">
-                <sbb-calendar-day
-                  slot="2023-01-16"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-17">
-                <sbb-calendar-day
-                  slot="2023-01-17"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-18">
-                <sbb-calendar-day
-                  slot="2023-01-18"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-19">
-                <sbb-calendar-day
-                  slot="2023-01-19"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-20">
-                <sbb-calendar-day
-                  slot="2023-01-20"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-21">
-                <sbb-calendar-day
-                  slot="2023-01-21"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-22">
-                <sbb-calendar-day
-                  slot="2023-01-22"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-23">
-                <sbb-calendar-day
-                  slot="2023-01-23"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-24">
-                <sbb-calendar-day
-                  slot="2023-01-24"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-25">
-                <sbb-calendar-day
-                  slot="2023-01-25"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-26">
-                <sbb-calendar-day
-                  slot="2023-01-26"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-27">
-                <sbb-calendar-day
-                  slot="2023-01-27"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-28">
-                <sbb-calendar-day
-                  slot="2023-01-28"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-29">
-                <sbb-calendar-day
-                  slot="2023-01-29"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-30">
-                <sbb-calendar-day
-                  slot="2023-01-30"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-31">
-                <sbb-calendar-day
-                  slot="2023-01-31"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <table class="sbb-calendar__table">
+      <thead>
+        <tr>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Monday
+            </span>
+            <span aria-hidden="true">
+              M
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Tuesday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Wednesday
+            </span>
+            <span aria-hidden="true">
+              W
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Thursday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Friday
+            </span>
+            <span aria-hidden="true">
+              F
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Saturday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Sunday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-01">
+              <sbb-calendar-day
+                slot="2023-01-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-02">
+              <sbb-calendar-day
+                slot="2023-01-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-03">
+              <sbb-calendar-day
+                slot="2023-01-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-04">
+              <sbb-calendar-day
+                slot="2023-01-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-05">
+              <sbb-calendar-day
+                slot="2023-01-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-06">
+              <sbb-calendar-day
+                slot="2023-01-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-07">
+              <sbb-calendar-day
+                slot="2023-01-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-08">
+              <sbb-calendar-day
+                slot="2023-01-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-09">
+              <sbb-calendar-day
+                slot="2023-01-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-10">
+              <sbb-calendar-day
+                slot="2023-01-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-11">
+              <sbb-calendar-day
+                slot="2023-01-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-12">
+              <sbb-calendar-day
+                slot="2023-01-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-13">
+              <sbb-calendar-day
+                slot="2023-01-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-14">
+              <sbb-calendar-day
+                slot="2023-01-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-15">
+              <sbb-calendar-day
+                slot="2023-01-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-16">
+              <sbb-calendar-day
+                slot="2023-01-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-17">
+              <sbb-calendar-day
+                slot="2023-01-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-18">
+              <sbb-calendar-day
+                slot="2023-01-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-19">
+              <sbb-calendar-day
+                slot="2023-01-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-20">
+              <sbb-calendar-day
+                slot="2023-01-20"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-21">
+              <sbb-calendar-day
+                slot="2023-01-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-22">
+              <sbb-calendar-day
+                slot="2023-01-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-23">
+              <sbb-calendar-day
+                slot="2023-01-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-24">
+              <sbb-calendar-day
+                slot="2023-01-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-25">
+              <sbb-calendar-day
+                slot="2023-01-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-26">
+              <sbb-calendar-day
+                slot="2023-01-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-27">
+              <sbb-calendar-day
+                slot="2023-01-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-28">
+              <sbb-calendar-day
+                slot="2023-01-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-29">
+              <sbb-calendar-day
+                slot="2023-01-29"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-30">
+              <sbb-calendar-day
+                slot="2023-01-30"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-31">
+              <sbb-calendar-day
+                slot="2023-01-31"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -3773,7 +4570,8 @@ snapshots["sbb-calendar enhanced renders A11y tree Chrome"] =
   "children": [
     {
       "role": "generic",
-      "name": ""
+      "name": "",
+      "invalid": false
     }
   ]
 }
@@ -3784,7 +4582,7 @@ snapshots["sbb-calendar enhanced renders A11y tree Chrome"] =
 snapshots["sbb-calendar enhanced renders vertical DOM"] = 
 `<sbb-calendar
   orientation="vertical"
-  selected="2023-01-20T00:00:00"
+  value="2023-01-20T00:00:00"
 >
   <sbb-calendar-day
     slot="2023-01-01"
@@ -3947,409 +4745,401 @@ snapshots["sbb-calendar enhanced renders vertical DOM"] =
 
 snapshots["sbb-calendar enhanced renders vertical Shadow DOM"] = 
 `<div class="sbb-calendar__wrapper">
-  <div class="sbb-calendar__controls">
-    <sbb-secondary-button
-      aria-label="Change to the previous month"
-      icon-name="chevron-small-left-small"
-      id="sbb-calendar__controls-previous"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-    <div class="sbb-calendar__controls-month">
-      <button
-        aria-label="Choose year and month January 2023"
-        class="sbb-calendar__controls-change-date sbb-calendar__date-selection"
-        type="button"
-      >
-        January 2023
-        <sbb-icon name="chevron-small-down-small">
-        </sbb-icon>
-      </button>
-      <span
-        class="sbb-screen-reader-only"
-        role="status"
-      >
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
         January 2023
       </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose year and month January 2023"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-up-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Change to the next month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
     </div>
-    <sbb-secondary-button
-      aria-label="Change to the next month"
-      icon-name="chevron-small-right-small"
-      id="sbb-calendar__controls-next"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-  </div>
-  <div class="sbb-calendar__table-overflow-break">
-    <div class="sbb-calendar__table-container sbb-calendar__table-day-view">
-      <table class="sbb-calendar__table">
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Monday
-              </span>
-              <span aria-hidden="true">
-                M
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-02">
-                <sbb-calendar-day
-                  slot="2023-01-02"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-09">
-                <sbb-calendar-day
-                  slot="2023-01-09"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-16">
-                <sbb-calendar-day
-                  slot="2023-01-16"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-23">
-                <sbb-calendar-day
-                  slot="2023-01-23"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-30">
-                <sbb-calendar-day
-                  slot="2023-01-30"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Tuesday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-03">
-                <sbb-calendar-day
-                  slot="2023-01-03"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-10">
-                <sbb-calendar-day
-                  slot="2023-01-10"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-17">
-                <sbb-calendar-day
-                  slot="2023-01-17"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-24">
-                <sbb-calendar-day
-                  slot="2023-01-24"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-31">
-                <sbb-calendar-day
-                  slot="2023-01-31"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Wednesday
-              </span>
-              <span aria-hidden="true">
-                W
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-04">
-                <sbb-calendar-day
-                  slot="2023-01-04"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-11">
-                <sbb-calendar-day
-                  slot="2023-01-11"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-18">
-                <sbb-calendar-day
-                  slot="2023-01-18"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-25">
-                <sbb-calendar-day
-                  slot="2023-01-25"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Thursday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-05">
-                <sbb-calendar-day
-                  slot="2023-01-05"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-12">
-                <sbb-calendar-day
-                  slot="2023-01-12"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-19">
-                <sbb-calendar-day
-                  slot="2023-01-19"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-26">
-                <sbb-calendar-day
-                  slot="2023-01-26"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Friday
-              </span>
-              <span aria-hidden="true">
-                F
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-06">
-                <sbb-calendar-day
-                  slot="2023-01-06"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-13">
-                <sbb-calendar-day
-                  slot="2023-01-13"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-20">
-                <sbb-calendar-day
-                  slot="2023-01-20"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-27">
-                <sbb-calendar-day
-                  slot="2023-01-27"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Saturday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-07">
-                <sbb-calendar-day
-                  slot="2023-01-07"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-14">
-                <sbb-calendar-day
-                  slot="2023-01-14"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-21">
-                <sbb-calendar-day
-                  slot="2023-01-21"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-28">
-                <sbb-calendar-day
-                  slot="2023-01-28"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Sunday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-01">
-                <sbb-calendar-day
-                  slot="2023-01-01"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-08">
-                <sbb-calendar-day
-                  slot="2023-01-08"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-15">
-                <sbb-calendar-day
-                  slot="2023-01-15"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-22">
-                <sbb-calendar-day
-                  slot="2023-01-22"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-29">
-                <sbb-calendar-day
-                  slot="2023-01-29"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <table class="sbb-calendar__table">
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Monday
+            </span>
+            <span aria-hidden="true">
+              M
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-02">
+              <sbb-calendar-day
+                slot="2023-01-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-09">
+              <sbb-calendar-day
+                slot="2023-01-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-16">
+              <sbb-calendar-day
+                slot="2023-01-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-23">
+              <sbb-calendar-day
+                slot="2023-01-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-30">
+              <sbb-calendar-day
+                slot="2023-01-30"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Tuesday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-03">
+              <sbb-calendar-day
+                slot="2023-01-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-10">
+              <sbb-calendar-day
+                slot="2023-01-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-17">
+              <sbb-calendar-day
+                slot="2023-01-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-24">
+              <sbb-calendar-day
+                slot="2023-01-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-31">
+              <sbb-calendar-day
+                slot="2023-01-31"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Wednesday
+            </span>
+            <span aria-hidden="true">
+              W
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-04">
+              <sbb-calendar-day
+                slot="2023-01-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-11">
+              <sbb-calendar-day
+                slot="2023-01-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-18">
+              <sbb-calendar-day
+                slot="2023-01-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-25">
+              <sbb-calendar-day
+                slot="2023-01-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Thursday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-05">
+              <sbb-calendar-day
+                slot="2023-01-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-12">
+              <sbb-calendar-day
+                slot="2023-01-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-19">
+              <sbb-calendar-day
+                slot="2023-01-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-26">
+              <sbb-calendar-day
+                slot="2023-01-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Friday
+            </span>
+            <span aria-hidden="true">
+              F
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-06">
+              <sbb-calendar-day
+                slot="2023-01-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-13">
+              <sbb-calendar-day
+                slot="2023-01-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-20">
+              <sbb-calendar-day
+                slot="2023-01-20"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-27">
+              <sbb-calendar-day
+                slot="2023-01-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Saturday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-07">
+              <sbb-calendar-day
+                slot="2023-01-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-14">
+              <sbb-calendar-day
+                slot="2023-01-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-21">
+              <sbb-calendar-day
+                slot="2023-01-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-28">
+              <sbb-calendar-day
+                slot="2023-01-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Sunday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-01">
+              <sbb-calendar-day
+                slot="2023-01-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-08">
+              <sbb-calendar-day
+                slot="2023-01-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-15">
+              <sbb-calendar-day
+                slot="2023-01-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-22">
+              <sbb-calendar-day
+                slot="2023-01-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-29">
+              <sbb-calendar-day
+                slot="2023-01-29"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -4358,7 +5148,7 @@ snapshots["sbb-calendar enhanced renders vertical Shadow DOM"] =
 snapshots["sbb-calendar enhanced renders in year view DOM"] = 
 `<sbb-calendar
   orientation="horizontal"
-  selected="2023-01-20T00:00:00"
+  value="2023-01-20T00:00:00"
   view="year"
 >
   <sbb-calendar-day
@@ -4522,157 +5312,552 @@ snapshots["sbb-calendar enhanced renders in year view DOM"] =
 
 snapshots["sbb-calendar enhanced renders in year view Shadow DOM"] = 
 `<div class="sbb-calendar__wrapper">
-  <div class="sbb-calendar__controls">
-    <sbb-secondary-button
-      aria-label="Change to the previous 24 years"
-      icon-name="chevron-small-left-small"
-      id="sbb-calendar__controls-previous"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-    <div class="sbb-calendar__controls-month">
-      <button
-        aria-label="Choose date 2016 - 2039"
-        class="sbb-calendar__controls-change-date"
-        id="sbb-calendar__year-selection"
-        type="button"
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
+        January 2023
+      </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
       >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose year and month January 2023"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-up-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Change to the next month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+    </div>
+    <table class="sbb-calendar__table">
+      <thead>
+        <tr>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Monday
+            </span>
+            <span aria-hidden="true">
+              M
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Tuesday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Wednesday
+            </span>
+            <span aria-hidden="true">
+              W
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Thursday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Friday
+            </span>
+            <span aria-hidden="true">
+              F
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Saturday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Sunday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-01">
+              <sbb-calendar-day
+                slot="2023-01-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-02">
+              <sbb-calendar-day
+                slot="2023-01-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-03">
+              <sbb-calendar-day
+                slot="2023-01-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-04">
+              <sbb-calendar-day
+                slot="2023-01-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-05">
+              <sbb-calendar-day
+                slot="2023-01-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-06">
+              <sbb-calendar-day
+                slot="2023-01-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-07">
+              <sbb-calendar-day
+                slot="2023-01-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-08">
+              <sbb-calendar-day
+                slot="2023-01-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-09">
+              <sbb-calendar-day
+                slot="2023-01-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-10">
+              <sbb-calendar-day
+                slot="2023-01-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-11">
+              <sbb-calendar-day
+                slot="2023-01-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-12">
+              <sbb-calendar-day
+                slot="2023-01-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-13">
+              <sbb-calendar-day
+                slot="2023-01-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-14">
+              <sbb-calendar-day
+                slot="2023-01-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-15">
+              <sbb-calendar-day
+                slot="2023-01-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-16">
+              <sbb-calendar-day
+                slot="2023-01-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-17">
+              <sbb-calendar-day
+                slot="2023-01-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-18">
+              <sbb-calendar-day
+                slot="2023-01-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-19">
+              <sbb-calendar-day
+                slot="2023-01-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-20">
+              <sbb-calendar-day
+                slot="2023-01-20"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-21">
+              <sbb-calendar-day
+                slot="2023-01-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-22">
+              <sbb-calendar-day
+                slot="2023-01-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-23">
+              <sbb-calendar-day
+                slot="2023-01-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-24">
+              <sbb-calendar-day
+                slot="2023-01-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-25">
+              <sbb-calendar-day
+                slot="2023-01-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-26">
+              <sbb-calendar-day
+                slot="2023-01-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-27">
+              <sbb-calendar-day
+                slot="2023-01-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-28">
+              <sbb-calendar-day
+                slot="2023-01-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-29">
+              <sbb-calendar-day
+                slot="2023-01-29"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-30">
+              <sbb-calendar-day
+                slot="2023-01-30"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-31">
+              <sbb-calendar-day
+                slot="2023-01-31"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="sbb-calendar__table-wrapper sbb-calendar__year-view">
+    <div class="sbb-calendar__table-header">
+      <span>
         2016 - 2039
-        <sbb-icon name="chevron-small-up-small">
-        </sbb-icon>
-      </button>
+      </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous 24 years"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose date 2016 - 2039"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-down-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
       <span
         class="sbb-screen-reader-only"
         role="status"
       >
         2016 - 2039
       </span>
+      <sbb-secondary-button
+        aria-label="Change to the next 24 years"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
     </div>
-    <sbb-secondary-button
-      aria-label="Change to the next 24 years"
-      icon-name="chevron-small-right-small"
-      id="sbb-calendar__controls-next"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-  </div>
-  <div class="sbb-calendar__table-overflow-break">
-    <div class="sbb-calendar__table-container sbb-calendar__table-year-view">
-      <table class="sbb-calendar__table">
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="0">
-              </sbb-calendar-year>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-year tabindex="-1">
-              </sbb-calendar-year>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <table class="sbb-calendar__table">
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="0">
+            </sbb-calendar-year>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-year tabindex="-1">
+            </sbb-calendar-year>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -4681,7 +5866,7 @@ snapshots["sbb-calendar enhanced renders in year view Shadow DOM"] =
 snapshots["sbb-calendar enhanced renders in month view DOM"] = 
 `<sbb-calendar
   orientation="horizontal"
-  selected="2023-01-20T00:00:00"
+  value="2023-01-20T00:00:00"
   view="month"
 >
   <sbb-calendar-day
@@ -4845,103 +6030,498 @@ snapshots["sbb-calendar enhanced renders in month view DOM"] =
 
 snapshots["sbb-calendar enhanced renders in month view Shadow DOM"] = 
 `<div class="sbb-calendar__wrapper">
-  <div class="sbb-calendar__controls">
-    <sbb-secondary-button
-      aria-label="Change to the previous year"
-      icon-name="chevron-small-left-small"
-      id="sbb-calendar__controls-previous"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-    <div class="sbb-calendar__controls-month">
-      <button
-        aria-label="Choose date 2023"
-        class="sbb-calendar__controls-change-date"
-        id="sbb-calendar__month-selection"
-        type="button"
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
+        January 2023
+      </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
       >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose year and month January 2023"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-up-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Change to the next month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+    </div>
+    <table class="sbb-calendar__table">
+      <thead>
+        <tr>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Monday
+            </span>
+            <span aria-hidden="true">
+              M
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Tuesday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Wednesday
+            </span>
+            <span aria-hidden="true">
+              W
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Thursday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Friday
+            </span>
+            <span aria-hidden="true">
+              F
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Saturday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Sunday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-01">
+              <sbb-calendar-day
+                slot="2023-01-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-02">
+              <sbb-calendar-day
+                slot="2023-01-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-03">
+              <sbb-calendar-day
+                slot="2023-01-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-04">
+              <sbb-calendar-day
+                slot="2023-01-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-05">
+              <sbb-calendar-day
+                slot="2023-01-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-06">
+              <sbb-calendar-day
+                slot="2023-01-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-07">
+              <sbb-calendar-day
+                slot="2023-01-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-08">
+              <sbb-calendar-day
+                slot="2023-01-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-09">
+              <sbb-calendar-day
+                slot="2023-01-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-10">
+              <sbb-calendar-day
+                slot="2023-01-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-11">
+              <sbb-calendar-day
+                slot="2023-01-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-12">
+              <sbb-calendar-day
+                slot="2023-01-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-13">
+              <sbb-calendar-day
+                slot="2023-01-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-14">
+              <sbb-calendar-day
+                slot="2023-01-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-15">
+              <sbb-calendar-day
+                slot="2023-01-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-16">
+              <sbb-calendar-day
+                slot="2023-01-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-17">
+              <sbb-calendar-day
+                slot="2023-01-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-18">
+              <sbb-calendar-day
+                slot="2023-01-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-19">
+              <sbb-calendar-day
+                slot="2023-01-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-20">
+              <sbb-calendar-day
+                slot="2023-01-20"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-21">
+              <sbb-calendar-day
+                slot="2023-01-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-22">
+              <sbb-calendar-day
+                slot="2023-01-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-23">
+              <sbb-calendar-day
+                slot="2023-01-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-24">
+              <sbb-calendar-day
+                slot="2023-01-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-25">
+              <sbb-calendar-day
+                slot="2023-01-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-26">
+              <sbb-calendar-day
+                slot="2023-01-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-27">
+              <sbb-calendar-day
+                slot="2023-01-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-28">
+              <sbb-calendar-day
+                slot="2023-01-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-29">
+              <sbb-calendar-day
+                slot="2023-01-29"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-30">
+              <sbb-calendar-day
+                slot="2023-01-30"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-31">
+              <sbb-calendar-day
+                slot="2023-01-31"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="sbb-calendar__month-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
         2023
-        <sbb-icon name="chevron-small-up-small">
-        </sbb-icon>
-      </button>
+      </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous year"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose date 2023"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-down-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
       <span
         class="sbb-screen-reader-only"
         role="status"
       >
         2023
       </span>
+      <sbb-secondary-button
+        aria-label="Change to the next year"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
     </div>
-    <sbb-secondary-button
-      aria-label="Change to the next year"
-      icon-name="chevron-small-right-small"
-      id="sbb-calendar__controls-next"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-  </div>
-  <div class="sbb-calendar__table-overflow-break">
-    <div class="sbb-calendar__table-container sbb-calendar__table-month-view">
-      <table class="sbb-calendar__table">
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="0">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-            <td class="sbb-calendar__table-data">
-              <sbb-calendar-month tabindex="-1">
-              </sbb-calendar-month>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <table class="sbb-calendar__table">
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="0">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+          <td class="sbb-calendar__table-data">
+            <sbb-calendar-month tabindex="-1">
+            </sbb-calendar-month>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -4951,7 +6531,7 @@ snapshots["sbb-calendar enhanced renders multiple DOM"] =
 `<sbb-calendar
   multiple=""
   orientation="horizontal"
-  selected="2023-01-20T00:00:00"
+  value="2023-01-20T00:00:00"
 >
   <sbb-calendar-day
     slot="2023-01-01"
@@ -5114,383 +6694,375 @@ snapshots["sbb-calendar enhanced renders multiple DOM"] =
 
 snapshots["sbb-calendar enhanced renders multiple Shadow DOM"] = 
 `<div class="sbb-calendar__wrapper">
-  <div class="sbb-calendar__controls">
-    <sbb-secondary-button
-      aria-label="Change to the previous month"
-      icon-name="chevron-small-left-small"
-      id="sbb-calendar__controls-previous"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-    <div class="sbb-calendar__controls-month">
-      <button
-        aria-label="Choose year and month January 2023"
-        class="sbb-calendar__controls-change-date sbb-calendar__date-selection"
-        type="button"
-      >
-        January 2023
-        <sbb-icon name="chevron-small-down-small">
-        </sbb-icon>
-      </button>
-      <span
-        class="sbb-screen-reader-only"
-        role="status"
-      >
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
         January 2023
       </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose year and month January 2023"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-up-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Change to the next month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
     </div>
-    <sbb-secondary-button
-      aria-label="Change to the next month"
-      icon-name="chevron-small-right-small"
-      id="sbb-calendar__controls-next"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-  </div>
-  <div class="sbb-calendar__table-overflow-break">
-    <div class="sbb-calendar__table-container sbb-calendar__table-day-view">
-      <table class="sbb-calendar__table">
-        <thead class="sbb-calendar__table-header">
-          <tr>
-            <th class="sbb-calendar__table-header-cell">
-              <sbb-calendar-weekday tabindex="0">
-              </sbb-calendar-weekday>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <sbb-calendar-weekday tabindex="0">
-              </sbb-calendar-weekday>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <sbb-calendar-weekday tabindex="0">
-              </sbb-calendar-weekday>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <sbb-calendar-weekday tabindex="0">
-              </sbb-calendar-weekday>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <sbb-calendar-weekday tabindex="0">
-              </sbb-calendar-weekday>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <sbb-calendar-weekday tabindex="0">
-              </sbb-calendar-weekday>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <sbb-calendar-weekday tabindex="0">
-              </sbb-calendar-weekday>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-01">
-                <sbb-calendar-day
-                  slot="2023-01-01"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-02">
-                <sbb-calendar-day
-                  slot="2023-01-02"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-03">
-                <sbb-calendar-day
-                  slot="2023-01-03"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-04">
-                <sbb-calendar-day
-                  slot="2023-01-04"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-05">
-                <sbb-calendar-day
-                  slot="2023-01-05"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-06">
-                <sbb-calendar-day
-                  slot="2023-01-06"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-07">
-                <sbb-calendar-day
-                  slot="2023-01-07"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-08">
-                <sbb-calendar-day
-                  slot="2023-01-08"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-09">
-                <sbb-calendar-day
-                  slot="2023-01-09"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-10">
-                <sbb-calendar-day
-                  slot="2023-01-10"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-11">
-                <sbb-calendar-day
-                  slot="2023-01-11"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-12">
-                <sbb-calendar-day
-                  slot="2023-01-12"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-13">
-                <sbb-calendar-day
-                  slot="2023-01-13"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-14">
-                <sbb-calendar-day
-                  slot="2023-01-14"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-15">
-                <sbb-calendar-day
-                  slot="2023-01-15"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-16">
-                <sbb-calendar-day
-                  slot="2023-01-16"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-17">
-                <sbb-calendar-day
-                  slot="2023-01-17"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-18">
-                <sbb-calendar-day
-                  slot="2023-01-18"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-19">
-                <sbb-calendar-day
-                  slot="2023-01-19"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-20">
-                <sbb-calendar-day
-                  slot="2023-01-20"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-21">
-                <sbb-calendar-day
-                  slot="2023-01-21"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-22">
-                <sbb-calendar-day
-                  slot="2023-01-22"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-23">
-                <sbb-calendar-day
-                  slot="2023-01-23"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-24">
-                <sbb-calendar-day
-                  slot="2023-01-24"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-25">
-                <sbb-calendar-day
-                  slot="2023-01-25"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-26">
-                <sbb-calendar-day
-                  slot="2023-01-26"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-27">
-                <sbb-calendar-day
-                  slot="2023-01-27"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-28">
-                <sbb-calendar-day
-                  slot="2023-01-28"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-29">
-                <sbb-calendar-day
-                  slot="2023-01-29"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-30">
-                <sbb-calendar-day
-                  slot="2023-01-30"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-31">
-                <sbb-calendar-day
-                  slot="2023-01-31"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <table class="sbb-calendar__table">
+      <thead>
+        <tr>
+          <th class="sbb-calendar__table-header-cell">
+            <sbb-calendar-weekday tabindex="0">
+            </sbb-calendar-weekday>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <sbb-calendar-weekday tabindex="0">
+            </sbb-calendar-weekday>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <sbb-calendar-weekday tabindex="0">
+            </sbb-calendar-weekday>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <sbb-calendar-weekday tabindex="0">
+            </sbb-calendar-weekday>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <sbb-calendar-weekday tabindex="0">
+            </sbb-calendar-weekday>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <sbb-calendar-weekday tabindex="0">
+            </sbb-calendar-weekday>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <sbb-calendar-weekday tabindex="0">
+            </sbb-calendar-weekday>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-01">
+              <sbb-calendar-day
+                slot="2023-01-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-02">
+              <sbb-calendar-day
+                slot="2023-01-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-03">
+              <sbb-calendar-day
+                slot="2023-01-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-04">
+              <sbb-calendar-day
+                slot="2023-01-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-05">
+              <sbb-calendar-day
+                slot="2023-01-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-06">
+              <sbb-calendar-day
+                slot="2023-01-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-07">
+              <sbb-calendar-day
+                slot="2023-01-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-08">
+              <sbb-calendar-day
+                slot="2023-01-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-09">
+              <sbb-calendar-day
+                slot="2023-01-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-10">
+              <sbb-calendar-day
+                slot="2023-01-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-11">
+              <sbb-calendar-day
+                slot="2023-01-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-12">
+              <sbb-calendar-day
+                slot="2023-01-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-13">
+              <sbb-calendar-day
+                slot="2023-01-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-14">
+              <sbb-calendar-day
+                slot="2023-01-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-15">
+              <sbb-calendar-day
+                slot="2023-01-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-16">
+              <sbb-calendar-day
+                slot="2023-01-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-17">
+              <sbb-calendar-day
+                slot="2023-01-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-18">
+              <sbb-calendar-day
+                slot="2023-01-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-19">
+              <sbb-calendar-day
+                slot="2023-01-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-20">
+              <sbb-calendar-day
+                slot="2023-01-20"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-21">
+              <sbb-calendar-day
+                slot="2023-01-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-22">
+              <sbb-calendar-day
+                slot="2023-01-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-23">
+              <sbb-calendar-day
+                slot="2023-01-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-24">
+              <sbb-calendar-day
+                slot="2023-01-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-25">
+              <sbb-calendar-day
+                slot="2023-01-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-26">
+              <sbb-calendar-day
+                slot="2023-01-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-27">
+              <sbb-calendar-day
+                slot="2023-01-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-28">
+              <sbb-calendar-day
+                slot="2023-01-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-29">
+              <sbb-calendar-day
+                slot="2023-01-29"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-30">
+              <sbb-calendar-day
+                slot="2023-01-30"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-31">
+              <sbb-calendar-day
+                slot="2023-01-31"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -5498,10 +7070,10 @@ snapshots["sbb-calendar enhanced renders multiple Shadow DOM"] =
 
 snapshots["sbb-calendar enhanced renders horizontal wide with week numbers DOM"] = 
 `<sbb-calendar
+  amount="2"
   orientation="horizontal"
-  selected="2023-01-20T00:00:00"
+  value="2023-01-20T00:00:00"
   week-numbers=""
-  wide=""
 >
   <sbb-calendar-day
     slot="2023-01-01"
@@ -5664,842 +7236,832 @@ snapshots["sbb-calendar enhanced renders horizontal wide with week numbers DOM"]
 
 snapshots["sbb-calendar enhanced renders horizontal wide with week numbers Shadow DOM"] = 
 `<div class="sbb-calendar__wrapper">
-  <div class="sbb-calendar__controls">
-    <sbb-secondary-button
-      aria-label="Change to the previous month"
-      icon-name="chevron-small-left-small"
-      id="sbb-calendar__controls-previous"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-    <div class="sbb-calendar__controls-month">
-      <button
-        aria-label="Choose year and month January 2023"
-        class="sbb-calendar__controls-change-date sbb-calendar__date-selection"
-        type="button"
-      >
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
         January 2023
-        <sbb-icon name="chevron-small-down-small">
-        </sbb-icon>
-      </button>
-      <button
-        aria-label="Choose year and month February 2023"
-        class="sbb-calendar__controls-change-date sbb-calendar__date-selection"
-        type="button"
+      </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
       >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose year and month January 2023"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-up-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Change to the next month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+    </div>
+    <table class="sbb-calendar__table">
+      <thead>
+        <tr>
+          <th class="sbb-calendar__table-header-cell">
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Monday
+            </span>
+            <span aria-hidden="true">
+              M
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Tuesday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Wednesday
+            </span>
+            <span aria-hidden="true">
+              W
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Thursday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Friday
+            </span>
+            <span aria-hidden="true">
+              F
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Saturday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Sunday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 52
+            </span>
+            <span aria-hidden="true">
+              52
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-01">
+              <sbb-calendar-day
+                slot="2023-01-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 1
+            </span>
+            <span aria-hidden="true">
+              1
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-02">
+              <sbb-calendar-day
+                slot="2023-01-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-03">
+              <sbb-calendar-day
+                slot="2023-01-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-04">
+              <sbb-calendar-day
+                slot="2023-01-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-05">
+              <sbb-calendar-day
+                slot="2023-01-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-06">
+              <sbb-calendar-day
+                slot="2023-01-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-07">
+              <sbb-calendar-day
+                slot="2023-01-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-08">
+              <sbb-calendar-day
+                slot="2023-01-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 2
+            </span>
+            <span aria-hidden="true">
+              2
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-09">
+              <sbb-calendar-day
+                slot="2023-01-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-10">
+              <sbb-calendar-day
+                slot="2023-01-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-11">
+              <sbb-calendar-day
+                slot="2023-01-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-12">
+              <sbb-calendar-day
+                slot="2023-01-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-13">
+              <sbb-calendar-day
+                slot="2023-01-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-14">
+              <sbb-calendar-day
+                slot="2023-01-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-15">
+              <sbb-calendar-day
+                slot="2023-01-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 3
+            </span>
+            <span aria-hidden="true">
+              3
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-16">
+              <sbb-calendar-day
+                slot="2023-01-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-17">
+              <sbb-calendar-day
+                slot="2023-01-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-18">
+              <sbb-calendar-day
+                slot="2023-01-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-19">
+              <sbb-calendar-day
+                slot="2023-01-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-20">
+              <sbb-calendar-day
+                slot="2023-01-20"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-21">
+              <sbb-calendar-day
+                slot="2023-01-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-22">
+              <sbb-calendar-day
+                slot="2023-01-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 4
+            </span>
+            <span aria-hidden="true">
+              4
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-23">
+              <sbb-calendar-day
+                slot="2023-01-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-24">
+              <sbb-calendar-day
+                slot="2023-01-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-25">
+              <sbb-calendar-day
+                slot="2023-01-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-26">
+              <sbb-calendar-day
+                slot="2023-01-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-27">
+              <sbb-calendar-day
+                slot="2023-01-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-28">
+              <sbb-calendar-day
+                slot="2023-01-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-29">
+              <sbb-calendar-day
+                slot="2023-01-29"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 5
+            </span>
+            <span aria-hidden="true">
+              5
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-30">
+              <sbb-calendar-day
+                slot="2023-01-30"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-31">
+              <sbb-calendar-day
+                slot="2023-01-31"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
         February 2023
-        <sbb-icon name="chevron-small-down-small">
-        </sbb-icon>
-      </button>
-      <span
-        class="sbb-screen-reader-only"
-        role="status"
-      >
-        January 2023 February 2023
       </span>
     </div>
-    <sbb-secondary-button
-      aria-label="Change to the next month"
-      icon-name="chevron-small-right-small"
-      id="sbb-calendar__controls-next"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-  </div>
-  <div class="sbb-calendar__table-overflow-break">
-    <div class="sbb-calendar__table-container sbb-calendar__table-day-view">
-      <table class="sbb-calendar__table">
-        <thead class="sbb-calendar__table-header">
-          <tr>
-            <th class="sbb-calendar__table-header-cell">
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Monday
-              </span>
-              <span aria-hidden="true">
-                M
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Tuesday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Wednesday
-              </span>
-              <span aria-hidden="true">
-                W
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Thursday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Friday
-              </span>
-              <span aria-hidden="true">
-                F
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Saturday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Sunday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 52
-              </span>
-              <span aria-hidden="true">
-                52
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-01">
-                <sbb-calendar-day
-                  slot="2023-01-01"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 1
-              </span>
-              <span aria-hidden="true">
-                1
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-02">
-                <sbb-calendar-day
-                  slot="2023-01-02"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-03">
-                <sbb-calendar-day
-                  slot="2023-01-03"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-04">
-                <sbb-calendar-day
-                  slot="2023-01-04"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-05">
-                <sbb-calendar-day
-                  slot="2023-01-05"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-06">
-                <sbb-calendar-day
-                  slot="2023-01-06"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-07">
-                <sbb-calendar-day
-                  slot="2023-01-07"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-08">
-                <sbb-calendar-day
-                  slot="2023-01-08"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 2
-              </span>
-              <span aria-hidden="true">
-                2
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-09">
-                <sbb-calendar-day
-                  slot="2023-01-09"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-10">
-                <sbb-calendar-day
-                  slot="2023-01-10"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-11">
-                <sbb-calendar-day
-                  slot="2023-01-11"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-12">
-                <sbb-calendar-day
-                  slot="2023-01-12"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-13">
-                <sbb-calendar-day
-                  slot="2023-01-13"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-14">
-                <sbb-calendar-day
-                  slot="2023-01-14"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-15">
-                <sbb-calendar-day
-                  slot="2023-01-15"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 3
-              </span>
-              <span aria-hidden="true">
-                3
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-16">
-                <sbb-calendar-day
-                  slot="2023-01-16"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-17">
-                <sbb-calendar-day
-                  slot="2023-01-17"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-18">
-                <sbb-calendar-day
-                  slot="2023-01-18"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-19">
-                <sbb-calendar-day
-                  slot="2023-01-19"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-20">
-                <sbb-calendar-day
-                  slot="2023-01-20"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-21">
-                <sbb-calendar-day
-                  slot="2023-01-21"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-22">
-                <sbb-calendar-day
-                  slot="2023-01-22"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 4
-              </span>
-              <span aria-hidden="true">
-                4
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-23">
-                <sbb-calendar-day
-                  slot="2023-01-23"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-24">
-                <sbb-calendar-day
-                  slot="2023-01-24"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-25">
-                <sbb-calendar-day
-                  slot="2023-01-25"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-26">
-                <sbb-calendar-day
-                  slot="2023-01-26"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-27">
-                <sbb-calendar-day
-                  slot="2023-01-27"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-28">
-                <sbb-calendar-day
-                  slot="2023-01-28"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-29">
-                <sbb-calendar-day
-                  slot="2023-01-29"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 5
-              </span>
-              <span aria-hidden="true">
-                5
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-30">
-                <sbb-calendar-day
-                  slot="2023-01-30"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-31">
-                <sbb-calendar-day
-                  slot="2023-01-31"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <table class="sbb-calendar__table">
-        <thead class="sbb-calendar__table-header">
-          <tr>
-            <th class="sbb-calendar__table-header-cell">
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Monday
-              </span>
-              <span aria-hidden="true">
-                M
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Tuesday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Wednesday
-              </span>
-              <span aria-hidden="true">
-                W
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Thursday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Friday
-              </span>
-              <span aria-hidden="true">
-                F
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Saturday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Sunday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 5
-              </span>
-              <span aria-hidden="true">
-                5
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-01">
-                <sbb-calendar-day
-                  slot="2023-02-01"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-02">
-                <sbb-calendar-day
-                  slot="2023-02-02"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-03">
-                <sbb-calendar-day
-                  slot="2023-02-03"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-04">
-                <sbb-calendar-day
-                  slot="2023-02-04"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-05">
-                <sbb-calendar-day
-                  slot="2023-02-05"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 6
-              </span>
-              <span aria-hidden="true">
-                6
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-06">
-                <sbb-calendar-day
-                  slot="2023-02-06"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-07">
-                <sbb-calendar-day
-                  slot="2023-02-07"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-08">
-                <sbb-calendar-day
-                  slot="2023-02-08"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-09">
-                <sbb-calendar-day
-                  slot="2023-02-09"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-10">
-                <sbb-calendar-day
-                  slot="2023-02-10"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-11">
-                <sbb-calendar-day
-                  slot="2023-02-11"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-12">
-                <sbb-calendar-day
-                  slot="2023-02-12"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 7
-              </span>
-              <span aria-hidden="true">
-                7
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-13">
-                <sbb-calendar-day
-                  slot="2023-02-13"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-14">
-                <sbb-calendar-day
-                  slot="2023-02-14"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-15">
-                <sbb-calendar-day
-                  slot="2023-02-15"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-16">
-                <sbb-calendar-day
-                  slot="2023-02-16"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-17">
-                <sbb-calendar-day
-                  slot="2023-02-17"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-18">
-                <sbb-calendar-day
-                  slot="2023-02-18"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-19">
-                <sbb-calendar-day
-                  slot="2023-02-19"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 8
-              </span>
-              <span aria-hidden="true">
-                8
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-20">
-                <sbb-calendar-day
-                  slot="2023-02-20"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-21">
-                <sbb-calendar-day
-                  slot="2023-02-21"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-22">
-                <sbb-calendar-day
-                  slot="2023-02-22"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-23">
-                <sbb-calendar-day
-                  slot="2023-02-23"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-24">
-                <sbb-calendar-day
-                  slot="2023-02-24"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-25">
-                <sbb-calendar-day
-                  slot="2023-02-25"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-26">
-                <sbb-calendar-day
-                  slot="2023-02-26"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Week 9
-              </span>
-              <span aria-hidden="true">
-                9
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-27">
-                <sbb-calendar-day
-                  slot="2023-02-27"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-28">
-                <sbb-calendar-day
-                  slot="2023-02-28"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <table class="sbb-calendar__table">
+      <thead>
+        <tr>
+          <th class="sbb-calendar__table-header-cell">
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Monday
+            </span>
+            <span aria-hidden="true">
+              M
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Tuesday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Wednesday
+            </span>
+            <span aria-hidden="true">
+              W
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Thursday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Friday
+            </span>
+            <span aria-hidden="true">
+              F
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Saturday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Sunday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 5
+            </span>
+            <span aria-hidden="true">
+              5
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-01">
+              <sbb-calendar-day
+                slot="2023-02-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-02">
+              <sbb-calendar-day
+                slot="2023-02-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-03">
+              <sbb-calendar-day
+                slot="2023-02-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-04">
+              <sbb-calendar-day
+                slot="2023-02-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-05">
+              <sbb-calendar-day
+                slot="2023-02-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 6
+            </span>
+            <span aria-hidden="true">
+              6
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-06">
+              <sbb-calendar-day
+                slot="2023-02-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-07">
+              <sbb-calendar-day
+                slot="2023-02-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-08">
+              <sbb-calendar-day
+                slot="2023-02-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-09">
+              <sbb-calendar-day
+                slot="2023-02-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-10">
+              <sbb-calendar-day
+                slot="2023-02-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-11">
+              <sbb-calendar-day
+                slot="2023-02-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-12">
+              <sbb-calendar-day
+                slot="2023-02-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 7
+            </span>
+            <span aria-hidden="true">
+              7
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-13">
+              <sbb-calendar-day
+                slot="2023-02-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-14">
+              <sbb-calendar-day
+                slot="2023-02-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-15">
+              <sbb-calendar-day
+                slot="2023-02-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-16">
+              <sbb-calendar-day
+                slot="2023-02-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-17">
+              <sbb-calendar-day
+                slot="2023-02-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-18">
+              <sbb-calendar-day
+                slot="2023-02-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-19">
+              <sbb-calendar-day
+                slot="2023-02-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 8
+            </span>
+            <span aria-hidden="true">
+              8
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-20">
+              <sbb-calendar-day
+                slot="2023-02-20"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-21">
+              <sbb-calendar-day
+                slot="2023-02-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-22">
+              <sbb-calendar-day
+                slot="2023-02-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-23">
+              <sbb-calendar-day
+                slot="2023-02-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-24">
+              <sbb-calendar-day
+                slot="2023-02-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-25">
+              <sbb-calendar-day
+                slot="2023-02-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-26">
+              <sbb-calendar-day
+                slot="2023-02-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Week 9
+            </span>
+            <span aria-hidden="true">
+              9
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-27">
+              <sbb-calendar-day
+                slot="2023-02-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-28">
+              <sbb-calendar-day
+                slot="2023-02-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -6507,10 +8069,10 @@ snapshots["sbb-calendar enhanced renders horizontal wide with week numbers Shado
 
 snapshots["sbb-calendar enhanced renders vertical wide with week numbers DOM"] = 
 `<sbb-calendar
+  amount="2"
   orientation="vertical"
-  selected="2023-01-20T00:00:00"
+  value="2023-01-20T00:00:00"
   week-numbers=""
-  wide=""
 >
   <sbb-calendar-day
     slot="2023-01-01"
@@ -6673,790 +8235,838 @@ snapshots["sbb-calendar enhanced renders vertical wide with week numbers DOM"] =
 
 snapshots["sbb-calendar enhanced renders vertical wide with week numbers Shadow DOM"] = 
 `<div class="sbb-calendar__wrapper">
-  <div class="sbb-calendar__controls">
-    <sbb-secondary-button
-      aria-label="Change to the previous month"
-      icon-name="chevron-small-left-small"
-      id="sbb-calendar__controls-previous"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-    <div class="sbb-calendar__controls-month">
-      <button
-        aria-label="Choose year and month January 2023"
-        class="sbb-calendar__controls-change-date sbb-calendar__date-selection"
-        type="button"
-      >
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
         January 2023
-        <sbb-icon name="chevron-small-down-small">
-        </sbb-icon>
-      </button>
-      <button
-        aria-label="Choose year and month February 2023"
-        class="sbb-calendar__controls-change-date sbb-calendar__date-selection"
-        type="button"
+      </span>
+      <sbb-secondary-button
+        aria-label="Change to the previous month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-left-small"
+        size="s"
+        tabindex="0"
       >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Choose year and month January 2023"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-up-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
+        aria-label="Change to the next month"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+    </div>
+    <table class="sbb-calendar__table">
+      <thead>
+        <tr>
+          <th class="sbb-calendar__table-data">
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 52
+            </span>
+            <span aria-hidden="true">
+              52
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 1
+            </span>
+            <span aria-hidden="true">
+              1
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 2
+            </span>
+            <span aria-hidden="true">
+              2
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 3
+            </span>
+            <span aria-hidden="true">
+              3
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 4
+            </span>
+            <span aria-hidden="true">
+              4
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 5
+            </span>
+            <span aria-hidden="true">
+              5
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Monday
+            </span>
+            <span aria-hidden="true">
+              M
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-02">
+              <sbb-calendar-day
+                slot="2023-01-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-09">
+              <sbb-calendar-day
+                slot="2023-01-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-16">
+              <sbb-calendar-day
+                slot="2023-01-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-23">
+              <sbb-calendar-day
+                slot="2023-01-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-30">
+              <sbb-calendar-day
+                slot="2023-01-30"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Tuesday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-03">
+              <sbb-calendar-day
+                slot="2023-01-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-10">
+              <sbb-calendar-day
+                slot="2023-01-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-17">
+              <sbb-calendar-day
+                slot="2023-01-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-24">
+              <sbb-calendar-day
+                slot="2023-01-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-31">
+              <sbb-calendar-day
+                slot="2023-01-31"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Wednesday
+            </span>
+            <span aria-hidden="true">
+              W
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-04">
+              <sbb-calendar-day
+                slot="2023-01-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-11">
+              <sbb-calendar-day
+                slot="2023-01-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-18">
+              <sbb-calendar-day
+                slot="2023-01-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-25">
+              <sbb-calendar-day
+                slot="2023-01-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Thursday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-05">
+              <sbb-calendar-day
+                slot="2023-01-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-12">
+              <sbb-calendar-day
+                slot="2023-01-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-19">
+              <sbb-calendar-day
+                slot="2023-01-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-26">
+              <sbb-calendar-day
+                slot="2023-01-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Friday
+            </span>
+            <span aria-hidden="true">
+              F
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-06">
+              <sbb-calendar-day
+                slot="2023-01-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-13">
+              <sbb-calendar-day
+                slot="2023-01-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-20">
+              <sbb-calendar-day
+                slot="2023-01-20"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-27">
+              <sbb-calendar-day
+                slot="2023-01-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Saturday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-07">
+              <sbb-calendar-day
+                slot="2023-01-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-14">
+              <sbb-calendar-day
+                slot="2023-01-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-21">
+              <sbb-calendar-day
+                slot="2023-01-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-28">
+              <sbb-calendar-day
+                slot="2023-01-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Sunday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-01">
+              <sbb-calendar-day
+                slot="2023-01-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-08">
+              <sbb-calendar-day
+                slot="2023-01-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-15">
+              <sbb-calendar-day
+                slot="2023-01-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-22">
+              <sbb-calendar-day
+                slot="2023-01-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-01-29">
+              <sbb-calendar-day
+                slot="2023-01-29"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="sbb-calendar__day-view sbb-calendar__table-wrapper">
+    <div class="sbb-calendar__table-header">
+      <span>
         February 2023
-        <sbb-icon name="chevron-small-down-small">
-        </sbb-icon>
-      </button>
-      <span
-        class="sbb-screen-reader-only"
-        role="status"
-      >
-        January 2023 February 2023
       </span>
     </div>
-    <sbb-secondary-button
-      aria-label="Change to the next month"
-      icon-name="chevron-small-right-small"
-      id="sbb-calendar__controls-next"
-      size="m"
-      tabindex="0"
-    >
-    </sbb-secondary-button>
-  </div>
-  <div class="sbb-calendar__table-overflow-break">
-    <div class="sbb-calendar__table-container sbb-calendar__table-day-view">
-      <table class="sbb-calendar__table">
-        <thead class="sbb-calendar__table-header">
-          <tr>
-            <th class="sbb-calendar__table-data">
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 52
-              </span>
-              <span aria-hidden="true">
-                52
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 1
-              </span>
-              <span aria-hidden="true">
-                1
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 2
-              </span>
-              <span aria-hidden="true">
-                2
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 3
-              </span>
-              <span aria-hidden="true">
-                3
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 4
-              </span>
-              <span aria-hidden="true">
-                4
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 5
-              </span>
-              <span aria-hidden="true">
-                5
-              </span>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Monday
-              </span>
-              <span aria-hidden="true">
-                M
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-02">
-                <sbb-calendar-day
-                  slot="2023-01-02"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-09">
-                <sbb-calendar-day
-                  slot="2023-01-09"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-16">
-                <sbb-calendar-day
-                  slot="2023-01-16"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-23">
-                <sbb-calendar-day
-                  slot="2023-01-23"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-30">
-                <sbb-calendar-day
-                  slot="2023-01-30"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Tuesday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-03">
-                <sbb-calendar-day
-                  slot="2023-01-03"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-10">
-                <sbb-calendar-day
-                  slot="2023-01-10"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-17">
-                <sbb-calendar-day
-                  slot="2023-01-17"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-24">
-                <sbb-calendar-day
-                  slot="2023-01-24"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-31">
-                <sbb-calendar-day
-                  slot="2023-01-31"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Wednesday
-              </span>
-              <span aria-hidden="true">
-                W
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-04">
-                <sbb-calendar-day
-                  slot="2023-01-04"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-11">
-                <sbb-calendar-day
-                  slot="2023-01-11"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-18">
-                <sbb-calendar-day
-                  slot="2023-01-18"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-25">
-                <sbb-calendar-day
-                  slot="2023-01-25"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Thursday
-              </span>
-              <span aria-hidden="true">
-                T
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-05">
-                <sbb-calendar-day
-                  slot="2023-01-05"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-12">
-                <sbb-calendar-day
-                  slot="2023-01-12"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-19">
-                <sbb-calendar-day
-                  slot="2023-01-19"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-26">
-                <sbb-calendar-day
-                  slot="2023-01-26"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Friday
-              </span>
-              <span aria-hidden="true">
-                F
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-06">
-                <sbb-calendar-day
-                  slot="2023-01-06"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-13">
-                <sbb-calendar-day
-                  slot="2023-01-13"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-20">
-                <sbb-calendar-day
-                  slot="2023-01-20"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-27">
-                <sbb-calendar-day
-                  slot="2023-01-27"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Saturday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </td>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-07">
-                <sbb-calendar-day
-                  slot="2023-01-07"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-14">
-                <sbb-calendar-day
-                  slot="2023-01-14"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-21">
-                <sbb-calendar-day
-                  slot="2023-01-21"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-28">
-                <sbb-calendar-day
-                  slot="2023-01-28"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-header-cell-vertical">
-              <span class="sbb-screen-reader-only">
-                Sunday
-              </span>
-              <span aria-hidden="true">
-                S
-              </span>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-01">
-                <sbb-calendar-day
-                  slot="2023-01-01"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-08">
-                <sbb-calendar-day
-                  slot="2023-01-08"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-15">
-                <sbb-calendar-day
-                  slot="2023-01-15"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-22">
-                <sbb-calendar-day
-                  slot="2023-01-22"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-01-29">
-                <sbb-calendar-day
-                  slot="2023-01-29"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <table class="sbb-calendar__table">
-        <thead class="sbb-calendar__table-header">
-          <tr>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 5
-              </span>
-              <span aria-hidden="true">
-                5
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 6
-              </span>
-              <span aria-hidden="true">
-                6
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 7
-              </span>
-              <span aria-hidden="true">
-                7
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 8
-              </span>
-              <span aria-hidden="true">
-                8
-              </span>
-            </th>
-            <th class="sbb-calendar__table-header-cell">
-              <span class="sbb-screen-reader-only">
-                Week 9
-              </span>
-              <span aria-hidden="true">
-                9
-              </span>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="sbb-calendar__table-body">
-          <tr>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-06">
-                <sbb-calendar-day
-                  slot="2023-02-06"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-13">
-                <sbb-calendar-day
-                  slot="2023-02-13"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-20">
-                <sbb-calendar-day
-                  slot="2023-02-20"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-27">
-                <sbb-calendar-day
-                  slot="2023-02-27"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__table-data">
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-07">
-                <sbb-calendar-day
-                  slot="2023-02-07"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-14">
-                <sbb-calendar-day
-                  slot="2023-02-14"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-21">
-                <sbb-calendar-day
-                  slot="2023-02-21"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-28">
-                <sbb-calendar-day
-                  slot="2023-02-28"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-01">
-                <sbb-calendar-day
-                  slot="2023-02-01"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-08">
-                <sbb-calendar-day
-                  slot="2023-02-08"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-15">
-                <sbb-calendar-day
-                  slot="2023-02-15"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-22">
-                <sbb-calendar-day
-                  slot="2023-02-22"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-02">
-                <sbb-calendar-day
-                  slot="2023-02-02"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-09">
-                <sbb-calendar-day
-                  slot="2023-02-09"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-16">
-                <sbb-calendar-day
-                  slot="2023-02-16"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-23">
-                <sbb-calendar-day
-                  slot="2023-02-23"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-03">
-                <sbb-calendar-day
-                  slot="2023-02-03"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-10">
-                <sbb-calendar-day
-                  slot="2023-02-10"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-17">
-                <sbb-calendar-day
-                  slot="2023-02-17"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-24">
-                <sbb-calendar-day
-                  slot="2023-02-24"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-04">
-                <sbb-calendar-day
-                  slot="2023-02-04"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-11">
-                <sbb-calendar-day
-                  slot="2023-02-11"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-18">
-                <sbb-calendar-day
-                  slot="2023-02-18"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-25">
-                <sbb-calendar-day
-                  slot="2023-02-25"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-          <tr>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-05">
-                <sbb-calendar-day
-                  slot="2023-02-05"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-12">
-                <sbb-calendar-day
-                  slot="2023-02-12"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-19">
-                <sbb-calendar-day
-                  slot="2023-02-19"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-            <td class="sbb-calendar__day-cell sbb-calendar__table-data">
-              <slot name="2023-02-26">
-                <sbb-calendar-day
-                  slot="2023-02-26"
-                  tabindex="-1"
-                >
-                </sbb-calendar-day>
-              </slot>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <table class="sbb-calendar__table">
+      <thead>
+        <tr>
+          <th class="sbb-calendar__table-data">
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 5
+            </span>
+            <span aria-hidden="true">
+              5
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 6
+            </span>
+            <span aria-hidden="true">
+              6
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 7
+            </span>
+            <span aria-hidden="true">
+              7
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 8
+            </span>
+            <span aria-hidden="true">
+              8
+            </span>
+          </th>
+          <th class="sbb-calendar__table-header-cell">
+            <span class="sbb-screen-reader-only">
+              Week 9
+            </span>
+            <span aria-hidden="true">
+              9
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Monday
+            </span>
+            <span aria-hidden="true">
+              M
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-06">
+              <sbb-calendar-day
+                slot="2023-02-06"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-13">
+              <sbb-calendar-day
+                slot="2023-02-13"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-20">
+              <sbb-calendar-day
+                slot="2023-02-20"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-27">
+              <sbb-calendar-day
+                slot="2023-02-27"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Tuesday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </td>
+          <td class="sbb-calendar__table-data">
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-07">
+              <sbb-calendar-day
+                slot="2023-02-07"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-14">
+              <sbb-calendar-day
+                slot="2023-02-14"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-21">
+              <sbb-calendar-day
+                slot="2023-02-21"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-28">
+              <sbb-calendar-day
+                slot="2023-02-28"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Wednesday
+            </span>
+            <span aria-hidden="true">
+              W
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-01">
+              <sbb-calendar-day
+                slot="2023-02-01"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-08">
+              <sbb-calendar-day
+                slot="2023-02-08"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-15">
+              <sbb-calendar-day
+                slot="2023-02-15"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-22">
+              <sbb-calendar-day
+                slot="2023-02-22"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Thursday
+            </span>
+            <span aria-hidden="true">
+              T
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-02">
+              <sbb-calendar-day
+                slot="2023-02-02"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-09">
+              <sbb-calendar-day
+                slot="2023-02-09"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-16">
+              <sbb-calendar-day
+                slot="2023-02-16"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-23">
+              <sbb-calendar-day
+                slot="2023-02-23"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Friday
+            </span>
+            <span aria-hidden="true">
+              F
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-03">
+              <sbb-calendar-day
+                slot="2023-02-03"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-10">
+              <sbb-calendar-day
+                slot="2023-02-10"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-17">
+              <sbb-calendar-day
+                slot="2023-02-17"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-24">
+              <sbb-calendar-day
+                slot="2023-02-24"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Saturday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-04">
+              <sbb-calendar-day
+                slot="2023-02-04"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-11">
+              <sbb-calendar-day
+                slot="2023-02-11"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-18">
+              <sbb-calendar-day
+                slot="2023-02-18"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-25">
+              <sbb-calendar-day
+                slot="2023-02-25"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+        <tr>
+          <td class="sbb-calendar__table-header-cell-vertical">
+            <span class="sbb-screen-reader-only">
+              Sunday
+            </span>
+            <span aria-hidden="true">
+              S
+            </span>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-05">
+              <sbb-calendar-day
+                slot="2023-02-05"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-12">
+              <sbb-calendar-day
+                slot="2023-02-12"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-19">
+              <sbb-calendar-day
+                slot="2023-02-19"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+          <td class="sbb-calendar__day-cell sbb-calendar__table-data">
+            <slot name="2023-02-26">
+              <sbb-calendar-day
+                slot="2023-02-26"
+                tabindex="-1"
+              >
+              </sbb-calendar-day>
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;

--- a/src/elements/calendar/calendar/__snapshots__/calendar.snapshot.spec.snap.js
+++ b/src/elements/calendar/calendar/__snapshots__/calendar.snapshot.spec.snap.js
@@ -26,17 +26,17 @@ snapshots["sbb-calendar default renders Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose year and month January 2023"
+        aria-label="Change to the next month"
         class="sbb-calendar__control"
-        icon-name="chevron-small-up-small"
+        icon-name="chevron-small-right-small"
         size="s"
         tabindex="0"
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Change to the next month"
+        aria-label="Choose year and month January 2023"
         class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
+        icon-name="chevron-small-up-small"
         size="s"
         tabindex="0"
       >
@@ -439,17 +439,17 @@ snapshots["sbb-calendar default renders vertical Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose year and month January 2023"
+        aria-label="Change to the next month"
         class="sbb-calendar__control"
-        icon-name="chevron-small-up-small"
+        icon-name="chevron-small-right-small"
         size="s"
         tabindex="0"
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Change to the next month"
+        aria-label="Choose year and month January 2023"
         class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
+        icon-name="chevron-small-up-small"
         size="s"
         tabindex="0"
       >
@@ -868,17 +868,17 @@ snapshots["sbb-calendar default renders in year view Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose year and month January 2023"
+        aria-label="Change to the next month"
         class="sbb-calendar__control"
-        icon-name="chevron-small-up-small"
+        icon-name="chevron-small-right-small"
         size="s"
         tabindex="0"
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Change to the next month"
+        aria-label="Choose year and month January 2023"
         class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
+        icon-name="chevron-small-up-small"
         size="s"
         tabindex="0"
       >
@@ -1266,6 +1266,14 @@ snapshots["sbb-calendar default renders in year view Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
+        aria-label="Change to the next 24 years"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
         aria-label="Choose date 2016 - 2039"
         class="sbb-calendar__control"
         icon-name="chevron-small-down-small"
@@ -1279,14 +1287,6 @@ snapshots["sbb-calendar default renders in year view Shadow DOM"] =
       >
         2016 - 2039
       </span>
-      <sbb-secondary-button
-        aria-label="Change to the next 24 years"
-        class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
-        size="s"
-        tabindex="0"
-      >
-      </sbb-secondary-button>
     </div>
     <table class="sbb-calendar__table">
       <tbody>
@@ -1431,17 +1431,17 @@ snapshots["sbb-calendar default renders in month view Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose year and month January 2023"
+        aria-label="Change to the next month"
         class="sbb-calendar__control"
-        icon-name="chevron-small-up-small"
+        icon-name="chevron-small-right-small"
         size="s"
         tabindex="0"
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Change to the next month"
+        aria-label="Choose year and month January 2023"
         class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
+        icon-name="chevron-small-up-small"
         size="s"
         tabindex="0"
       >
@@ -1829,6 +1829,14 @@ snapshots["sbb-calendar default renders in month view Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
+        aria-label="Change to the next year"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
         aria-label="Choose date 2023"
         class="sbb-calendar__control"
         icon-name="chevron-small-down-small"
@@ -1842,14 +1850,6 @@ snapshots["sbb-calendar default renders in month view Shadow DOM"] =
       >
         2023
       </span>
-      <sbb-secondary-button
-        aria-label="Change to the next year"
-        class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
-        size="s"
-        tabindex="0"
-      >
-      </sbb-secondary-button>
     </div>
     <table class="sbb-calendar__table">
       <tbody>
@@ -1940,17 +1940,17 @@ snapshots["sbb-calendar default renders multiple Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose year and month January 2023"
+        aria-label="Change to the next month"
         class="sbb-calendar__control"
-        icon-name="chevron-small-up-small"
+        icon-name="chevron-small-right-small"
         size="s"
         tabindex="0"
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Change to the next month"
+        aria-label="Choose year and month January 2023"
         class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
+        icon-name="chevron-small-up-small"
         size="s"
         tabindex="0"
       >
@@ -2327,17 +2327,17 @@ snapshots["sbb-calendar default renders horizontal wide with week numbers Shadow
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose year and month January 2023"
+        aria-label="Change to the next month"
         class="sbb-calendar__control"
-        icon-name="chevron-small-up-small"
+        icon-name="chevron-small-right-small"
         size="s"
         tabindex="0"
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Change to the next month"
+        aria-label="Choose year and month January 2023"
         class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
+        icon-name="chevron-small-up-small"
         size="s"
         tabindex="0"
       >
@@ -3171,17 +3171,17 @@ snapshots["sbb-calendar default renders vertical wide with week numbers Shadow D
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose year and month January 2023"
+        aria-label="Change to the next month"
         class="sbb-calendar__control"
-        icon-name="chevron-small-up-small"
+        icon-name="chevron-small-right-small"
         size="s"
         tabindex="0"
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Change to the next month"
+        aria-label="Choose year and month January 2023"
         class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
+        icon-name="chevron-small-up-small"
         size="s"
         tabindex="0"
       >
@@ -4174,17 +4174,17 @@ snapshots["sbb-calendar enhanced renders Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose year and month January 2023"
+        aria-label="Change to the next month"
         class="sbb-calendar__control"
-        icon-name="chevron-small-up-small"
+        icon-name="chevron-small-right-small"
         size="s"
         tabindex="0"
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Change to the next month"
+        aria-label="Choose year and month January 2023"
         class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
+        icon-name="chevron-small-up-small"
         size="s"
         tabindex="0"
       >
@@ -4759,17 +4759,17 @@ snapshots["sbb-calendar enhanced renders vertical Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose year and month January 2023"
+        aria-label="Change to the next month"
         class="sbb-calendar__control"
-        icon-name="chevron-small-up-small"
+        icon-name="chevron-small-right-small"
         size="s"
         tabindex="0"
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Change to the next month"
+        aria-label="Choose year and month January 2023"
         class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
+        icon-name="chevron-small-up-small"
         size="s"
         tabindex="0"
       >
@@ -5326,17 +5326,17 @@ snapshots["sbb-calendar enhanced renders in year view Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose year and month January 2023"
+        aria-label="Change to the next month"
         class="sbb-calendar__control"
-        icon-name="chevron-small-up-small"
+        icon-name="chevron-small-right-small"
         size="s"
         tabindex="0"
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Change to the next month"
+        aria-label="Choose year and month January 2023"
         class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
+        icon-name="chevron-small-up-small"
         size="s"
         tabindex="0"
       >
@@ -5724,6 +5724,14 @@ snapshots["sbb-calendar enhanced renders in year view Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
+        aria-label="Change to the next 24 years"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
         aria-label="Choose date 2016 - 2039"
         class="sbb-calendar__control"
         icon-name="chevron-small-down-small"
@@ -5737,14 +5745,6 @@ snapshots["sbb-calendar enhanced renders in year view Shadow DOM"] =
       >
         2016 - 2039
       </span>
-      <sbb-secondary-button
-        aria-label="Change to the next 24 years"
-        class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
-        size="s"
-        tabindex="0"
-      >
-      </sbb-secondary-button>
     </div>
     <table class="sbb-calendar__table">
       <tbody>
@@ -6044,17 +6044,17 @@ snapshots["sbb-calendar enhanced renders in month view Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose year and month January 2023"
+        aria-label="Change to the next month"
         class="sbb-calendar__control"
-        icon-name="chevron-small-up-small"
+        icon-name="chevron-small-right-small"
         size="s"
         tabindex="0"
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Change to the next month"
+        aria-label="Choose year and month January 2023"
         class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
+        icon-name="chevron-small-up-small"
         size="s"
         tabindex="0"
       >
@@ -6442,6 +6442,14 @@ snapshots["sbb-calendar enhanced renders in month view Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
+        aria-label="Change to the next year"
+        class="sbb-calendar__control"
+        icon-name="chevron-small-right-small"
+        size="s"
+        tabindex="0"
+      >
+      </sbb-secondary-button>
+      <sbb-secondary-button
         aria-label="Choose date 2023"
         class="sbb-calendar__control"
         icon-name="chevron-small-down-small"
@@ -6455,14 +6463,6 @@ snapshots["sbb-calendar enhanced renders in month view Shadow DOM"] =
       >
         2023
       </span>
-      <sbb-secondary-button
-        aria-label="Change to the next year"
-        class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
-        size="s"
-        tabindex="0"
-      >
-      </sbb-secondary-button>
     </div>
     <table class="sbb-calendar__table">
       <tbody>
@@ -6708,17 +6708,17 @@ snapshots["sbb-calendar enhanced renders multiple Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose year and month January 2023"
+        aria-label="Change to the next month"
         class="sbb-calendar__control"
-        icon-name="chevron-small-up-small"
+        icon-name="chevron-small-right-small"
         size="s"
         tabindex="0"
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Change to the next month"
+        aria-label="Choose year and month January 2023"
         class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
+        icon-name="chevron-small-up-small"
         size="s"
         tabindex="0"
       >
@@ -7250,17 +7250,17 @@ snapshots["sbb-calendar enhanced renders horizontal wide with week numbers Shado
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose year and month January 2023"
+        aria-label="Change to the next month"
         class="sbb-calendar__control"
-        icon-name="chevron-small-up-small"
+        icon-name="chevron-small-right-small"
         size="s"
         tabindex="0"
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Change to the next month"
+        aria-label="Choose year and month January 2023"
         class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
+        icon-name="chevron-small-up-small"
         size="s"
         tabindex="0"
       >
@@ -8249,17 +8249,17 @@ snapshots["sbb-calendar enhanced renders vertical wide with week numbers Shadow 
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose year and month January 2023"
+        aria-label="Change to the next month"
         class="sbb-calendar__control"
-        icon-name="chevron-small-up-small"
+        icon-name="chevron-small-right-small"
         size="s"
         tabindex="0"
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Change to the next month"
+        aria-label="Choose year and month January 2023"
         class="sbb-calendar__control"
-        icon-name="chevron-small-right-small"
+        icon-name="chevron-small-up-small"
         size="s"
         tabindex="0"
       >

--- a/src/elements/calendar/calendar/__snapshots__/calendar.snapshot.spec.snap.js
+++ b/src/elements/calendar/calendar/__snapshots__/calendar.snapshot.spec.snap.js
@@ -1274,7 +1274,7 @@ snapshots["sbb-calendar default renders in year view Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose date 2016 - 2039"
+        aria-label="Change to date selection"
         class="sbb-calendar__control"
         icon-name="chevron-small-down-small"
         size="s"
@@ -1837,7 +1837,7 @@ snapshots["sbb-calendar default renders in month view Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose date 2023"
+        aria-label="Change to date selection"
         class="sbb-calendar__control"
         icon-name="chevron-small-down-small"
         size="s"
@@ -5732,7 +5732,7 @@ snapshots["sbb-calendar enhanced renders in year view Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose date 2016 - 2039"
+        aria-label="Change to date selection"
         class="sbb-calendar__control"
         icon-name="chevron-small-down-small"
         size="s"
@@ -6450,7 +6450,7 @@ snapshots["sbb-calendar enhanced renders in month view Shadow DOM"] =
       >
       </sbb-secondary-button>
       <sbb-secondary-button
-        aria-label="Choose date 2023"
+        aria-label="Change to date selection"
         class="sbb-calendar__control"
         icon-name="chevron-small-down-small"
         size="s"

--- a/src/elements/calendar/calendar/calendar.component.ts
+++ b/src/elements/calendar/calendar/calendar.component.ts
@@ -1538,6 +1538,12 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
         this._previousMonthDisabled(),
       ),
       this._getArrow(
+        'right',
+        () => this._goToDifferentMonth(1),
+        i18nNextMonth[this._language.current],
+        this._nextMonthDisabled(),
+      ),
+      this._getArrow(
         'up',
         () => {
           this._resetFocus = true;
@@ -1545,12 +1551,6 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
           this._startTableTransition();
         },
         `${i18nYearMonthSelection[this._language.current]} ${monthLabel}`,
-      ),
-      this._getArrow(
-        'right',
-        () => this._goToDifferentMonth(1),
-        i18nNextMonth[this._language.current],
-        this._nextMonthDisabled(),
       ),
     ];
   }
@@ -1581,17 +1581,17 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
             this._previousYearDisabled(),
           )}
           ${this._getArrow(
-            'down',
-            () => this._resetCalendarViewAndEmitMonthChange(true),
-            `${i18nCalendarDateSelection[this._language.current]} ${this._chosenYear}`,
-          )}
-          <span class="sbb-screen-reader-only" role="status"> ${this._chosenYear} </span>
-          ${this._getArrow(
             'right',
             () => this._goToDifferentYear(1),
             i18nNextYear[this._language.current],
             this._nextYearDisabled(),
           )}
+          ${this._getArrow(
+            'down',
+            () => this._resetCalendarViewAndEmitMonthChange(true),
+            `${i18nCalendarDateSelection[this._language.current]} ${this._chosenYear}`,
+          )}
+          <span class="sbb-screen-reader-only" role="status">${this._chosenYear}</span>
         </div>
         <table
           class="sbb-calendar__table"
@@ -1655,17 +1655,17 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
             this._previousYearRangeDisabled(),
           )}
           ${this._getArrow(
-            'down',
-            () => this._resetCalendarViewAndEmitMonthChange(true),
-            `${i18nCalendarDateSelection[this._language.current]} ${yearLabel}`,
-          )}
-          <span class="sbb-screen-reader-only" role="status"> ${yearLabel} </span>
-          ${this._getArrow(
             'right',
             () => this._goToDifferentYearRange(YEARS_PER_PAGE),
             i18nNextYearRange(YEARS_PER_PAGE)[this._language.current],
             this._nextYearRangeDisabled(),
           )}
+          ${this._getArrow(
+            'down',
+            () => this._resetCalendarViewAndEmitMonthChange(true),
+            `${i18nCalendarDateSelection[this._language.current]} ${yearLabel}`,
+          )}
+          <span class="sbb-screen-reader-only" role="status">${yearLabel}</span>
         </div>
         <table
           class="sbb-calendar__table"

--- a/src/elements/calendar/calendar/calendar.component.ts
+++ b/src/elements/calendar/calendar/calendar.component.ts
@@ -15,6 +15,8 @@ import {
   type DateAdapter,
   defaultDateAdapter,
   forceType,
+  type FormRestoreReason,
+  type FormRestoreState,
   handleDistinctChange,
   i18nCalendarDateSelection,
   i18nCalendarWeekNumber,
@@ -31,9 +33,8 @@ import {
   readConfig,
   SbbElement,
   type SbbElementType,
+  SbbFormAssociatedMixin,
   SbbLanguageController,
-  SbbMediaMatcherController,
-  SbbMediaQueryBreakpointLargeAndAbove,
   screenReaderOnlyStyles,
   THURSDAY,
   TUESDAY,
@@ -100,25 +101,6 @@ interface CalendarKeyboardNavigationMonthYearViewsParameters {
   verticalOffset: number;
 }
 
-/**
- * Parameters needed in day view to correctly calculate the next element in keyboard navigation.
- *
- * In orientation='vertical', it's not possible to rely on any array/index to calculate the element to navigate to,
- * so calculations on dates must be done, which should consider view boundaries, offsets and month's length.
- */
-interface CalendarKeyboardNavigationDayViewParameters {
-  /** The first day rendered. */
-  firstDayInView: string | null;
-  /** The last day rendered. It depends on the 'wide' value. */
-  lastDayInView: string | null;
-  /** The offset from the first day of the week (Monday) of the first rendered month. */
-  firstMonthOffset: number;
-  /** The number of days in the first rendered month. */
-  firstMonthLength: number;
-  /** The offset from the first day of the week (Monday) of the second rendered month. If wide is false, it's equal to zero. */
-  secondMonthOffset: number;
-}
-
 export interface Day<T = Date> {
   /** Date as ISO string. */
   value: string;
@@ -145,7 +127,7 @@ export interface Weekday {
  *
  * @slot - Use the unnamed slot to add customized `sbb-calendar-day` elements.
  */
-export class SbbCalendarElement<T = Date> extends SbbElement {
+export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElement) {
   public static override readonly elementName: string = 'sbb-calendar';
   public static override elementDependencies: SbbElementType[] = [
     SbbCalendarDayElement,
@@ -166,10 +148,9 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
     monthchange: 'monthchange',
   } as const;
 
-  /** If set to true, two months are displayed */
   @forceType()
-  @property({ type: Boolean })
-  public accessor wide: boolean = false;
+  @property({ type: Number })
+  public accessor amount: number = 1;
 
   /** The initial view of the calendar which should be displayed on opening. */
   @property() public accessor view: 'day' | 'month' | 'year' = 'day';
@@ -202,9 +183,9 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
    * The selected date: accepts a date object, or, if `multiple`, an array of dates.
    */
   @property()
-  public set selected(value: T | T[] | null) {
+  public set value(value: T | T[] | null) {
     if (Array.isArray(value)) {
-      this._selected = value
+      this._value = value
         .map((dateLike: T) =>
           this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(dateLike)),
         )
@@ -223,16 +204,16 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
         (!this._isDayInRange(this._dateAdapter.toIso8601(selectedDate)) ||
           this._dateFilter(selectedDate))
       ) {
-        this._selected = selectedDate;
+        this._value = selectedDate;
       } else {
-        this._selected = null;
+        this._value = null;
       }
     }
   }
-  public get selected(): T | T[] | null {
-    return this._selected;
+  public get value(): T | T[] | null {
+    return this._value;
   }
-  @state() private accessor _selected: T | T[] | null = null;
+  @state() private accessor _value: T | T[] | null = null;
 
   /** A function used to filter out dates. */
   @property({ attribute: 'date-filter' })
@@ -252,37 +233,21 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
   /** The currently active date. */
   @state() private accessor _activeDate: T = this._dateAdapter.today();
 
-  /** The current wide property considering property value and breakpoints. From zero to small `wide` has always to be false. */
-  @state()
-  private set _wide(wide: boolean) {
-    this.toggleState('wide', wide);
-    this._wideInternal = wide;
-  }
-  private get _wide(): boolean {
-    return this._wideInternal;
-  }
-  // We keep the state in a field because of the WebKit bug https://bugs.webkit.org/show_bug.cgi?id=303467.
-  // TODO: re-check whether field is needed
-  private _wideInternal: boolean = false;
-
   @state() private accessor _calendarView: SbbCalendarElement['view'] = 'day';
 
   private _nextCalendarView: SbbCalendarElement['view'] = 'day';
-
-  /** Information about the rendered day view; used in keyboard navigation. */
-  private _keyboardNavigationDayViewParameters: CalendarKeyboardNavigationDayViewParameters = {
-    firstDayInView: null,
-    lastDayInView: null,
-    firstMonthOffset: 0,
-    firstMonthLength: 0,
-    secondMonthOffset: 0,
-  };
 
   /** A list of days, in two formats (long and single char). */
   private _weekdays!: Weekday[];
 
   /** Grid of calendar cells representing the dates of the month. */
-  private _weeks: Day<T>[][] = [];
+  private _weeks: Day<T>[][][] = [];
+
+  /** The first visible day in the calendar. */
+  private _firstVisibleDay: string = '';
+
+  /** The last visible day in the calendar. */
+  private _lastVisibleDay: string = '';
 
   /** Grid of calendar cells representing months. */
   private _months!: MonthCell[][];
@@ -290,20 +255,11 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
   /** Grid of calendar cells representing years. */
   private _years!: number[][];
 
-  /** Grid of calendar cells representing years for the wide view. */
-  private _nextMonthYears!: number[][];
-
-  /** Grid of calendar cells representing the dates of the next month. */
-  private _nextMonthWeeks!: Day<T>[][];
-
   /** An array containing all the month names in the current language. */
   private _monthNames: string[] = this._dateAdapter.getMonthNames('long');
 
   /** An array containing the weeks' numbers for the current month. */
-  private _weekNumbers!: number[];
-
-  /** An array containing the weeks' numbers for the next month in wide mode. */
-  private _nextMonthWeekNumbers!: number[];
+  private _weekNumbers!: number[][];
 
   private _enhancedVariant: boolean = false;
 
@@ -340,9 +296,6 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
   private _language = new SbbLanguageController(this).withHandler(() => {
     this._monthNames = this._dateAdapter.getMonthNames('long');
     this._createMonthRows();
-  });
-  private _mediaMatcher = new SbbMediaMatcherController(this, {
-    [SbbMediaQueryBreakpointLargeAndAbove]: () => this._init(),
   });
 
   public constructor() {
@@ -402,6 +355,48 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
   }
 
   /** @internal */
+  public override formResetCallback(): void {}
+
+  /** @internal */
+  public override formStateRestoreCallback(
+    state: FormRestoreState | null,
+    reason: FormRestoreReason,
+  ): void {
+    if (reason === 'autocomplete' || state == null) {
+      return;
+    }
+    const restore = (value: string | T | null): T | null =>
+      this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
+    if (typeof state === 'string') {
+      this.value = restore(state);
+    } else if (state instanceof FormData) {
+      if (this.multiple) {
+        this._readFormData(state as FormData).then(
+          (array) => (this.value = array.map(restore).filter((date): date is T => date != null)),
+        );
+        return;
+      }
+
+      const entry = state.get(this.name);
+      if (entry instanceof Blob) {
+        entry.text().then((text) => (this.value = restore(JSON.parse(text))));
+      } else {
+        this.value = restore(entry);
+      }
+    }
+  }
+
+  private async _readFormData(formData: FormData): Promise<T[]> {
+    return Promise.all(
+      formData
+        .getAll(this.name)
+        .map(async (entry) =>
+          entry instanceof Blob ? JSON.parse(await entry.text()) : (entry as T),
+        ),
+    );
+  }
+
+  /** @internal */
   public override focus(): void {
     this._resetFocus = true;
     this._focusCell();
@@ -414,7 +409,7 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
       return;
     }
 
-    if (changedProperties.has('wide') || changedProperties.has('orientation')) {
+    if (changedProperties.has('amount') || changedProperties.has('orientation')) {
       this.resetPosition();
     }
 
@@ -445,16 +440,16 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
   };
 
   /**
-   * The `_selected` state should be adapted when the `multiple` property changes:
-   *   - if it changes to true, the '_selected' is set to an array;
+   * The `_value` state should be adapted when the `multiple` property changes:
+   *   - if it changes to true, the '_value' is set to an array;
    *   - if it changes to false, the first available option is set as 'value' otherwise it's set to null.
    */
   private _onMultipleChanged(isMultiple: boolean): void {
-    if (isMultiple && !Array.isArray(this._selected)) {
-      this._selected = this._selected ? [this._selected as T] : [];
+    if (isMultiple && !Array.isArray(this._value)) {
+      this._value = this._value ? [this._value as T] : [];
     }
-    if (!isMultiple && Array.isArray(this._selected)) {
-      this._selected = (this._selected as T[]).length ? (this._selected as T[])[0] : null;
+    if (!isMultiple && Array.isArray(this._value)) {
+      this._value = (this._value as T[]).length ? (this._value as T[])[0] : null;
     }
   }
 
@@ -471,27 +466,36 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
     if (activeDate) {
       this._assignActiveDate(activeDate);
     }
-    this._wide =
-      (this._mediaMatcher.matches(SbbMediaQueryBreakpointLargeAndAbove) ?? false) && this.wide;
-    this._weeks = this._createWeekRows(this._activeDate);
+
+    const amount = this.amount < 1 ? 1 : this.amount;
+    this._weeks = Array.from({ length: amount }, (_, i) =>
+      this._createWeekRows(this._dateAdapter.addCalendarMonths(this._activeDate, i)),
+    );
+    const dateFromFirstMonth = this._weeks[0][0][0].dateValue;
+    this._firstVisibleDay = this._dateAdapter.toIso8601(
+      this._dateAdapter.createDate(
+        this._dateAdapter.getYear(dateFromFirstMonth),
+        this._dateAdapter.getMonth(dateFromFirstMonth),
+        1,
+      )!,
+    );
+    const dateFromLastMonth = this._weeks[amount - 1][0][0].dateValue;
+    this._lastVisibleDay = this._dateAdapter.toIso8601(
+      this._dateAdapter.createDate(
+        this._dateAdapter.getYear(dateFromLastMonth),
+        this._dateAdapter.getMonth(dateFromLastMonth),
+        this._dateAdapter.getNumDaysInMonth(dateFromLastMonth),
+      )!,
+    );
+
     this._years = this._createYearRows();
-    this._weekNumbers = this._weeks
-      .flat()
-      .sort((a, b) => a.value.localeCompare(b.value))
-      .map((day: Day<T>) => day.weekValue)
-      .filter((v, i, a) => a.indexOf(v) === i);
-    this._nextMonthWeeks = [[]];
-    this._nextMonthYears = [[]];
-    if (this._wide) {
-      const nextMonthDate = this._dateAdapter.addCalendarMonths(this._activeDate, 1);
-      this._nextMonthWeeks = this._createWeekRows(nextMonthDate, true);
-      this._nextMonthYears = this._createYearRows(YEARS_PER_PAGE);
-      this._nextMonthWeekNumbers = this._nextMonthWeeks
+    this._weekNumbers = this._weeks.map((week) =>
+      week
         .flat()
         .sort((a, b) => a.value.localeCompare(b.value))
         .map((day: Day<T>) => day.weekValue)
-        .filter((v, i, a) => a.indexOf(v) === i);
-    }
+        .filter((v, i, a) => a.indexOf(v) === i),
+    );
     this._initialized = true;
   }
 
@@ -518,36 +522,9 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
   }
 
   /** Creates the rows along the horizontal direction and sets the parameters used in keyboard navigation. */
-  private _createWeekRows(value: T, isSecondMonthInView = false): Day<T>[][] {
+  private _createWeekRows(value: T): Day<T>[][] {
     const daysInMonth: number = this._dateAdapter.getNumDaysInMonth(value);
     const weekOffset: number = this._dateAdapter.getFirstWeekOffset(value);
-    if (!isSecondMonthInView) {
-      this._keyboardNavigationDayViewParameters.firstMonthLength = daysInMonth;
-      this._keyboardNavigationDayViewParameters.firstMonthOffset = weekOffset;
-      this._keyboardNavigationDayViewParameters.firstDayInView = this._dateAdapter.toIso8601(
-        this._dateAdapter.createDate(
-          this._dateAdapter.getYear(value),
-          this._dateAdapter.getMonth(value),
-          1,
-        ),
-      );
-      this._keyboardNavigationDayViewParameters.lastDayInView = this._dateAdapter.toIso8601(
-        this._dateAdapter.createDate(
-          this._dateAdapter.getYear(value),
-          this._dateAdapter.getMonth(value),
-          daysInMonth,
-        ),
-      );
-    } else {
-      this._keyboardNavigationDayViewParameters.secondMonthOffset = weekOffset;
-      this._keyboardNavigationDayViewParameters.lastDayInView = this._dateAdapter.toIso8601(
-        this._dateAdapter.createDate(
-          this._dateAdapter.getYear(value),
-          this._dateAdapter.getMonth(value),
-          daysInMonth,
-        ),
-      );
-    }
     return this.orientation === 'horizontal'
       ? this._createWeekRowsHorizontal(value, daysInMonth, weekOffset)
       : this._createWeekRowsVertical(value, daysInMonth, weekOffset);
@@ -668,11 +645,11 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
   }
 
   /** Creates the rows for the year selection view. */
-  private _createYearRows(offset: number = 0): number[][] {
+  private _createYearRows(): number[][] {
     const startValueYearView: number = this._getStartValueYearView();
     const allYears: number[] = new Array(YEARS_PER_PAGE)
       .fill(0)
-      .map((_, i: number) => startValueYearView + offset + i);
+      .map((_, i: number) => startValueYearView + i);
     const rows: number = YEARS_PER_PAGE / YEARS_PER_ROW;
     const yearArray: number[][] = [];
     for (let i: number = 0; i < rows; i++) {
@@ -725,11 +702,7 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
       // This also must be very early in the event handler, otherwise there will be a flash
       // of selection.
       window.getSelection()?.removeAllRanges();
-      let selected = !this._selected
-        ? []
-        : Array.isArray(this._selected)
-          ? this._selected
-          : [this._selected];
+      let selected = !this._value ? [] : Array.isArray(this._value) ? this._value : [this._value];
       const serializedSelected = selected.map((s) => this._dateAdapter.toIso8601(s));
       if (
         event.shiftKey &&
@@ -755,11 +728,11 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
       }
 
       this._lastSelection = day;
-      this._selected = selected;
-      this._emitDateSelectedEvent(this._selected.map((e) => this._dateAdapter.deserialize(e)!));
-    } else if (!this._selected || this._dateAdapter.compareDate(this._selected as T, day) !== 0) {
+      this._value = selected;
+      this._emitDateSelectedEvent(this._value.map((e) => this._dateAdapter.deserialize(e)!));
+    } else if (!this._value || this._dateAdapter.compareDate(this._value as T, day) !== 0) {
       // In single selection, check if the day is already selected
-      this._selected = day;
+      this._value = day;
       this._emitDateSelectedEvent(this._dateAdapter.deserialize(day)!);
     }
   }
@@ -772,12 +745,12 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
    *     - if not, the selected dates are the new ones.
    */
   private _selectMultipleDates(days: Day<T>[]): void {
-    this._selected = this._mergeDates(days.map((e) => e.value));
-    this._emitDateSelectedEvent(this._selected.map((e) => this._dateAdapter.deserialize(e)!));
+    this._value = this._mergeDates(days.map((e) => e.value));
+    this._emitDateSelectedEvent(this._value.map((e) => this._dateAdapter.deserialize(e)!));
   }
 
   private _mergeDates(dates: string[], selected?: string[]): T[] {
-    selected ??= (this._selected as T[]).map((s) => this._dateAdapter.toIso8601(s));
+    selected ??= (this._value as T[]).map((s) => this._dateAdapter.toIso8601(s));
     // Filter disabled days by matching the provided `dates` parameter against the enabled cells.
     // Since the buttons' value is set to the Day's interface value (ISO string), there's no need to deserialize it.
     const enabledDays: string[] = (this._cells as SbbCalendarDayElement<T>[])
@@ -806,15 +779,18 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
   private _emitDateSelectedEvent(dateselected: T | T[]): void {
     /** @type {SbbDateSelectedEvent<T>} Event emitted on date selection. */
     this.dispatchEvent(new SbbDateSelectedEvent<T>(dateselected));
+
+    /** @type {InputEvent} Event emitted on user selection. */
+    this.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }));
+    /** @type {Event} Event emitted on user selection. */
+    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
   }
 
   private _emitMonthChange(): void {
     // FIXME: the name of this variable appears as event name in the readme
     //  due to a bug in the custom-elements-manifest library.
     //  https://github.com/open-wc/custom-elements-manifest/issues/149
-    const monthchange = (this.wide ? [...this._weeks, ...this._nextMonthWeeks] : this._weeks)
-      .flat()
-      .sort((a, b) => a.value.localeCompare(b.value)) as Day[];
+    const monthchange = this._weeks.flat(2).sort((a, b) => a.value.localeCompare(b.value)) as Day[];
     /**
      * @type {SbbMonthChangeEvent}
      * Emits when the month changes.
@@ -827,9 +803,9 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
     if (this.view === 'month') {
       let selectedDate: T | undefined;
       if (this.multiple) {
-        selectedDate = (this.selected as T[]).at(-1);
+        selectedDate = (this.value as T[]).at(-1);
       } else {
-        selectedDate = this.selected as T;
+        selectedDate = this.value as T;
       }
       this._chosenYear = this._dateAdapter.getYear(selectedDate ?? this._dateAdapter.today());
     } else {
@@ -838,15 +814,7 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
   }
 
   private _assignActiveDate(date: T): void {
-    if (this.min && this._dateAdapter.compareDate(this.min, date) > 0) {
-      this._activeDate = this.min;
-      return;
-    }
-    if (this.max && this._dateAdapter.compareDate(this.max, date) < 0) {
-      this._activeDate = this.max;
-      return;
-    }
-    this._activeDate = date;
+    this._activeDate = this._dateAdapter.clampDate(date, this.min, this.max)!;
   }
 
   /** Goes to the month identified by the shift. */
@@ -895,7 +863,10 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
 
   /** Checks if the "next month" button should be disabled. */
   private _nextMonthDisabled(): boolean {
-    let nextMonth = this._dateAdapter.addCalendarMonths(this._activeDate, this._wide ? 2 : 1);
+    let nextMonth = this._dateAdapter.addCalendarMonths(
+      this._activeDate,
+      this.amount < 1 ? 1 : this.amount,
+    );
     nextMonth = this._dateAdapter.createDate(
       this._dateAdapter.getYear(nextMonth),
       this._dateAdapter.getMonth(nextMonth),
@@ -917,7 +888,7 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
   /** Checks if the "next year" button should be disabled. */
   private _nextYearDisabled(): boolean {
     const nextYear = this._dateAdapter.createDate(
-      this._dateAdapter.getYear(this._activeDate) + (this._wide ? 2 : 1),
+      this._dateAdapter.getYear(this._activeDate) + (this.amount < 1 ? 1 : this.amount),
       1,
       1,
     );
@@ -932,9 +903,7 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
 
   /** Checks if the "next year" button should be disabled in year view. */
   private _nextYearRangeDisabled(): boolean {
-    const years = this._wide ? this._nextMonthYears : this._years;
-    const lastYearRange = years[years.length - 1];
-    const lastYear = lastYearRange[lastYearRange.length - 1];
+    const lastYear = this._years.flat(2).at(-1)!;
     const nextYear = this._dateAdapter.createDate(lastYear + 1, 1, 1);
     return this._nextDisabled(nextYear);
   }
@@ -966,8 +935,12 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
         : this._getFirstFocusableDay();
     } else {
       const selectedOrCurrent =
-        this.shadowRoot?.querySelector<SbbCalendarCellBaseElement<T>>(':state(selected)') ??
-        this.shadowRoot?.querySelector<SbbCalendarCellBaseElement<T>>(':state(current)');
+        this.shadowRoot?.querySelector<SbbCalendarCellBaseElement<T>>(
+          `sbb-calendar-${this._calendarView}:state(selected)`,
+        ) ??
+        this.shadowRoot?.querySelector<SbbCalendarCellBaseElement<T>>(
+          `sbb-calendar-${this._calendarView}:state(current)`,
+        );
       return selectedOrCurrent && !selectedOrCurrent.disabled
         ? selectedOrCurrent
         : this.shadowRoot!.querySelector<SbbCalendarCellBaseElement<T>>(
@@ -1035,10 +1008,6 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
       this.orientation === 'horizontal'
         ? { leftRight: 1, upDown: DAYS_PER_ROW }
         : { leftRight: DAYS_PER_ROW, upDown: 1 };
-    const offsetForVertical: number =
-      index < this._keyboardNavigationDayViewParameters.firstMonthLength
-        ? this._keyboardNavigationDayViewParameters.firstMonthOffset
-        : this._keyboardNavigationDayViewParameters.secondMonthOffset;
 
     switch (evt.key) {
       case 'ArrowUp':
@@ -1055,6 +1024,7 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
           const delta: number = firstOfWeek - +day.dayValue;
           return this._findDayPageUpDown(cells, index, day, delta, arrowsOffset.upDown);
         } else {
+          const offsetForVertical: number = this._dateAdapter.getFirstWeekOffset(day.dateValue);
           const weekNumber: number = Math.ceil((+day.dayValue + offsetForVertical) / DAYS_PER_ROW);
           const firstOfWeek: number = (weekNumber - 1) * DAYS_PER_ROW - offsetForVertical + 1;
           const delta: number = firstOfWeek - +day.dayValue;
@@ -1073,6 +1043,7 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
             Math.trunc((lastOfMonth - +day.dayValue!) / DAYS_PER_ROW) * DAYS_PER_ROW;
           return this._findDayPageUpDown(cells, index, day, delta, -arrowsOffset.upDown);
         } else {
+          const offsetForVertical: number = this._dateAdapter.getFirstWeekOffset(day.dateValue);
           const weekNumber: number = Math.ceil((+day.dayValue + offsetForVertical) / DAYS_PER_ROW);
           const lastOfWeek: number = weekNumber * DAYS_PER_ROW - offsetForVertical;
           const delta: number = lastOfWeek - +day.dayValue;
@@ -1094,10 +1065,7 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
   }
 
   private _isDayOutOfView(date: string): boolean {
-    return (
-      date < this._keyboardNavigationDayViewParameters.firstDayInView! ||
-      date > this._keyboardNavigationDayViewParameters.lastDayInView!
-    );
+    return date < this._firstVisibleDay || date > this._lastVisibleDay;
   }
 
   private _findDayArrows(
@@ -1314,7 +1282,7 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
       this._resetFocus = true;
     }
     this._activeDate =
-      (this.multiple ? (this._selected as T[]).at(-1) : (this._selected as T)) ??
+      (this.multiple ? (this._value as T[]).at(-1) : (this._value as T)) ??
       this._dateAdapter.today();
     this._setChosenYear();
     this._chosenMonth = undefined;
@@ -1326,147 +1294,97 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
     }
   }
 
-  /** Render the view for the day selection. */
-  private _renderDayView(): TemplateResult {
-    const nextMonthActiveDate = this._wide
-      ? this._dateAdapter.addCalendarMonths(this._activeDate, 1)
-      : undefined;
-    return html`
-      <div class="sbb-calendar__controls">
-        ${this._getArrow(
-          'left',
-          () => this._goToDifferentMonth(-1),
-          i18nPreviousMonth[this._language.current],
-          this._previousMonthDisabled(),
-        )}
-        <div class="sbb-calendar__controls-month">
-          ${this._createLabelForDayView(this._activeDate)}
-          ${this._wide ? this._createLabelForDayView(nextMonthActiveDate!) : nothing}
-          <span class="sbb-screen-reader-only" role="status">
-            ${this._createAriaLabelForDayView(this._activeDate, nextMonthActiveDate!)}
-          </span>
-        </div>
-        ${this._getArrow(
-          'right',
-          () => this._goToDifferentMonth(1),
-          i18nNextMonth[this._language.current],
-          this._nextMonthDisabled(),
-        )}
-      </div>
-      <div class="sbb-calendar__table-overflow-break">
-        <div class="sbb-calendar__table-container sbb-calendar__table-day-view">
-          ${this.orientation === 'horizontal'
-            ? html`
-                ${this._createDayTable(this._weeks, this._weekNumbers)}
-                ${this._wide
-                  ? this._createDayTable(this._nextMonthWeeks, this._nextMonthWeekNumbers, true)
-                  : nothing}
-              `
-            : html`
-                ${this._createDayTableVertical(this._weeks, this._weekNumbers)}
-                ${this._wide
-                  ? this._createDayTableVertical(
-                      this._nextMonthWeeks,
-                      this._nextMonthWeekNumbers,
-                      nextMonthActiveDate,
-                    )
-                  : nothing}
-              `}
-        </div>
-      </div>
-    `;
-  }
-
-  /** Creates the label with the month for the daily view. */
-  private _createLabelForDayView(d: T): TemplateResult {
-    const monthLabel = `${
-      this._monthNames[this._dateAdapter.getMonth(d) - 1]
-    } ${this._dateAdapter.getYear(d)}`;
-    return html`
-      <button
-        type="button"
-        class="sbb-calendar__date-selection sbb-calendar__controls-change-date"
-        aria-label="${i18nYearMonthSelection[this._language.current]} ${monthLabel}"
-        @click=${() => {
-          this._resetFocus = true;
-          this._nextCalendarView = 'year';
-          this._startTableTransition();
-        }}
-      >
-        ${monthLabel}
-        <sbb-icon name="chevron-small-down-small"></sbb-icon>
-      </button>
-    `;
-  }
-
-  /** Creates the aria-label for the daily view. */
-  private _createAriaLabelForDayView(...dates: T[]): string {
-    let monthLabel = '';
-    for (const d of dates) {
-      if (d) {
-        monthLabel += `${
-          this._monthNames[this._dateAdapter.getMonth(d) - 1]
-        } ${this._dateAdapter.getYear(d)} `;
-      }
-    }
-    return monthLabel;
-  }
-
   /** Creates the calendar table for the daily view. */
   private _createDayTable(
     weeks: Day<T>[][],
     weekNumbers: number[],
-    isWideNextMonth: boolean = false,
+    first: boolean,
   ): TemplateResult {
-    const weeksForSelectMultipleWeekNumbers: Day<T>[] = (
-      this._wide
-        ? [...this._weeks, ...this._nextMonthWeeks]
-        : isWideNextMonth
-          ? this._nextMonthWeeks
-          : this._weeks
-    ).flat();
-    const weeksForSelectMultipleWeekDays: Day<T>[] = (
-      isWideNextMonth ? this._nextMonthWeeks : this._weeks
-    ).flat();
+    const firstDay = weeks[0][0].dateValue;
+    const monthLabel = `${
+      this._monthNames[this._dateAdapter.getMonth(firstDay) - 1]
+    } ${this._dateAdapter.getYear(firstDay)}`;
+    const weeksForSelectMultipleWeekNumbers: Day<T>[] = weeks.flat();
+    const weeksForSelectMultipleWeekDays: Day<T>[] = weeks.flat();
     return html`
-      <table
-        class="sbb-calendar__table"
-        @focusout=${(event: FocusEvent) =>
-          this._handleTableBlur(event.relatedTarget as HTMLElement)}
-        @animationend=${(e: AnimationEvent) => this._tableAnimationEnd(e)}
-      >
-        <thead class="sbb-calendar__table-header">
-          <tr>
-            ${this.weekNumbers ? html`<th class="sbb-calendar__table-header-cell"></th>` : nothing}
-            ${this._weekdays.map(
-              (weekDay: Weekday, index: number) => html`
-                <th class="sbb-calendar__table-header-cell">
-                  ${this.multiple
-                    ? html`
-                        <sbb-calendar-weekday
-                          .value=${weekDay}
-                          @click=${() => {
-                            // NOTE: Sundays have index 7, while their weekDayValue is 0
-                            const days: Day<T>[] = weeksForSelectMultipleWeekDays.filter(
-                              (day: Day<T>) => day.weekDayValue === (index + 1) % 7,
-                            )!;
-                            this._selectMultipleDates(days);
-                          }}
-                        ></sbb-calendar-weekday>
-                      `
-                    : html`
-                        <span class="sbb-screen-reader-only">${weekDay.long}</span>
-                        <span aria-hidden="true">${weekDay.narrow}</span>
-                      `}
-                </th>
-              `,
-            )}
-          </tr>
-        </thead>
-        <tbody class="sbb-calendar__table-body">
-          ${weeks.map((week: Day<T>[], rowIndex: number) => {
-            const firstRowOffset: number = DAYS_PER_ROW - week.length;
-            if (rowIndex === 0 && firstRowOffset) {
+      <div class="sbb-calendar__table-wrapper sbb-calendar__day-view">
+        <div class="sbb-calendar__table-header">
+          <span>${monthLabel}</span> ${first ? this._createDayTableControls(monthLabel) : nothing}
+        </div>
+        <table
+          class="sbb-calendar__table"
+          @focusout=${(event: FocusEvent) =>
+            this._handleTableBlur(event.relatedTarget as HTMLElement)}
+          @animationend=${(e: AnimationEvent) => this._tableAnimationEnd(e)}
+        >
+          <thead>
+            <tr>
+              ${this.weekNumbers
+                ? html`<th class="sbb-calendar__table-header-cell"></th>`
+                : nothing}
+              ${this._weekdays.map(
+                (weekDay: Weekday, index: number) => html`
+                  <th class="sbb-calendar__table-header-cell">
+                    ${this.multiple
+                      ? html`
+                          <sbb-calendar-weekday
+                            .value=${weekDay}
+                            @click=${() => {
+                              // NOTE: Sundays have index 7, while their weekDayValue is 0
+                              const days: Day<T>[] = weeksForSelectMultipleWeekDays.filter(
+                                (day: Day<T>) => day.weekDayValue === (index + 1) % 7,
+                              )!;
+                              this._selectMultipleDates(days);
+                            }}
+                          ></sbb-calendar-weekday>
+                        `
+                      : html`
+                          <span class="sbb-screen-reader-only">${weekDay.long}</span>
+                          <span aria-hidden="true">${weekDay.narrow}</span>
+                        `}
+                  </th>
+                `,
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            ${weeks.map((week: Day<T>[], rowIndex: number) => {
+              const firstRowOffset: number = DAYS_PER_ROW - week.length;
+              if (rowIndex === 0 && firstRowOffset) {
+                return html`
+                  <tr>
+                    ${this.weekNumbers
+                      ? html`
+                          <td class="sbb-calendar__table-header-cell-vertical">
+                            ${this.multiple
+                              ? html`
+                                  <sbb-calendar-weeknumber
+                                    .value=${weekNumbers[0]}
+                                    @click=${() => {
+                                      const days: Day<T>[] =
+                                        weeksForSelectMultipleWeekNumbers.filter(
+                                          (day: Day<T>) => day.weekValue === weekNumbers[0],
+                                        )!;
+                                      this._selectMultipleDates(days);
+                                    }}
+                                  ></sbb-calendar-weeknumber>
+                                `
+                              : html`
+                                  <span class="sbb-screen-reader-only"
+                                    >${`${i18nCalendarWeekNumber[this._language.current]} ${weekNumbers[0]}`}</span
+                                  >
+                                  <span aria-hidden="true">${weekNumbers[0]}</span>
+                                `}
+                          </td>
+                        `
+                      : nothing}
+                    ${[...Array(firstRowOffset).keys()].map(
+                      () => html`<td class="sbb-calendar__table-data"></td>`,
+                    )}
+                    ${this._createDayCells(week)}
+                  </tr>
+                `;
+              }
               return html`
                 <tr>
                   ${this.weekNumbers
@@ -1475,10 +1393,10 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
                           ${this.multiple
                             ? html`
                                 <sbb-calendar-weeknumber
-                                  .value=${weekNumbers[0]}
+                                  .value=${weekNumbers[rowIndex]}
                                   @click=${() => {
                                     const days: Day<T>[] = weeksForSelectMultipleWeekNumbers.filter(
-                                      (day: Day<T>) => day.weekValue === weekNumbers[0],
+                                      (day: Day<T>) => day.weekValue === weekNumbers[rowIndex],
                                     )!;
                                     this._selectMultipleDates(days);
                                   }}
@@ -1486,52 +1404,20 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
                               `
                             : html`
                                 <span class="sbb-screen-reader-only"
-                                  >${`${i18nCalendarWeekNumber[this._language.current]} ${weekNumbers[0]}`}</span
+                                  >${`${i18nCalendarWeekNumber[this._language.current]} ${weekNumbers[rowIndex]}`}</span
                                 >
-                                <span aria-hidden="true">${weekNumbers[0]}</span>
+                                <span aria-hidden="true">${weekNumbers[rowIndex]}</span>
                               `}
                         </td>
                       `
                     : nothing}
-                  ${[...Array(firstRowOffset).keys()].map(
-                    () => html`<td class="sbb-calendar__table-data"></td>`,
-                  )}
                   ${this._createDayCells(week)}
                 </tr>
               `;
-            }
-            return html`
-              <tr>
-                ${this.weekNumbers
-                  ? html`
-                      <td class="sbb-calendar__table-header-cell-vertical">
-                        ${this.multiple
-                          ? html`
-                              <sbb-calendar-weeknumber
-                                .value=${weekNumbers[rowIndex]}
-                                @click=${() => {
-                                  const days: Day<T>[] = weeksForSelectMultipleWeekNumbers.filter(
-                                    (day: Day<T>) => day.weekValue === weekNumbers[rowIndex],
-                                  )!;
-                                  this._selectMultipleDates(days);
-                                }}
-                              ></sbb-calendar-weeknumber>
-                            `
-                          : html`
-                              <span class="sbb-screen-reader-only"
-                                >${`${i18nCalendarWeekNumber[this._language.current]} ${weekNumbers[rowIndex]}`}</span
-                              >
-                              <span aria-hidden="true">${weekNumbers[rowIndex]}</span>
-                            `}
-                      </td>
-                    `
-                  : nothing}
-                ${this._createDayCells(week)}
-              </tr>
-            `;
-          })}
-        </tbody>
-      </table>
+            })}
+          </tbody>
+        </table>
+      </div>
     `;
   }
 
@@ -1539,95 +1425,116 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
   private _createDayTableVertical(
     weeks: Day<T>[][],
     weekNumbers: number[],
-    nextMonthActiveDate?: T,
+    first: boolean,
   ): TemplateResult {
-    const weekOffset = this._dateAdapter.getFirstWeekOffset(
-      nextMonthActiveDate ?? this._activeDate,
-    );
-    const weeksForSelectMultipleWeekNumbers: Day<T>[] = (
-      this._wide
-        ? [...this._weeks, ...this._nextMonthWeeks]
-        : nextMonthActiveDate
-          ? this._nextMonthWeeks
-          : this._weeks
-    ).flat();
+    const firstDay = weeks[0][0].dateValue;
+    const monthLabel = `${
+      this._monthNames[this._dateAdapter.getMonth(firstDay) - 1]
+    } ${this._dateAdapter.getYear(firstDay)}`;
+    const activeDate = weeks[0][0].dateValue;
+    const weekOffset = this._dateAdapter.getFirstWeekOffset(activeDate ?? this._activeDate);
+    const weeksForSelectMultipleWeekNumbers: Day<T>[] = weeks.flat();
     return html`
-      <table
-        class="sbb-calendar__table"
-        @focusout=${(event: FocusEvent) =>
-          this._handleTableBlur(event.relatedTarget as HTMLElement)}
-        @animationend=${(e: AnimationEvent) => this._tableAnimationEnd(e)}
-      >
-        ${this.weekNumbers
-          ? html`
-              <thead class="sbb-calendar__table-header">
+      <div class="sbb-calendar__table-wrapper sbb-calendar__day-view">
+        <div class="sbb-calendar__table-header">
+          <span>${monthLabel}</span> ${first ? this._createDayTableControls(monthLabel) : nothing}
+        </div>
+        <table
+          class="sbb-calendar__table"
+          @focusout=${(event: FocusEvent) =>
+            this._handleTableBlur(event.relatedTarget as HTMLElement)}
+          @animationend=${(e: AnimationEvent) => this._tableAnimationEnd(e)}
+        >
+          ${this.weekNumbers
+            ? html`
+                <thead>
+                  <tr>
+                    <th class="sbb-calendar__table-data"></th>
+                    ${weekNumbers.map(
+                      (weekNumber: number) => html`
+                        <th class="sbb-calendar__table-header-cell">
+                          ${this.multiple
+                            ? html`
+                                <sbb-calendar-weeknumber
+                                  .value=${weekNumber}
+                                  @click=${() => {
+                                    const days: Day<T>[] = weeksForSelectMultipleWeekNumbers.filter(
+                                      (day: Day<T>) => day.weekValue === weekNumber,
+                                    )!;
+                                    this._selectMultipleDates(days);
+                                  }}
+                                ></sbb-calendar-weeknumber>
+                              `
+                            : html`
+                                <span class="sbb-screen-reader-only"
+                                  >${`${i18nCalendarWeekNumber[this._language.current]} ${weekNumber}`}</span
+                                >
+                                <span aria-hidden="true">${weekNumber}</span>
+                              `}
+                        </th>
+                      `,
+                    )}
+                  </tr>
+                </thead>
+              `
+            : nothing}
+          <tbody>
+            ${weeks.map((week: Day<T>[], rowIndex: number) => {
+              const weekday = this._weekdays[rowIndex];
+              return html`
                 <tr>
-                  ${nextMonthActiveDate
-                    ? nothing
-                    : html`<th class="sbb-calendar__table-data"></th>`}
-                  ${weekNumbers.map(
-                    (weekNumber: number) => html`
-                      <th class="sbb-calendar__table-header-cell">
-                        ${this.multiple
-                          ? html`
-                              <sbb-calendar-weeknumber
-                                .value=${weekNumber}
-                                @click=${() => {
-                                  const days: Day<T>[] = weeksForSelectMultipleWeekNumbers.filter(
-                                    (day: Day<T>) => day.weekValue === weekNumber,
-                                  )!;
-                                  this._selectMultipleDates(days);
-                                }}
-                              ></sbb-calendar-weeknumber>
-                            `
-                          : html`
-                              <span class="sbb-screen-reader-only"
-                                >${`${i18nCalendarWeekNumber[this._language.current]} ${weekNumber}`}</span
-                              >
-                              <span aria-hidden="true">${weekNumber}</span>
-                            `}
-                      </th>
-                    `,
-                  )}
+                  <td class="sbb-calendar__table-header-cell-vertical">
+                    ${this.multiple
+                      ? html`
+                          <sbb-calendar-weekday
+                            .value=${weekday}
+                            @click=${() => this._selectMultipleDates(week)}
+                          >
+                            ${weekday.narrow}
+                          </sbb-calendar-weekday>
+                        `
+                      : html`
+                          <span class="sbb-screen-reader-only">${weekday.long}</span>
+                          <span aria-hidden="true">${weekday.narrow}</span>
+                        `}
+                  </td>
+                  ${rowIndex < weekOffset
+                    ? html`<td class="sbb-calendar__table-data"></td>`
+                    : nothing}
+                  ${this._createDayCells(week)}
                 </tr>
-              </thead>
-            `
-          : nothing}
-        <tbody class="sbb-calendar__table-body">
-          ${weeks.map((week: Day<T>[], rowIndex: number) => {
-            const weekday = this._weekdays[rowIndex];
-            const selectableDays = this._wide ? [...week, ...this._nextMonthWeeks[rowIndex]] : week;
-            return html`
-              <tr>
-                ${nextMonthActiveDate
-                  ? nothing
-                  : html`
-                      <td class="sbb-calendar__table-header-cell-vertical">
-                        ${this.multiple
-                          ? html`
-                              <sbb-calendar-weekday
-                                .value=${weekday}
-                                @click=${() => this._selectMultipleDates(selectableDays)}
-                              >
-                                ${weekday.narrow}
-                              </sbb-calendar-weekday>
-                            `
-                          : html`
-                              <span class="sbb-screen-reader-only">${weekday.long}</span>
-                              <span aria-hidden="true">${weekday.narrow}</span>
-                            `}
-                      </td>
-                    `}
-                ${rowIndex < weekOffset
-                  ? html`<td class="sbb-calendar__table-data"></td>`
-                  : nothing}
-                ${this._createDayCells(week)}
-              </tr>
-            `;
-          })}
-        </tbody>
-      </table>
+              `;
+            })}
+          </tbody>
+        </table>
+      </div>
     `;
+  }
+
+  private _createDayTableControls(monthLabel: string): TemplateResult[] {
+    return [
+      this._getArrow(
+        'left',
+        () => this._goToDifferentMonth(-1),
+        i18nPreviousMonth[this._language.current],
+        this._previousMonthDisabled(),
+      ),
+      this._getArrow(
+        'up',
+        () => {
+          this._resetFocus = true;
+          this._nextCalendarView = 'year';
+          this._startTableTransition();
+        },
+        `${i18nYearMonthSelection[this._language.current]} ${monthLabel}`,
+      ),
+      this._getArrow(
+        'right',
+        () => this._goToDifferentMonth(1),
+        i18nNextMonth[this._language.current],
+        this._nextMonthDisabled(),
+      ),
+    ];
   }
 
   /** Creates the cells for the daily view. */
@@ -1646,80 +1553,55 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
   /** Render the view for the month selection. */
   private _renderMonthView(): TemplateResult {
     return html`
-      <div class="sbb-calendar__controls">
-        ${this._getArrow(
-          'left',
-          () => this._goToDifferentYear(-1),
-          i18nPreviousYear[this._language.current],
-          this._previousYearDisabled(),
-        )}
-        <div class="sbb-calendar__controls-month">${this._createLabelForMonthView()}</div>
-        ${this._getArrow(
-          'right',
-          () => this._goToDifferentYear(1),
-          i18nNextYear[this._language.current],
-          this._nextYearDisabled(),
-        )}
-      </div>
-      <div class="sbb-calendar__table-overflow-break">
-        <div class="sbb-calendar__table-container sbb-calendar__table-month-view">
-          ${this._createMonthTable(this._months, this._chosenYear!)}
-          ${this._wide ? this._createMonthTable(this._months, this._chosenYear! + 1) : nothing}
-        </div>
-      </div>
-    `;
-  }
-
-  /** Creates the label with the year for the monthly view. */
-  private _createLabelForMonthView(): TemplateResult {
-    return html`<button
-        type="button"
-        id="sbb-calendar__month-selection"
-        class="sbb-calendar__controls-change-date"
-        aria-label=${`${i18nCalendarDateSelection[this._language.current]} ${this._chosenYear}`}
-        @click=${() => this._resetCalendarViewAndEmitMonthChange(true)}
-      >
-        ${this._chosenYear} ${this._wide ? ` - ${this._chosenYear! + 1}` : nothing}
-        <sbb-icon name="chevron-small-up-small"></sbb-icon>
-      </button>
-      <span class="sbb-screen-reader-only" role="status"> ${this._chosenYear} </span>`;
-  }
-
-  /** Creates the table for the month selection view. */
-  private _createMonthTable(months: MonthCell[][], year: number): TemplateResult {
-    return html`
-      <table
-        class="sbb-calendar__table"
-        @animationend=${(e: AnimationEvent) => this._tableAnimationEnd(e)}
-      >
-        ${this._wide
-          ? html`<thead class="sbb-calendar__table-header" aria-hidden="true">
-              <tr>
-                <th class="sbb-calendar__table-header-cell" colspan=${MONTHS_PER_ROW}>${year}</th>
-              </tr>
-            </thead>`
-          : nothing}
-        <tbody class="sbb-calendar__table-body">
-          ${months.map(
-            (row: MonthCell[]) => html`
-              <tr>
-                ${row.map((month: MonthCell) => {
-                  return html`
-                    <td class="sbb-calendar__table-data">
-                      <sbb-calendar-month
-                        .value="${year}-${month.value}"
-                        @click=${() => this._onMonthSelection(month.monthValue, year)}
-                        @keydown=${(evt: KeyboardEvent) => this._handleKeyboardEvent(evt)}
-                      >
-                      </sbb-calendar-month>
-                    </td>
-                  `;
-                })}
-              </tr>
-            `,
+      <div class="sbb-calendar__table-wrapper sbb-calendar__month-view">
+        <div class="sbb-calendar__table-header">
+          <span>${this._chosenYear}</span>
+          ${this._getArrow(
+            'left',
+            () => this._goToDifferentYear(-1),
+            i18nPreviousYear[this._language.current],
+            this._previousYearDisabled(),
           )}
-        </tbody>
-      </table>
+          ${this._getArrow(
+            'down',
+            () => this._resetCalendarViewAndEmitMonthChange(true),
+            `${i18nCalendarDateSelection[this._language.current]} ${this._chosenYear}`,
+          )}
+          <span class="sbb-screen-reader-only" role="status"> ${this._chosenYear} </span>
+          ${this._getArrow(
+            'right',
+            () => this._goToDifferentYear(1),
+            i18nNextYear[this._language.current],
+            this._nextYearDisabled(),
+          )}
+        </div>
+        <table
+          class="sbb-calendar__table"
+          @animationend=${(e: AnimationEvent) => this._tableAnimationEnd(e)}
+        >
+          <tbody>
+            ${this._months.map(
+              (row: MonthCell[]) => html`
+                <tr>
+                  ${row.map((month: MonthCell) => {
+                    return html`
+                      <td class="sbb-calendar__table-data">
+                        <sbb-calendar-month
+                          .value="${this._chosenYear}-${month.value}"
+                          @click=${() =>
+                            this._onMonthSelection(month.monthValue, this._chosenYear!)}
+                          @keydown=${(evt: KeyboardEvent) => this._handleKeyboardEvent(evt)}
+                        >
+                        </sbb-calendar-month>
+                      </td>
+                    `;
+                  })}
+                </tr>
+              `,
+            )}
+          </tbody>
+        </table>
+      </div>
     `;
   }
 
@@ -1740,100 +1622,64 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
 
   /** Render the view for the year selection. */
   private _renderYearView(): TemplateResult {
-    return html`
-      <div class="sbb-calendar__controls">
-        ${this._getArrow(
-          'left',
-          () => this._goToDifferentYearRange(-YEARS_PER_PAGE),
-          i18nPreviousYearRange(YEARS_PER_PAGE)[this._language.current],
-          this._previousYearRangeDisabled(),
-        )}
-        <div class="sbb-calendar__controls-month">${this._createLabelForYearView()}</div>
-        ${this._getArrow(
-          'right',
-          () => this._goToDifferentYearRange(YEARS_PER_PAGE),
-          i18nNextYearRange(YEARS_PER_PAGE)[this._language.current],
-          this._nextYearRangeDisabled(),
-        )}
-      </div>
-      <div class="sbb-calendar__table-overflow-break">
-        <div class="sbb-calendar__table-container sbb-calendar__table-year-view">
-          ${this._createYearTable(this._years)}
-          ${this._wide ? this._createYearTable(this._nextMonthYears, true) : nothing}
-        </div>
-      </div>
-    `;
-  }
-
-  /** Creates the button arrow for all the views. */
-  private _getArrow(
-    direction: 'left' | 'right',
-    click: () => void,
-    ariaLabel: string,
-    disabled: boolean,
-  ): TemplateResult {
-    return html`<sbb-secondary-button
-      size="m"
-      icon-name="chevron-small-${direction}-small"
-      aria-label=${ariaLabel}
-      @click=${click}
-      ?disabled=${disabled}
-      id="sbb-calendar__controls-${direction === 'left' ? 'previous' : 'next'}"
-    ></sbb-secondary-button>`;
-  }
-
-  /** Creates the label with the year range for the yearly view. */
-  private _createLabelForYearView(): TemplateResult {
-    const firstYear: number = this._years.flat()[0];
-    const lastYearArray: number[] = (this._wide ? this._nextMonthYears : this._years).flat();
+    const firstYear: number = this._years.flat(2)[0];
+    const lastYearArray: number[] = this._years.at(-1)!.flat();
     const lastYear: number = lastYearArray[lastYearArray.length - 1];
     const yearLabel = `${firstYear} - ${lastYear}`;
     return html`
-      <button
-        type="button"
-        id="sbb-calendar__year-selection"
-        class="sbb-calendar__controls-change-date"
-        aria-label="${i18nCalendarDateSelection[this._language.current]} ${yearLabel}"
-        @click=${() => this._resetCalendarViewAndEmitMonthChange(true)}
-      >
-        ${yearLabel}
-        <sbb-icon name="chevron-small-up-small"></sbb-icon>
-      </button>
-      <span class="sbb-screen-reader-only" role="status"> ${yearLabel} </span>
+      <div class="sbb-calendar__table-wrapper sbb-calendar__year-view">
+        <div class="sbb-calendar__table-header">
+          <span>${yearLabel}</span>
+          ${this._getArrow(
+            'left',
+            () => this._goToDifferentYearRange(-YEARS_PER_PAGE),
+            i18nPreviousYearRange(YEARS_PER_PAGE)[this._language.current],
+            this._previousYearRangeDisabled(),
+          )}
+          ${this._getArrow(
+            'down',
+            () => this._resetCalendarViewAndEmitMonthChange(true),
+            `${i18nCalendarDateSelection[this._language.current]} ${yearLabel}`,
+          )}
+          <span class="sbb-screen-reader-only" role="status"> ${yearLabel} </span>
+          ${this._getArrow(
+            'right',
+            () => this._goToDifferentYearRange(YEARS_PER_PAGE),
+            i18nNextYearRange(YEARS_PER_PAGE)[this._language.current],
+            this._nextYearRangeDisabled(),
+          )}
+        </div>
+        <table
+          class="sbb-calendar__table"
+          @animationend=${(e: AnimationEvent) => this._tableAnimationEnd(e)}
+        >
+          <tbody>
+            ${this._years.map(
+              (row: number[]) =>
+                html` <tr>
+                  ${row.map((year: number) => {
+                    return html`
+                      <td class="sbb-calendar__table-data">
+                        <sbb-calendar-year
+                          .value=${String(year)}
+                          @keydown=${(evt: KeyboardEvent) => this._handleKeyboardEvent(evt)}
+                          @click=${() => this._onYearSelection(year)}
+                        >
+                        </sbb-calendar-year>
+                      </td>
+                    `;
+                  })}
+                </tr>`,
+            )}
+          </tbody>
+        </table>
+      </div>
     `;
   }
 
-  /** Creates the table for the year selection view. */
-  private _createYearTable(years: number[][], shiftRight = false): TemplateResult {
-    return html` <table
-      class="sbb-calendar__table"
-      @animationend=${(e: AnimationEvent) => this._tableAnimationEnd(e)}
-    >
-      <tbody class="sbb-calendar__table-body">
-        ${years.map(
-          (row: number[]) =>
-            html` <tr>
-              ${row.map((year: number) => {
-                return html`
-                  <td class="sbb-calendar__table-data">
-                    <sbb-calendar-year
-                      .value=${String(year)}
-                      @keydown=${(evt: KeyboardEvent) => this._handleKeyboardEvent(evt)}
-                      @click=${() => this._onYearSelection(year, shiftRight)}
-                    >
-                    </sbb-calendar-year>
-                  </td>
-                `;
-              })}
-            </tr>`,
-        )}
-      </tbody>
-    </table>`;
-  }
-
   /** Select the year and change the view to month selection. */
-  private _onYearSelection(year: number, rightSide: boolean): void {
-    this._chosenYear = rightSide ? year - 1 : year;
+  private _onYearSelection(year: number): void {
+    this._chosenYear = year;
     this._nextCalendarView = 'month';
     this._assignActiveDate(
       this._dateAdapter.createDate(
@@ -1845,21 +1691,21 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
     this._startTableTransition();
   }
 
-  private _getView(): TemplateResult {
-    if (isServer || this.hydrationRequired) {
-      // TODO: We disable SSR for calendar for now. Figure out, if there is a way
-      // to enable it, while considering i18n and date information.
-      return html`${nothing}`;
-    }
-    switch (this._calendarView) {
-      case 'year':
-        return this._renderYearView();
-      case 'month':
-        return this._renderMonthView();
-      case 'day':
-      default:
-        return this._renderDayView();
-    }
+  /** Creates the button arrow for all the views. */
+  private _getArrow(
+    direction: 'left' | 'right' | 'down' | 'up',
+    click: () => void,
+    ariaLabel: string,
+    disabled = false,
+  ): TemplateResult {
+    return html`<sbb-secondary-button
+      class="sbb-calendar__control"
+      size="s"
+      icon-name="chevron-small-${direction}-small"
+      aria-label=${ariaLabel}
+      @click=${click}
+      ?disabled=${disabled}
+    ></sbb-secondary-button>`;
   }
 
   private _tableAnimationEnd(event: AnimationEvent): void {
@@ -1882,8 +1728,32 @@ export class SbbCalendarElement<T = Date> extends SbbElement {
       ?.forEach((e) => e.classList.toggle('sbb-calendar__table-hide'));
   }
 
+  private _getView(): TemplateResult | typeof nothing {
+    switch (this._calendarView) {
+      case 'year':
+        return this._renderYearView();
+      case 'month':
+        return this._renderMonthView();
+      default:
+        return nothing;
+    }
+  }
+
   protected override render(): TemplateResult {
-    return html`<div class="sbb-calendar__wrapper">${this._getView()}</div>`;
+    if (isServer || this.hydrationRequired) {
+      // TODO: We disable SSR for calendar for now. Figure out, if there is a way
+      // to enable it, while considering i18n and date information.
+      return html`${nothing}`;
+    }
+
+    return html`<div class="sbb-calendar__wrapper">
+      ${this.orientation === 'horizontal'
+        ? this._weeks.map((weeks, i) => this._createDayTable(weeks, this._weekNumbers[i], i === 0))
+        : this._weeks.map((weeks, i) =>
+            this._createDayTableVertical(weeks, this._weekNumbers[i], i === 0),
+          )}
+      ${this._getView()}
+    </div>`;
   }
 }
 

--- a/src/elements/calendar/calendar/calendar.component.ts
+++ b/src/elements/calendar/calendar/calendar.component.ts
@@ -239,8 +239,6 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
 
   @state() private accessor _calendarView: SbbCalendarElement['view'] = 'day';
 
-  private _nextCalendarView: SbbCalendarElement['view'] = 'day';
-
   /** A list of days, in two formats (long and single char). */
   private _weekdays!: Weekday[];
 
@@ -420,7 +418,7 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
     if (changedProperties.has('view')) {
       this._setChosenYear();
       this._chosenMonth = undefined;
-      this._nextCalendarView = this._calendarView = this.view;
+      this._calendarView = this.view;
     }
   }
 
@@ -434,7 +432,9 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
     if (name === '_calendarView') {
       this.internals.states.delete(`view-${oldValue}`);
       this.internals.states.add(`view-${this._calendarView}`);
-      this.toggleState('');
+      if (this._containingFocus) {
+        this._resetFocus = true;
+      }
     }
   }
 
@@ -1290,12 +1290,12 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
       : this._findNext(days, nextIndex, -verticalOffset);
   }
 
-  private _resetCalendarViewAndEmitMonthChange(initTransition = false): void {
-    this._resetCalendarView(initTransition);
+  private _resetCalendarViewAndEmitMonthChange(): void {
+    this._resetCalendarView();
     this._emitMonthChange();
   }
 
-  private _resetCalendarView(initTransition = false): void {
+  private _resetCalendarView(): void {
     if (this._containingFocus) {
       this._resetFocus = true;
     }
@@ -1305,11 +1305,7 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
     this._setChosenYear();
     this._chosenMonth = undefined;
     this._init();
-    this._nextCalendarView = this._calendarView = this.view;
-
-    if (initTransition) {
-      this._startTableTransition();
-    }
+    this._calendarView = this.view;
   }
 
   /** Creates the calendar table for the daily view. */
@@ -1333,7 +1329,6 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
           class="sbb-calendar__table"
           @focusout=${(event: FocusEvent) =>
             this._handleTableBlur(event.relatedTarget as HTMLElement)}
-          @animationend=${(e: AnimationEvent) => this._tableAnimationEnd(e)}
         >
           <thead>
             <tr>
@@ -1461,7 +1456,6 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
           class="sbb-calendar__table"
           @focusout=${(event: FocusEvent) =>
             this._handleTableBlur(event.relatedTarget as HTMLElement)}
-          @animationend=${(e: AnimationEvent) => this._tableAnimationEnd(e)}
         >
           ${this.weekNumbers
             ? html`
@@ -1547,8 +1541,7 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
         'up',
         () => {
           this._resetFocus = true;
-          this._nextCalendarView = 'year';
-          this._startTableTransition();
+          this._calendarView = 'year';
         },
         `${i18nYearMonthSelection[this._language.current]} ${monthLabel}`,
       ),
@@ -1588,15 +1581,12 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
           )}
           ${this._getArrow(
             'down',
-            () => this._resetCalendarViewAndEmitMonthChange(true),
+            () => this._resetCalendarViewAndEmitMonthChange(),
             `${i18nCalendarDateSelection[this._language.current]} ${this._chosenYear}`,
           )}
           <span class="sbb-screen-reader-only" role="status">${this._chosenYear}</span>
         </div>
-        <table
-          class="sbb-calendar__table"
-          @animationend=${(e: AnimationEvent) => this._tableAnimationEnd(e)}
-        >
+        <table class="sbb-calendar__table">
           <tbody>
             ${this._months.map(
               (row: MonthCell[]) => html`
@@ -1626,7 +1616,7 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
   /** Select the month and change the view to day selection. */
   private _onMonthSelection(month: number, year: number): void {
     this._chosenMonth = month;
-    this._nextCalendarView = 'day';
+    this._calendarView = 'day';
     this._init(
       this._dateAdapter.createDate(
         year,
@@ -1634,7 +1624,6 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
         this._dateAdapter.getDate(this._activeDate),
       ),
     );
-    this._startTableTransition();
     this._emitMonthChange();
   }
 
@@ -1662,15 +1651,12 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
           )}
           ${this._getArrow(
             'down',
-            () => this._resetCalendarViewAndEmitMonthChange(true),
+            () => this._resetCalendarViewAndEmitMonthChange(),
             `${i18nCalendarDateSelection[this._language.current]} ${yearLabel}`,
           )}
           <span class="sbb-screen-reader-only" role="status">${yearLabel}</span>
         </div>
-        <table
-          class="sbb-calendar__table"
-          @animationend=${(e: AnimationEvent) => this._tableAnimationEnd(e)}
-        >
+        <table class="sbb-calendar__table">
           <tbody>
             ${this._years.map(
               (row: number[]) =>
@@ -1698,7 +1684,7 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
   /** Select the year and change the view to month selection. */
   private _onYearSelection(year: number): void {
     this._chosenYear = year;
-    this._nextCalendarView = 'month';
+    this._calendarView = 'month';
     this._assignActiveDate(
       this._dateAdapter.createDate(
         this._chosenYear,
@@ -1706,7 +1692,6 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
         this._dateAdapter.getDate(this._activeDate),
       ),
     );
-    this._startTableTransition();
   }
 
   /** Creates the button arrow for all the views. */
@@ -1724,26 +1709,6 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
       @click=${click}
       ?disabled=${disabled}
     ></sbb-secondary-button>`;
-  }
-
-  private _tableAnimationEnd(event: AnimationEvent): void {
-    const table = event.target as HTMLElement;
-    if (event.animationName === 'hide') {
-      table.classList.remove('sbb-calendar__table-hide');
-      if (this._containingFocus) {
-        this._resetFocus = true;
-      }
-      this._calendarView = this._nextCalendarView;
-    } else if (event.animationName === 'show') {
-      this.internals.states.delete('transition');
-    }
-  }
-
-  private _startTableTransition(): void {
-    this.internals.states.add('transition');
-    this.shadowRoot
-      ?.querySelectorAll('table')
-      ?.forEach((e) => e.classList.toggle('sbb-calendar__table-hide'));
   }
 
   private _getView(): TemplateResult | typeof nothing {

--- a/src/elements/calendar/calendar/calendar.component.ts
+++ b/src/elements/calendar/calendar/calendar.component.ts
@@ -148,6 +148,9 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
     monthchange: 'monthchange',
   } as const;
 
+  /**
+   * The amount of months to display in this calendar.
+   */
   @forceType()
   @property({ type: Number })
   public accessor amount: number = 1;

--- a/src/elements/calendar/calendar/calendar.component.ts
+++ b/src/elements/calendar/calendar/calendar.component.ts
@@ -801,7 +801,7 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
     /** @type {InputEvent} Event emitted on user selection. */
     this.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }));
     /** @type {Event} Event emitted on user selection. */
-    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+    this.dispatchEvent(new Event('change', { bubbles: true }));
   }
 
   private _emitMonthChange(): void {
@@ -1585,7 +1585,7 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
           ${this._getArrow(
             'down',
             () => this._resetCalendarViewAndEmitMonthChange(),
-            `${i18nCalendarDateSelection[this._language.current]} ${this._chosenYear}`,
+            i18nCalendarDateSelection[this._language.current],
           )}
           <span class="sbb-screen-reader-only" role="status">${this._chosenYear}</span>
         </div>
@@ -1655,7 +1655,7 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
           ${this._getArrow(
             'down',
             () => this._resetCalendarViewAndEmitMonthChange(),
-            `${i18nCalendarDateSelection[this._language.current]} ${yearLabel}`,
+            i18nCalendarDateSelection[this._language.current],
           )}
           <span class="sbb-screen-reader-only" role="status">${yearLabel}</span>
         </div>

--- a/src/elements/calendar/calendar/calendar.component.ts
+++ b/src/elements/calendar/calendar/calendar.component.ts
@@ -1011,8 +1011,11 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
       .activeElement as SbbCalendarCellBaseElement<T>;
     if (nextEl !== activeEl) {
       nextEl.tabIndex = 0;
-      nextEl?.focus();
-      activeEl.tabIndex = -1;
+      nextEl.focus();
+
+      if (cells.includes(activeEl)) {
+        activeEl.tabIndex = -1;
+      }
     }
   }
 

--- a/src/elements/calendar/calendar/calendar.component.ts
+++ b/src/elements/calendar/calendar/calendar.component.ts
@@ -3,6 +3,7 @@ import {
   html,
   isServer,
   nothing,
+  type PropertyDeclaration,
   type PropertyValues,
   type TemplateResult,
   unsafeCSS,
@@ -420,6 +421,20 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
       this._setChosenYear();
       this._chosenMonth = undefined;
       this._nextCalendarView = this._calendarView = this.view;
+    }
+  }
+
+  public override requestUpdate(
+    name?: PropertyKey,
+    oldValue?: unknown,
+    options?: PropertyDeclaration,
+  ): void {
+    super.requestUpdate(name, oldValue, options);
+
+    if (name === '_calendarView') {
+      this.internals.states.delete(`view-${oldValue}`);
+      this.internals.states.add(`view-${this._calendarView}`);
+      this.toggleState('');
     }
   }
 

--- a/src/elements/calendar/calendar/calendar.scss
+++ b/src/elements/calendar/calendar/calendar.scss
@@ -61,6 +61,7 @@
 
 .sbb-calendar__table-header span {
   flex: 1 1 auto;
+  color: var(--sbb-calendar-control-view-change-color);
 
   .sbb-calendar__day-view:not(:first-of-type) & {
     text-align: center;

--- a/src/elements/calendar/calendar/calendar.scss
+++ b/src/elements/calendar/calendar/calendar.scss
@@ -47,10 +47,6 @@
   flex: 1 1 auto;
   padding-inline-start: var(--sbb-spacing-fixed-3x);
   color: var(--sbb-calendar-control-view-change-color);
-
-  .sbb-calendar__day-view:not(:first-of-type) & {
-    text-align: center;
-  }
 }
 
 .sbb-calendar__control {

--- a/src/elements/calendar/calendar/calendar.scss
+++ b/src/elements/calendar/calendar/calendar.scss
@@ -11,19 +11,10 @@
   line-height: var(--sbb-typo-line-height-text);
 
   --sbb-calendar-cell-size: #{sbb.px-to-rem-build(44)};
-
-  // Match Figma design
-  --sbb-calendar-cell-border-radius: calc(
-    var(--sbb-border-radius-4x) + var(--sbb-calendar-cell-border-width)
-  );
   --sbb-calendar-cell-transition-duration: var(
     --sbb-disable-animation-duration,
     var(--sbb-animation-duration-2x)
   );
-
-  @include sbb.mq($from: small) {
-    --sbb-calendar-control-view-change-height: #{sbb.px-to-rem-build(48)};
-  }
 }
 
 :host(:state(enhanced)) {
@@ -54,7 +45,7 @@
 .sbb-calendar__table-header {
   display: flex;
   align-items: center;
-  gap: var(--sbb-spacing-fixed-1x);
+  gap: var(--sbb-calendar-control-gap);
   height: var(--sbb-size-element-xs);
   margin-block-end: var(--sbb-spacing-fixed-4x);
 }
@@ -130,8 +121,8 @@
 
 sbb-calendar-day {
   :host(:not(:state(enhanced))) & {
-    --sbb-calendar-cell-justify-content: center;
-    --sbb-calendar-day-height: #{sbb.px-to-rem-build(44)};
+    --sbb-calendar-day-justify-content: center;
+    --sbb-calendar-day-height: var(--sbb-calendar-day-size);
     --sbb-calendar-day-extra-display: none;
     --sbb-calendar-day-value-height: unset;
     --sbb-calendar-day-crossed-out-top: 50%;

--- a/src/elements/calendar/calendar/calendar.scss
+++ b/src/elements/calendar/calendar/calendar.scss
@@ -5,6 +5,7 @@
 
   // We add width definition to host, to make overwriting easy for consumers.
   width: max-content;
+  max-width: 100%;
 
   // Set the line-height for adjacent elements in order to prevent from influence of a consumer-set line-height.
   line-height: var(--sbb-typo-line-height-text);
@@ -31,149 +32,49 @@
 
 .sbb-calendar__wrapper {
   width: 100%;
-  display: block;
-  transition-duration: var(--sbb-calendar-cell-transition-duration);
-}
-
-.sbb-calendar__controls {
-  width: 100%;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--sbb-calendar-control-gap);
-  margin-block-end: var(--sbb-calendar-control-margin-block-end);
-}
-
-.sbb-calendar__controls-month {
-  width: 100%;
   display: flex;
+  flex-wrap: wrap;
   gap: var(--sbb-calendar-tables-gap);
+  transition-duration: var(--sbb-calendar-cell-transition-duration);
+  position: relative;
 }
 
-#sbb-calendar__controls-previous,
-#sbb-calendar__controls-next {
+:is(.sbb-calendar__year-view, .sbb-calendar__month-view) {
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+}
+
+.sbb-calendar__wrapper:has(> :where(.sbb-calendar__year-view, .sbb-calendar__month-view))
+  .sbb-calendar__day-view {
+  visibility: hidden;
+}
+
+.sbb-calendar__table-header {
+  display: flex;
+  align-items: center;
+  gap: var(--sbb-spacing-fixed-1x);
+  height: var(--sbb-size-element-xs);
+  margin-block-end: var(--sbb-spacing-fixed-4x);
+}
+
+.sbb-calendar__table-header span {
+  flex: 1 1 auto;
+
+  .sbb-calendar__day-view:not(:first-of-type) & {
+    text-align: center;
+  }
+}
+
+.sbb-calendar__control {
   -webkit-tap-highlight-color: transparent;
-}
-
-.sbb-calendar__controls-change-date {
-  display: flex;
-  align-items: center;
-  margin: auto;
-  height: var(--sbb-calendar-control-view-change-height);
-  font-size: var(--sbb-text-font-size-s);
-  letter-spacing: var(--sbb-typo-letter-spacing-text);
-  line-height: var(--sbb-typo-letter-spacing-text);
-  text-transform: capitalize;
-  cursor: var(--sbb-cursor-pointer);
-  padding-inline: var(--sbb-calendar-control-view-change-padding-inline);
-  border-radius: var(--sbb-border-radius-infinity);
-  background-color: var(--sbb-calendar-control-view-change-background);
-  color: var(--sbb-calendar-control-view-change-color);
-  transition-duration: var(--sbb-calendar-cell-transition-duration);
-  transition-timing-function: var(--sbb-calendar-cell-transition-easing-function);
-  transition-property: background-color, padding-block-end;
-
-  &:disabled {
-    --sbb-calendar-control-view-change-background: light-dark(
-      var(--sbb-color-milk),
-      var(--sbb-color-anthracite)
-    );
-    --sbb-calendar-control-view-change-color: light-dark(
-      var(--sbb-color-granite),
-      var(--sbb-color-aluminium)
-    );
-
-    cursor: unset;
-  }
-
-  &:focus-visible {
-    @include sbb.focus-outline;
-
-    outline-offset: var(--sbb-spacing-fixed-1x);
-  }
-
-  @include sbb.hover-mq {
-    &:not(:active, :disabled):hover {
-      padding-block-end: var(--sbb-calendar-cell-hover-shift);
-    }
-  }
-
-  &:not(:disabled):active {
-    --sbb-calendar-control-view-change-background: var(--sbb-background-color-3);
-  }
-}
-
-.sbb-calendar__table-month-view,
-.sbb-calendar__table-year-view {
-  --sbb-calendar-table-column-spaces: 6;
-}
-
-.sbb-calendar__table-overflow-break {
-  // We have to cut the negative margin which is built by the containing sbb-calendar__table-container.
-  // Overflow: hidden would cut the focus outline. Therefore we take `contain` here.
-  contain: layout;
-}
-
-.sbb-calendar__table-container {
-  display: flex;
-  gap: var(--sbb-calendar-tables-gap);
-  margin-inline: var(--sbb-calendar-margin);
-
-  // The padding of the first and last column should not be visible if calendar is stretched.
-  // Therefore we need a negative inline margin.
-  // As we don't want to squeeze, the margin should never be greater than zero.
-
-  // Min width is equals to the normal width of the calendar
-  --sbb-calendar-min-width: calc(7 * var(--sbb-calendar-cell-size));
-
-  // The overflow variable is equals the difference between the actual width and the min width.
-  --sbb-calendar-overflow: calc(100% - var(--sbb-calendar-min-width));
-
-  // The start offset is negative margin which should overlap the parent container. Should never be a positive value.
-  --sbb-calendar-start-offset: min(
-    0px,
-    -1 * (var(--sbb-calendar-overflow) / var(--sbb-calendar-table-column-spaces))
-  );
-  --sbb-calendar-margin: var(--sbb-calendar-start-offset);
-
-  :host(:state(wide)) & {
-    --sbb-calendar-min-width: calc(
-      2 * 7 * var(--sbb-calendar-cell-size) + var(--sbb-calendar-tables-gap)
-    );
-    --sbb-calendar-margin: calc(0.5 * var(--sbb-calendar-start-offset));
-  }
-
-  :host([orientation='horizontal'][week-numbers]) & {
-    --sbb-calendar-min-width: calc(8 * var(--sbb-calendar-cell-size));
-  }
-
-  :host([orientation='horizontal'][week-numbers]:state(wide)) & {
-    --sbb-calendar-min-width: calc(
-      2 * 8 * var(--sbb-calendar-cell-size) + var(--sbb-calendar-tables-gap)
-    );
-  }
-
-  // The container's min-width is set in vertical mode;
-  // the value `calc(7 * var(--sbb-calendar-cell-size))` is fine
-  // considering that the maximum number of weeks in a month is 6, plus 1 for the header at the table's left side.
-  :host([orientation='vertical']) & {
-    min-width: var(--sbb-calendar-min-width);
-
-    // The variable that defines the margin is set to 0 to correctly display the table if consumers set a custom width.
-    --sbb-calendar-start-offset: 0;
-  }
-
-  // The min-width in wide is calculated as (max number of weeks in a month) * (displayed months) + (header column) = 6 * 2 + 1 = 13.
-  :host([orientation='vertical']:state(wide)) & {
-    --sbb-calendar-min-width: calc(
-      13 * var(--sbb-calendar-cell-size) + var(--sbb-calendar-tables-gap)
-    );
-  }
 }
 
 .sbb-calendar__table {
   width: 100%;
   border-collapse: collapse;
   height: max-content;
+  flex: 0 0;
 
   animation: {
     name: show;
@@ -188,20 +89,9 @@
       duration: var(--sbb-calendar-table-animation-duration);
     }
   }
-
-  :host(:not(:state(wide))) & {
-    // Due to a Safari iOS rendering bug we need to define min-width as well.
-    // Otherwise, after orientation change, there is a wrong width if placed in an sbb-dialog.
-    min-width: 100%;
-  }
 }
 
-.sbb-calendar__table-header {
-  // Depending where in the DOM it's used, it's possible that browser defaults set text-align to left.
-  text-align: center;
-}
-
-.sbb-calendar__table-body {
+.sbb-calendar__table :is(thead, tbody) {
   // Depending where in the DOM it's used, it's possible that browser defaults set text-align to left.
   text-align: center;
 }
@@ -209,6 +99,7 @@
 .sbb-calendar__table-header-cell,
 .sbb-calendar__table-header-cell-vertical {
   width: var(--sbb-calendar-cell-size);
+  min-width: var(--sbb-calendar-cell-size);
   color: var(--sbb-calendar-header-color);
   padding: 0;
   font-size: var(--sbb-text-font-size-xs);

--- a/src/elements/calendar/calendar/calendar.scss
+++ b/src/elements/calendar/calendar/calendar.scss
@@ -100,7 +100,5 @@ sbb-calendar-day {
     --sbb-calendar-day-height: var(--sbb-calendar-day-size);
     --sbb-calendar-day-extra-display: none;
     --sbb-calendar-day-value-height: unset;
-    --sbb-calendar-day-crossed-out-top: 50%;
-    --sbb-calendar-day-crossed-out-translate: translate(-50%, -50%) rotate(-45deg);
   }
 }

--- a/src/elements/calendar/calendar/calendar.scss
+++ b/src/elements/calendar/calendar/calendar.scss
@@ -9,12 +9,6 @@
 
   // Set the line-height for adjacent elements in order to prevent from influence of a consumer-set line-height.
   line-height: var(--sbb-typo-line-height-text);
-
-  --sbb-calendar-cell-size: #{sbb.px-to-rem-build(44)};
-  --sbb-calendar-cell-transition-duration: var(
-    --sbb-disable-animation-duration,
-    var(--sbb-animation-duration-2x)
-  );
 }
 
 :host(:state(enhanced)) {
@@ -26,7 +20,6 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--sbb-calendar-tables-gap);
-  transition-duration: var(--sbb-calendar-cell-transition-duration);
   position: relative;
 }
 
@@ -69,20 +62,6 @@
   border-collapse: collapse;
   height: max-content;
   flex: 0 0;
-
-  animation: {
-    name: show;
-    duration: var(--sbb-calendar-table-animation-duration);
-  }
-
-  &.sbb-calendar__table-hide {
-    --sbb-calendar-cell-transition-duration: 0ms;
-
-    animation: {
-      name: hide;
-      duration: var(--sbb-calendar-table-animation-duration);
-    }
-  }
 }
 
 .sbb-calendar__table :is(thead, tbody) {
@@ -127,29 +106,5 @@ sbb-calendar-day {
     --sbb-calendar-day-value-height: unset;
     --sbb-calendar-day-crossed-out-top: 50%;
     --sbb-calendar-day-crossed-out-translate: translate(-50%, -50%) rotate(-45deg);
-  }
-}
-
-@keyframes show {
-  from {
-    opacity: 0;
-    transform: translateY(var(--sbb-calendar-table-animation-shift));
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0%);
-  }
-}
-
-@keyframes hide {
-  from {
-    opacity: 1;
-    transform: translateY(0%);
-  }
-
-  to {
-    opacity: 0;
-    transform: translateY(var(--sbb-calendar-table-animation-shift));
   }
 }

--- a/src/elements/calendar/calendar/calendar.scss
+++ b/src/elements/calendar/calendar/calendar.scss
@@ -45,9 +45,10 @@
   inset-inline-start: 0;
 }
 
-.sbb-calendar__wrapper:has(> :where(.sbb-calendar__year-view, .sbb-calendar__month-view))
-  .sbb-calendar__day-view {
-  visibility: hidden;
+.sbb-calendar__day-view {
+  :host(:not(:state(view-day))) & {
+    visibility: hidden;
+  }
 }
 
 .sbb-calendar__table-header {

--- a/src/elements/calendar/calendar/calendar.scss
+++ b/src/elements/calendar/calendar/calendar.scss
@@ -61,6 +61,7 @@
 
 .sbb-calendar__table-header span {
   flex: 1 1 auto;
+  padding-inline-start: var(--sbb-spacing-fixed-3x);
   color: var(--sbb-calendar-control-view-change-color);
 
   .sbb-calendar__day-view:not(:first-of-type) & {

--- a/src/elements/calendar/calendar/calendar.snapshot.spec.ts
+++ b/src/elements/calendar/calendar/calendar.snapshot.spec.ts
@@ -34,7 +34,7 @@ describe(`sbb-calendar`, () => {
 
         beforeEach(async () => {
           element = await fixture(html`
-            <sbb-calendar selected="2023-01-20T00:00:00"
+            <sbb-calendar value="2023-01-20T00:00:00"
               >${variant === 'default' ? nothing : createSlottedDays(2023, 1)}</sbb-calendar
             >
           `);
@@ -56,7 +56,7 @@ describe(`sbb-calendar`, () => {
 
         beforeEach(async () => {
           element = await fixture(html`
-            <sbb-calendar selected="2023-01-20T00:00:00" orientation="vertical"
+            <sbb-calendar value="2023-01-20T00:00:00" orientation="vertical"
               >${variant === 'default' ? nothing : createSlottedDays(2023, 1)}</sbb-calendar
             >
           `);
@@ -76,7 +76,7 @@ describe(`sbb-calendar`, () => {
 
         beforeEach(async () => {
           element = await fixture(html`
-            <sbb-calendar selected="2023-01-20T00:00:00" view="year"
+            <sbb-calendar value="2023-01-20T00:00:00" view="year"
               >${variant === 'default' ? nothing : createSlottedDays(2023, 1)}</sbb-calendar
             >
           `);
@@ -96,7 +96,7 @@ describe(`sbb-calendar`, () => {
 
         beforeEach(async () => {
           element = await fixture(html`
-            <sbb-calendar selected="2023-01-20T00:00:00" view="month"
+            <sbb-calendar value="2023-01-20T00:00:00" view="month"
               >${variant === 'default' ? nothing : createSlottedDays(2023, 1)}</sbb-calendar
             >
           `);
@@ -116,7 +116,7 @@ describe(`sbb-calendar`, () => {
 
         beforeEach(async () => {
           element = await fixture(html`
-            <sbb-calendar selected="2023-01-20T00:00:00" multiple
+            <sbb-calendar value="2023-01-20T00:00:00" multiple
               >${variant === 'default' ? nothing : createSlottedDays(2023, 1)}</sbb-calendar
             >
           `);
@@ -137,7 +137,11 @@ describe(`sbb-calendar`, () => {
         beforeEach(async () => {
           await setViewport({ width: sbbBreakpointLargeMinPx, height: 640 });
           element = await fixture(html`
-            <sbb-calendar selected="2023-01-20T00:00:00" orientation="horizontal" wide week-numbers
+            <sbb-calendar
+              value="2023-01-20T00:00:00"
+              orientation="horizontal"
+              amount="2"
+              week-numbers
               >${variant === 'default' ? nothing : createSlottedDays(2023, 1)}</sbb-calendar
             >
           `);
@@ -158,7 +162,7 @@ describe(`sbb-calendar`, () => {
         beforeEach(async () => {
           await setViewport({ width: sbbBreakpointLargeMinPx, height: 640 });
           element = await fixture(html`
-            <sbb-calendar selected="2023-01-20T00:00:00" orientation="vertical" wide week-numbers
+            <sbb-calendar value="2023-01-20T00:00:00" orientation="vertical" amount="2" week-numbers
               >${variant === 'default' ? nothing : createSlottedDays(2023, 1)}</sbb-calendar
             >
           `);

--- a/src/elements/calendar/calendar/calendar.spec.ts
+++ b/src/elements/calendar/calendar/calendar.spec.ts
@@ -9,6 +9,7 @@ import {
   elementInternalsSpy,
   fixture,
   sbbBreakpointLargeMinPx,
+  tabKey,
 } from '../../core/testing/private.ts';
 import { EventSpy, waitForLitRender } from '../../core/testing.ts';
 import { defaultDateAdapter } from '../../core.ts';
@@ -551,6 +552,36 @@ describe(`sbb-calendar`, () => {
           await waitForLitRender(element);
 
           expect(document.activeElement).to.be.equal(activeElement);
+        });
+
+        it('restores focus into year view after focusing out and back in', async () => {
+          const outsideButton = document.createElement('button');
+          element.parentElement!.append(outsideButton);
+
+          // Navigate to year view
+          const yearSelectionButton =
+            element.shadowRoot!.querySelector<HTMLElement>(yearButtonSelector)!;
+          yearSelectionButton.focus();
+          await sendKeys({ press: 'Enter' });
+          await waitForLitRender(element);
+
+          expect(element.shadowRoot!.querySelector('.sbb-calendar__year-view')).not.to.be.null;
+
+          // Focus out of calendar
+          await sendKeys({ press: tabKey });
+          await waitForLitRender(element);
+          expect(document.activeElement).to.be.equal(outsideButton);
+          expect(element).not.to.have.attribute('tabindex');
+
+          // Focus back into the calendar
+          await sendKeys({ press: `Shift+${tabKey}` });
+          await waitForLitRender(element);
+
+          // The focused element should now be a year cell inside the calendar
+          const focusedYear = element.shadowRoot!.querySelector<SbbCalendarYearElement>(
+            'sbb-calendar-year[tabindex="0"]',
+          );
+          expect(document.activeElement!.shadowRoot!.activeElement).to.be.equal(focusedYear);
         });
 
         it('does not create horizontal scrollbar when calendar is 100% width in overflow container', async () => {

--- a/src/elements/calendar/calendar/calendar.spec.ts
+++ b/src/elements/calendar/calendar/calendar.spec.ts
@@ -276,7 +276,7 @@ describe(`sbb-calendar`, () => {
           )!;
           expect(yearSelection).not.to.be.null;
           expect(yearSelection).dom.to.be.equal(`
-            <sbb-secondary-button aria-label="Choose date 2016 - 2039" class="sbb-calendar__control" icon-name="chevron-small-down-small" size="s" tabindex="0">
+            <sbb-secondary-button aria-label="Change to date selection" class="sbb-calendar__control" icon-name="chevron-small-down-small" size="s" tabindex="0">
             </sbb-secondary-button>
           `);
 
@@ -299,7 +299,7 @@ describe(`sbb-calendar`, () => {
           )!;
           expect(monthSelection).not.to.be.null;
           expect(monthSelection).dom.to.be.equal(`
-            <sbb-secondary-button aria-label="Choose date 2023" class="sbb-calendar__control" icon-name="chevron-small-down-small" size="s" tabindex="0">
+            <sbb-secondary-button aria-label="Change to date selection" class="sbb-calendar__control" icon-name="chevron-small-down-small" size="s" tabindex="0">
             </sbb-secondary-button>
           `);
 

--- a/src/elements/calendar/calendar/calendar.spec.ts
+++ b/src/elements/calendar/calendar/calendar.spec.ts
@@ -10,7 +10,7 @@ import {
   fixture,
   sbbBreakpointLargeMinPx,
 } from '../../core/testing/private.ts';
-import { EventSpy, waitForCondition, waitForLitRender } from '../../core/testing.ts';
+import { EventSpy, waitForLitRender } from '../../core/testing.ts';
 import { defaultDateAdapter } from '../../core.ts';
 import { SbbCalendarDayElement } from '../calendar-day/calendar-day.component.ts';
 import {
@@ -22,7 +22,6 @@ import type { SbbCalendarMonthElement } from '../calendar-month/calendar-month.c
 import type { SbbCalendarWeekdayElement } from '../calendar-weekday/calendar-weekday.component.ts';
 import type { SbbCalendarWeeknumberElement } from '../calendar-weeknumber/calendar-weeknumber.component.ts';
 import type { SbbCalendarYearElement } from '../calendar-year/calendar-year.component.ts';
-import type { SbbCalendarCellBaseElement } from '../common/calendar-cell-base-element.ts';
 
 import type { SbbDateSelectedEvent, SbbMonthChangeEvent } from './calendar.component.ts';
 import { SbbCalendarElement } from './calendar.component.ts';
@@ -60,26 +59,6 @@ describe(`sbb-calendar`, () => {
       );
     }
     return null;
-  };
-
-  const getWaitFromTransitionQuery = (
-    element: SbbCalendarElement,
-  ): SbbCalendarCellBaseElement[] => {
-    return element['_calendarView'] === 'day'
-      ? getDayCells(element)
-      : element['_calendarView'] === 'year'
-        ? Array.from(element.shadowRoot!.querySelectorAll('sbb-calendar-year'))
-        : Array.from(element.shadowRoot!.querySelectorAll('sbb-calendar-month'));
-  };
-
-  const waitForTransition = async (element: SbbCalendarElement): Promise<void> => {
-    // Wait for the transition to be over
-    await waitForCondition(() => !element.matches(':state(transition)'));
-
-    await waitForLitRender(element);
-
-    // Wait for the new table to be rendered completely
-    await waitForCondition(() => getWaitFromTransitionQuery(element).length > 0);
   };
 
   before(() => {
@@ -289,7 +268,7 @@ describe(`sbb-calendar`, () => {
 
           expect(yearSelectionButton).not.to.be.null;
           yearSelectionButton.click();
-          await waitForTransition(element);
+          await waitForLitRender(element);
 
           const yearSelection: HTMLElement = element.shadowRoot!.querySelector(
             returnFromYearViewSelector,
@@ -312,7 +291,7 @@ describe(`sbb-calendar`, () => {
           )!;
           expect(yearButton.value).to.be.equal('2023');
           yearButton.click();
-          await waitForTransition(element);
+          await waitForLitRender(element);
 
           const monthSelection: HTMLElement = element.shadowRoot!.querySelector(
             returnFromMonthViewSelector,
@@ -332,7 +311,7 @@ describe(`sbb-calendar`, () => {
           monthCells[0].click();
           await waitForLitRender(element);
 
-          await waitForTransition(element);
+          await waitForLitRender(element);
 
           const dayCells: SbbCalendarDayElement[] = getDayCells(element);
           expect(dayCells.length).to.be.equal(31);
@@ -345,7 +324,7 @@ describe(`sbb-calendar`, () => {
             element.shadowRoot!.querySelector(yearButtonSelector)!;
           expect(yearSelectionButton).not.to.be.null;
           yearSelectionButton.click();
-          await waitForTransition(element);
+          await waitForLitRender(element);
 
           const yearButtonArray: SbbCalendarYearElement[] = Array.from(
             element.shadowRoot!.querySelectorAll('sbb-calendar-year'),
@@ -353,7 +332,7 @@ describe(`sbb-calendar`, () => {
           const yearButton = yearButtonArray.find((e) => e.value === '2030')!;
           expect(yearButton).not.to.be.null;
           yearButton.click();
-          await waitForTransition(element);
+          await waitForLitRender(element);
 
           const monthCells: SbbCalendarMonthElement[] = Array.from(
             element.shadowRoot!.querySelectorAll('sbb-calendar-month'),
@@ -361,7 +340,7 @@ describe(`sbb-calendar`, () => {
           expect(monthCells.length).to.be.equal(12);
           monthCells[8].click();
           await waitForLitRender(element);
-          await waitForTransition(element);
+          await waitForLitRender(element);
 
           const dayCells = getDayCells(element);
           expect(dayCells.length).to.be.equal(30);
@@ -369,13 +348,13 @@ describe(`sbb-calendar`, () => {
 
           // Without selecting a day, change to the year view
           yearSelectionButton.click();
-          await waitForTransition(element);
+          await waitForLitRender(element);
           // Go back to day view again by clicking once more
           const monthSelection: HTMLElement = element.shadowRoot!.querySelector(
             returnFromYearViewSelector,
           )!;
           monthSelection.click();
-          await waitForTransition(element);
+          await waitForLitRender(element);
           // We expect to be in the month of the selected day (Dec 2023)
           const dayCells2 = getDayCells(element);
           expect(dayCells2.length).to.be.equal(31);
@@ -410,7 +389,7 @@ describe(`sbb-calendar`, () => {
             const yearSelectionButton =
               element.shadowRoot!.querySelector<HTMLElement>(yearButtonSelector)!;
             yearSelectionButton.click();
-            await waitForTransition(element);
+            await waitForLitRender(element);
 
             // Select same year
             const yearButtonArray: SbbCalendarYearElement[] = Array.from(
@@ -418,7 +397,7 @@ describe(`sbb-calendar`, () => {
             );
             const year2023Button = yearButtonArray.find((e) => e.value === '2023')!;
             year2023Button.click();
-            await waitForTransition(element);
+            await waitForLitRender(element);
 
             const monthSelection: HTMLElement = element.shadowRoot!.querySelector(
               returnFromMonthViewSelector,
@@ -434,7 +413,7 @@ describe(`sbb-calendar`, () => {
             );
 
             october2023Button.click();
-            await waitForTransition(element);
+            await waitForLitRender(element);
 
             const selectedDayButton = getDayCells(element).find((e) =>
               e.matches('sbb-calendar-day[slot="2023-10-15"]'),
@@ -458,7 +437,7 @@ describe(`sbb-calendar`, () => {
             const yearSelectionButton =
               element.shadowRoot!.querySelector<HTMLElement>(yearButtonSelector)!;
             yearSelectionButton.click();
-            await waitForTransition(element);
+            await waitForLitRender(element);
 
             // Select same year
             const yearButtonArray: SbbCalendarYearElement[] = Array.from(
@@ -468,7 +447,7 @@ describe(`sbb-calendar`, () => {
             expect(document.activeElement!.shadowRoot!.activeElement).to.be.equal(year2023Button);
 
             year2023Button.click();
-            await waitForTransition(element);
+            await waitForLitRender(element);
 
             // Check that we're in month selection view
             const monthSelection: HTMLElement = element.shadowRoot!.querySelector(
@@ -485,7 +464,7 @@ describe(`sbb-calendar`, () => {
             );
 
             october2023Button.click();
-            await waitForTransition(element);
+            await waitForLitRender(element);
 
             const selectedDayButton = getDayCells(element).find((e) =>
               e.matches('sbb-calendar-day[slot="2023-10-15"]'),
@@ -509,7 +488,7 @@ describe(`sbb-calendar`, () => {
             const yearSelectionButton =
               element.shadowRoot!.querySelector<HTMLElement>(yearButtonSelector)!;
             yearSelectionButton.click();
-            await waitForTransition(element);
+            await waitForLitRender(element);
 
             // Select a different year (2024, not the current year 2023)
             const yearButtonArray: SbbCalendarYearElement[] = Array.from(
@@ -517,7 +496,7 @@ describe(`sbb-calendar`, () => {
             );
             const yearButton = yearButtonArray.find((e) => e.value === '2024')!;
             yearButton.click();
-            await waitForTransition(element);
+            await waitForLitRender(element);
 
             // Check that we're in month selection view
             const monthSelection = element.shadowRoot!.querySelector<HTMLElement>(
@@ -534,7 +513,7 @@ describe(`sbb-calendar`, () => {
               january2024Button,
             );
             january2024Button.click();
-            await waitForTransition(element);
+            await waitForLitRender(element);
 
             const selectedDayButton = getDayCells(element).find((e) =>
               e.matches('sbb-calendar-day[slot="2024-01-01"]'),
@@ -554,7 +533,7 @@ describe(`sbb-calendar`, () => {
 
           // Trigger an update which triggers updated().
           element.amount = 2;
-          await waitForTransition(element);
+          await waitForLitRender(element);
 
           expect(document.activeElement).to.be.equal(document.body);
         });
@@ -569,7 +548,7 @@ describe(`sbb-calendar`, () => {
 
           // Trigger an update which triggers updated().
           element.amount = 2;
-          await waitForTransition(element);
+          await waitForLitRender(element);
 
           expect(document.activeElement).to.be.equal(activeElement);
         });
@@ -1047,7 +1026,7 @@ describe(`sbb-calendar`, () => {
               )!
               .click();
 
-            await waitForTransition(element);
+            await waitForLitRender(element);
 
             // Open month selection
             const yearButtonArray: SbbCalendarYearElement[] = Array.from(
@@ -1056,7 +1035,7 @@ describe(`sbb-calendar`, () => {
             const year2039Button = yearButtonArray.find((e) => e.value === '2039')!;
             year2039Button!.click();
 
-            await waitForTransition(element);
+            await waitForLitRender(element);
 
             const monthButtonArray: SbbCalendarMonthElement[] = Array.from(
               element.shadowRoot!.querySelectorAll('sbb-calendar-month'),
@@ -1064,7 +1043,7 @@ describe(`sbb-calendar`, () => {
             const december2039Button = monthButtonArray.find((e) => e.value === '2039-12')!;
             december2039Button!.click();
 
-            await waitForTransition(element);
+            await waitForLitRender(element);
 
             // Day view should be opened with December 2039
             expect(
@@ -1099,7 +1078,7 @@ describe(`sbb-calendar`, () => {
               )!
               .click();
 
-            await waitForTransition(element);
+            await waitForLitRender(element);
 
             // Open month selection
             const yearButtonArray: SbbCalendarYearElement[] = Array.from(
@@ -1108,7 +1087,7 @@ describe(`sbb-calendar`, () => {
             const year2023Button = yearButtonArray.find((e) => e.value === '2023')!;
             year2023Button!.click();
 
-            await waitForTransition(element);
+            await waitForLitRender(element);
 
             const monthButtonArray: SbbCalendarMonthElement[] = Array.from(
               element.shadowRoot!.querySelectorAll('sbb-calendar-month'),
@@ -1125,7 +1104,7 @@ describe(`sbb-calendar`, () => {
               )!;
 
               nextButton.click();
-              await waitForTransition(element);
+              await waitForLitRender(element);
             }
 
             const nextButton = element.shadowRoot!.querySelector<SbbSecondaryButtonElement>(
@@ -1325,7 +1304,7 @@ describe(`sbb-calendar`, () => {
 
           expect(yearSelectionButton).not.to.be.null;
           yearSelectionButton.click();
-          await waitForTransition(element);
+          await waitForLitRender(element);
 
           const years: SbbCalendarYearElement[] = Array.from(
             element.shadowRoot!.querySelectorAll('sbb-calendar-year'),

--- a/src/elements/calendar/calendar/calendar.spec.ts
+++ b/src/elements/calendar/calendar/calendar.spec.ts
@@ -391,7 +391,7 @@ describe(`sbb-calendar`, () => {
             today = null;
           });
 
-          it.only('focuses current day', async () => {
+          it('focuses current day', async () => {
             element = await fixture(html`
               <sbb-calendar>
                 ${variant === 'default'

--- a/src/elements/calendar/calendar/calendar.spec.ts
+++ b/src/elements/calendar/calendar/calendar.spec.ts
@@ -1,6 +1,6 @@
 import { assert, expect } from '@open-wc/testing';
 import { sendKeys, setViewport } from '@web/test-runner-commands';
-import { nothing } from 'lit';
+import { nothing, type TemplateResult } from 'lit';
 import { html } from 'lit/static-html.js';
 import { type SinonStub, stub } from 'sinon';
 
@@ -30,6 +30,11 @@ import '../../button.ts';
 import '../../calendar.ts';
 
 const toIso8601 = (date: Date): string => defaultDateAdapter.toIso8601(date);
+const yearButtonSelector = '.sbb-calendar__day-view [icon-name="chevron-small-up-small"]';
+const returnFromMonthViewSelector =
+  '.sbb-calendar__month-view [icon-name="chevron-small-down-small"]';
+const returnFromYearViewSelector =
+  '.sbb-calendar__year-view [icon-name="chevron-small-down-small"]';
 
 describe(`sbb-calendar`, () => {
   const elementInternals = elementInternalsSpy();
@@ -77,15 +82,6 @@ describe(`sbb-calendar`, () => {
     await waitForCondition(() => getWaitFromTransitionQuery(element).length > 0);
   };
 
-  const goToNextView = async (element: SbbCalendarElement): Promise<void> => {
-    const nextButton = element.shadowRoot!.querySelector<SbbSecondaryButtonElement>(
-      'sbb-secondary-button#sbb-calendar__controls-next',
-    )!;
-
-    nextButton.click();
-    await waitForTransition(element);
-  };
-
   before(() => {
     todayStub = stub(defaultDateAdapter, 'today').callsFake(
       () => today ?? new Date(2023, 9, 10, 0, 0, 0, 0),
@@ -114,7 +110,7 @@ describe(`sbb-calendar`, () => {
           switch (variant) {
             case 'enhanced': {
               template = html` <sbb-calendar
-                selected="2023-01-15"
+                value="2023-01-15"
                 @monthchange=${(e: SbbMonthChangeEvent) => monthChangeHandler(e)}
               >
                 ${createSlottedDays(2023, 1, true)}
@@ -122,7 +118,7 @@ describe(`sbb-calendar`, () => {
               break;
             }
             case 'mixed': {
-              template = html` <sbb-calendar selected="2023-01-15">
+              template = html` <sbb-calendar value="2023-01-15">
                 <sbb-calendar-day slot=${toIso8601(new Date('2023-01-05'))}>
                   ${createPrice(true)}
                 </sbb-calendar-day>
@@ -130,7 +126,7 @@ describe(`sbb-calendar`, () => {
               break;
             }
             default: {
-              template = html`<sbb-calendar selected="2023-01-15"></sbb-calendar>`;
+              template = html`<sbb-calendar value="2023-01-15"></sbb-calendar>`;
               break;
             }
           }
@@ -154,7 +150,7 @@ describe(`sbb-calendar`, () => {
           expect(await day.getAttribute('slot')).to.be.equal('2023-01-01');
 
           const nextMonthButton: HTMLElement = element.shadowRoot!.querySelector(
-            '#sbb-calendar__controls-next',
+            'sbb-secondary-button[icon-name="chevron-small-right-small"]',
           )!;
           nextMonthButton.click();
           await waitForLitRender(element);
@@ -169,7 +165,7 @@ describe(`sbb-calendar`, () => {
           expect(await day.getAttribute('slot')).to.be.equal('2023-01-01');
 
           const prevMonthButton: HTMLElement = element.shadowRoot!.querySelector(
-            '#sbb-calendar__controls-previous',
+            'sbb-secondary-button[icon-name="chevron-small-left-small"]',
           )!;
           prevMonthButton.click();
           await waitForLitRender(element);
@@ -187,7 +183,7 @@ describe(`sbb-calendar`, () => {
           expect(await day.getAttribute('slot')).to.be.equal('2023-01-01');
 
           const nextMonthButton: HTMLElement = element.shadowRoot!.querySelector(
-            '#sbb-calendar__controls-next',
+            'sbb-secondary-button[icon-name="chevron-small-right-small"]',
           )!;
           expect(nextMonthButton).to.have.attribute('disabled');
           nextMonthButton.click();
@@ -206,7 +202,7 @@ describe(`sbb-calendar`, () => {
           expect(await day.getAttribute('slot')).to.be.equal('2023-01-01');
 
           const nextMonthButton = element.shadowRoot!.querySelector(
-            '#sbb-calendar__controls-previous',
+            'sbb-secondary-button[icon-name="chevron-small-left-small"]',
           ) as HTMLElement;
           expect(nextMonthButton).to.have.attribute('disabled');
           nextMonthButton.click();
@@ -288,23 +284,20 @@ describe(`sbb-calendar`, () => {
         });
 
         it('changes to year and month selection views', async () => {
-          const yearSelectionButton: HTMLElement = element.shadowRoot!.querySelector(
-            '.sbb-calendar__date-selection',
-          )!;
+          const yearSelectionButton: HTMLElement =
+            element.shadowRoot!.querySelector(yearButtonSelector)!;
 
           expect(yearSelectionButton).not.to.be.null;
           yearSelectionButton.click();
           await waitForTransition(element);
 
           const yearSelection: HTMLElement = element.shadowRoot!.querySelector(
-            '#sbb-calendar__year-selection',
+            returnFromYearViewSelector,
           )!;
           expect(yearSelection).not.to.be.null;
           expect(yearSelection).dom.to.be.equal(`
-            <button aria-label="Choose date 2016 - 2039" class="sbb-calendar__controls-change-date" id="sbb-calendar__year-selection" type="button">
-              2016 - 2039
-              <sbb-icon name="chevron-small-up-small"></sbb-icon>
-            </button>
+            <sbb-secondary-button aria-label="Choose date 2016 - 2039" class="sbb-calendar__control" icon-name="chevron-small-down-small" size="s" tabindex="0">
+            </sbb-secondary-button>
           `);
 
           const yearCells: SbbCalendarYearElement[] = Array.from(
@@ -314,21 +307,20 @@ describe(`sbb-calendar`, () => {
           expect(yearCells[0].value).to.be.equal('2016');
           expect(yearCells[yearCells.length - 1].value).to.be.equal('2039');
 
-          const yearButton =
-            element.shadowRoot!.querySelector<SbbCalendarYearElement>(':state(selected)')!;
+          const yearButton = element.shadowRoot!.querySelector<SbbCalendarYearElement>(
+            '.sbb-calendar__year-view :state(selected)',
+          )!;
           expect(yearButton.value).to.be.equal('2023');
           yearButton.click();
           await waitForTransition(element);
 
           const monthSelection: HTMLElement = element.shadowRoot!.querySelector(
-            '#sbb-calendar__month-selection',
+            returnFromMonthViewSelector,
           )!;
           expect(monthSelection).not.to.be.null;
           expect(monthSelection).dom.to.be.equal(`
-            <button aria-label="Choose date 2023" class="sbb-calendar__controls-change-date" id="sbb-calendar__month-selection" type="button">
-              2023
-              <sbb-icon name="chevron-small-up-small"></sbb-icon>
-            </button>
+            <sbb-secondary-button aria-label="Choose date 2023" class="sbb-calendar__control" icon-name="chevron-small-down-small" size="s" tabindex="0">
+            </sbb-secondary-button>
           `);
 
           const monthCells: SbbCalendarMonthElement[] = Array.from(
@@ -349,9 +341,8 @@ describe(`sbb-calendar`, () => {
 
         it('reset view if day is not selected when year/month are changed', async () => {
           // We move from Dec 2023 to Sep 2030
-          const yearSelectionButton: HTMLElement = element.shadowRoot!.querySelector(
-            '.sbb-calendar__date-selection',
-          )!;
+          const yearSelectionButton: HTMLElement =
+            element.shadowRoot!.querySelector(yearButtonSelector)!;
           expect(yearSelectionButton).not.to.be.null;
           yearSelectionButton.click();
           await waitForTransition(element);
@@ -381,7 +372,7 @@ describe(`sbb-calendar`, () => {
           await waitForTransition(element);
           // Go back to day view again by clicking once more
           const monthSelection: HTMLElement = element.shadowRoot!.querySelector(
-            '#sbb-calendar__year-selection',
+            returnFromYearViewSelector,
           )!;
           monthSelection.click();
           await waitForTransition(element);
@@ -400,7 +391,7 @@ describe(`sbb-calendar`, () => {
             today = null;
           });
 
-          it('focuses current day', async () => {
+          it.only('focuses current day', async () => {
             element = await fixture(html`
               <sbb-calendar>
                 ${variant === 'default'
@@ -416,9 +407,8 @@ describe(`sbb-calendar`, () => {
             `);
 
             // Open year selection
-            const yearSelectionButton = element.shadowRoot!.querySelector<HTMLElement>(
-              '.sbb-calendar__date-selection',
-            )!;
+            const yearSelectionButton =
+              element.shadowRoot!.querySelector<HTMLElement>(yearButtonSelector)!;
             yearSelectionButton.click();
             await waitForTransition(element);
 
@@ -431,7 +421,7 @@ describe(`sbb-calendar`, () => {
             await waitForTransition(element);
 
             const monthSelection: HTMLElement = element.shadowRoot!.querySelector(
-              '#sbb-calendar__month-selection',
+              returnFromMonthViewSelector,
             )!;
             expect(monthSelection).not.to.be.null;
 
@@ -461,13 +451,12 @@ describe(`sbb-calendar`, () => {
             // Flaky on Firefox
             this.retries(3);
 
-            element.selected = new Date('2023-10-15');
+            element.value = new Date('2023-10-15');
             await waitForLitRender(element);
 
             // Open year selection
-            const yearSelectionButton = element.shadowRoot!.querySelector<HTMLElement>(
-              '.sbb-calendar__date-selection',
-            )!;
+            const yearSelectionButton =
+              element.shadowRoot!.querySelector<HTMLElement>(yearButtonSelector)!;
             yearSelectionButton.click();
             await waitForTransition(element);
 
@@ -483,7 +472,7 @@ describe(`sbb-calendar`, () => {
 
             // Check that we're in month selection view
             const monthSelection: HTMLElement = element.shadowRoot!.querySelector(
-              '#sbb-calendar__month-selection',
+              returnFromMonthViewSelector,
             )!;
             expect(monthSelection).not.to.be.null;
 
@@ -513,13 +502,12 @@ describe(`sbb-calendar`, () => {
             // Flaky on Firefox
             this.retries(3);
 
-            element.selected = new Date('2023-10-15');
+            element.value = new Date('2023-10-15');
             await waitForLitRender(element);
 
             // Open year selection
-            const yearSelectionButton = element.shadowRoot!.querySelector<HTMLElement>(
-              '.sbb-calendar__date-selection',
-            )!;
+            const yearSelectionButton =
+              element.shadowRoot!.querySelector<HTMLElement>(yearButtonSelector)!;
             yearSelectionButton.click();
             await waitForTransition(element);
 
@@ -533,7 +521,7 @@ describe(`sbb-calendar`, () => {
 
             // Check that we're in month selection view
             const monthSelection = element.shadowRoot!.querySelector<HTMLElement>(
-              '#sbb-calendar__month-selection',
+              returnFromMonthViewSelector,
             )!;
             expect(monthSelection).not.to.be.null;
 
@@ -565,7 +553,7 @@ describe(`sbb-calendar`, () => {
           expect(document.activeElement).to.be.equal(document.body);
 
           // Trigger an update which triggers updated().
-          element.wide = true;
+          element.amount = 2;
           await waitForTransition(element);
 
           expect(document.activeElement).to.be.equal(document.body);
@@ -580,7 +568,7 @@ describe(`sbb-calendar`, () => {
           expect(document.activeElement).to.be.equal(activeElement);
 
           // Trigger an update which triggers updated().
-          element.wide = true;
+          element.amount = 2;
           await waitForTransition(element);
 
           expect(document.activeElement).to.be.equal(activeElement);
@@ -609,43 +597,47 @@ describe(`sbb-calendar`, () => {
           element.view = 'year';
           await waitForLitRender(element);
 
-          expect(element.shadowRoot!.querySelector('.sbb-calendar__table-year-view')).not.to.be
-            .null;
+          expect(element.shadowRoot!.querySelector('.sbb-calendar__year-view')).not.to.be.null;
         });
 
         it('opens month view', async () => {
           element.view = 'month';
           await waitForLitRender(element);
 
-          expect(element.shadowRoot!.querySelector('.sbb-calendar__table-month-view')).not.to.be
-            .null;
+          expect(element.shadowRoot!.querySelector('.sbb-calendar__month-view')).not.to.be.null;
           expect(
             element
-              .shadowRoot!.querySelector('#sbb-calendar__month-selection')!
+              .shadowRoot!.querySelector(
+                '.sbb-calendar__month-view .sbb-calendar__table-header span',
+              )!
               .textContent!.trim(),
           ).to.be.equal('2023');
         });
 
         it('opens month view with selected date', async () => {
-          element.selected = new Date('2017-01-22');
+          element.value = new Date('2017-01-22');
           element.view = 'month';
           await waitForLitRender(element);
 
           expect(
             element
-              .shadowRoot!.querySelector('#sbb-calendar__month-selection')!
+              .shadowRoot!.querySelector(
+                '.sbb-calendar__month-view .sbb-calendar__table-header span',
+              )!
               .textContent!.trim(),
           ).to.be.equal('2017');
         });
 
         it('opens month view with current date', async () => {
-          element.selected = null;
+          element.value = null;
           element.view = 'month';
           await waitForLitRender(element);
 
           expect(
             element
-              .shadowRoot!.querySelector('#sbb-calendar__month-selection')!
+              .shadowRoot!.querySelector(
+                '.sbb-calendar__month-view .sbb-calendar__table-header span',
+              )!
               .textContent!.trim(),
           ).to.be.equal('2023');
         });
@@ -653,14 +645,14 @@ describe(`sbb-calendar`, () => {
         describe('shift click', () => {
           it('should select multiple dates with shift click', async () => {
             element.multiple = true;
-            element.selected = [];
+            element.value = [];
 
             const days = getDayCells(element);
             const initialDayButton = days.find((e) => e.slot === '2023-01-10');
 
             initialDayButton!.click();
-            expect(element.selected.length).to.be.equal(1);
-            expect(toIso8601(element.selected[0])).to.be.equal('2023-01-10');
+            expect(element.value.length).to.be.equal(1);
+            expect(toIso8601(element.value[0])).to.be.equal('2023-01-10');
 
             const lastDayButton = days.find((e) => e.slot === '2023-01-20');
             const shiftClickEvent = new MouseEvent('click', {
@@ -670,23 +662,21 @@ describe(`sbb-calendar`, () => {
             });
             lastDayButton!.dispatchEvent(shiftClickEvent);
 
-            expect(element.selected.length).to.be.equal(11);
-            expect(toIso8601(element.selected[0])).to.be.equal('2023-01-10');
-            expect(toIso8601(element.selected[element.selected.length - 1])).to.be.equal(
-              '2023-01-20',
-            );
+            expect(element.value.length).to.be.equal(11);
+            expect(toIso8601(element.value[0])).to.be.equal('2023-01-10');
+            expect(toIso8601(element.value[element.value.length - 1])).to.be.equal('2023-01-20');
           });
 
           it('should select multiple dates with shift click in the past', async () => {
             element.multiple = true;
-            element.selected = [];
+            element.value = [];
 
             const days = getDayCells(element);
             const initialDayButton = days.find((e) => e.slot === '2023-01-20');
 
             initialDayButton!.click();
-            expect(element.selected.length).to.be.equal(1);
-            expect(toIso8601(element.selected[0])).to.be.equal('2023-01-20');
+            expect(element.value.length).to.be.equal(1);
+            expect(toIso8601(element.value[0])).to.be.equal('2023-01-20');
 
             const lastDayButton = days.find((e) => e.slot === '2023-01-10');
             const shiftClickEvent = new MouseEvent('click', {
@@ -696,11 +686,9 @@ describe(`sbb-calendar`, () => {
             });
             lastDayButton!.dispatchEvent(shiftClickEvent);
 
-            expect(element.selected.length).to.be.equal(11);
-            expect(toIso8601(element.selected[0])).to.be.equal('2023-01-10');
-            expect(toIso8601(element.selected[element.selected.length - 1])).to.be.equal(
-              '2023-01-20',
-            );
+            expect(element.value.length).to.be.equal(11);
+            expect(toIso8601(element.value[0])).to.be.equal('2023-01-10');
+            expect(toIso8601(element.value[element.value.length - 1])).to.be.equal('2023-01-20');
           });
         });
 
@@ -712,7 +700,7 @@ describe(`sbb-calendar`, () => {
 
           it('it should focus on the first of the month if selected date is not in the view', async () => {
             const nextMonthButton: HTMLElement = element.shadowRoot!.querySelector(
-              '#sbb-calendar__controls-next',
+              'sbb-secondary-button[icon-name="chevron-small-right-small"]',
             )!;
             nextMonthButton.click();
             await waitForLitRender(element);
@@ -845,7 +833,7 @@ describe(`sbb-calendar`, () => {
           switch (variant) {
             case 'enhanced': {
               template = html` <sbb-calendar
-                selected="2023-01-15"
+                value="2023-01-15"
                 orientation="vertical"
                 @monthchange=${(e: SbbMonthChangeEvent) => monthChangeHandler(e)}
               >
@@ -854,7 +842,7 @@ describe(`sbb-calendar`, () => {
               break;
             }
             case 'mixed': {
-              template = html` <sbb-calendar selected="2023-01-15" orientation="vertical">
+              template = html` <sbb-calendar value="2023-01-15" orientation="vertical">
                 <sbb-calendar-day slot=${toIso8601(new Date('2023-01-05'))}>
                   ${createPrice(true)}
                 </sbb-calendar-day>
@@ -863,7 +851,7 @@ describe(`sbb-calendar`, () => {
             }
             default: {
               template = html`<sbb-calendar
-                selected="2023-01-15"
+                value="2023-01-15"
                 orientation="vertical"
               ></sbb-calendar>`;
               break;
@@ -885,7 +873,7 @@ describe(`sbb-calendar`, () => {
 
           it('it should focus on the first of the month if selected date is not in the view', async () => {
             const nextMonthButton: HTMLElement = element.shadowRoot!.querySelector(
-              '#sbb-calendar__controls-next',
+              'sbb-secondary-button[icon-name="chevron-small-right-small"]',
             )!;
             nextMonthButton.click();
             await waitForLitRender(element);
@@ -963,7 +951,7 @@ describe(`sbb-calendar`, () => {
 
       it('renders with min and max', async () => {
         element = await fixture(html`
-          <sbb-calendar selected="2023-01-20" min="2023-01-09" max="2023-01-29">
+          <sbb-calendar value="2023-01-20" min="2023-01-09" max="2023-01-29">
             ${variant === 'default'
               ? nothing
               : variant === 'enhanced'
@@ -977,11 +965,11 @@ describe(`sbb-calendar`, () => {
         `);
 
         const buttonPrevDay = element.shadowRoot!.querySelector<SbbSecondaryButtonElement>(
-          'sbb-secondary-button#sbb-calendar__controls-previous',
+          'sbb-secondary-button[icon-name="chevron-small-left-small"]',
         );
         expect(buttonPrevDay).to.have.attribute('disabled');
         const buttonNextDay = element.shadowRoot!.querySelector(
-          'sbb-secondary-button#sbb-calendar__controls-next',
+          'sbb-secondary-button[icon-name="chevron-small-right-small"]',
         );
         expect(buttonNextDay).to.have.attribute('disabled');
 
@@ -1021,12 +1009,12 @@ describe(`sbb-calendar`, () => {
             // Flaky on WebKit
             this.retries(3);
 
-            let template;
+            let template: TemplateResult;
             switch (variant) {
               case 'enhanced': {
                 template = html`<sbb-calendar
-                  selected="2023-01-15"
-                  wide
+                  value="2023-01-15"
+                  amount="2"
                   @monthchange=${(e: SbbMonthChangeEvent) => monthChangeHandler(e)}
                 >
                   ${createSlottedDays(2023, 1, true)} ${createSlottedDays(2023, 2, true)}
@@ -1034,7 +1022,7 @@ describe(`sbb-calendar`, () => {
                 break;
               }
               case 'mixed': {
-                template = html`<sbb-calendar selected="2023-01-15" wide>
+                template = html`<sbb-calendar value="2023-01-15" amount="2">
                   <sbb-calendar-day slot=${toIso8601(new Date('2023-01-22'))}>
                     ${createPrice(true)}
                   </sbb-calendar-day>
@@ -1045,7 +1033,7 @@ describe(`sbb-calendar`, () => {
                 break;
               }
               default: {
-                template = html`<sbb-calendar selected="2023-01-15" wide></sbb-calendar>`;
+                template = html`<sbb-calendar value="2023-01-15" amount="2"></sbb-calendar>`;
                 break;
               }
             }
@@ -1054,7 +1042,9 @@ describe(`sbb-calendar`, () => {
 
             // Open year selection
             element
-              .shadowRoot!.querySelector<HTMLButtonElement>('button.sbb-calendar__date-selection')!
+              .shadowRoot!.querySelector<HTMLButtonElement>(
+                '.sbb-calendar__control[icon-name="chevron-small-up-small"]',
+              )!
               .click();
 
             await waitForTransition(element);
@@ -1063,32 +1053,30 @@ describe(`sbb-calendar`, () => {
             const yearButtonArray: SbbCalendarYearElement[] = Array.from(
               element.shadowRoot!.querySelectorAll('sbb-calendar-year'),
             );
-            const year2063Button = yearButtonArray.find((e) => e.value === '2063')!;
-            year2063Button!.click();
+            const year2039Button = yearButtonArray.find((e) => e.value === '2039')!;
+            year2039Button!.click();
 
             await waitForTransition(element);
 
             const monthButtonArray: SbbCalendarMonthElement[] = Array.from(
               element.shadowRoot!.querySelectorAll('sbb-calendar-month'),
             );
-            const december2063Button = monthButtonArray.find((e) => e.value === '2063-12')!;
-            december2063Button!.click();
+            const december2039Button = monthButtonArray.find((e) => e.value === '2039-12')!;
+            december2039Button!.click();
 
             await waitForTransition(element);
 
-            // Day view should be opened with December 2062
+            // Day view should be opened with December 2039
             expect(
               element
-                .shadowRoot!.querySelector<HTMLButtonElement>(
-                  'button.sbb-calendar__date-selection',
-                )!
-                .innerText.trim(),
-            ).to.be.equal('December 2063');
+                .shadowRoot!.querySelector<HTMLButtonElement>('.sbb-calendar__table-header span')!
+                .textContent.trim(),
+            ).to.be.equal('December 2039');
           });
 
           it('renders with min and max', async () => {
             element = await fixture(html`
-              <sbb-calendar selected="2024-11-20" min="2023-11-04" max="2026-12-31" wide>
+              <sbb-calendar value="2024-11-20" min="2023-11-04" max="2026-12-31" amount="2">
                 ${variant === 'default'
                   ? nothing
                   : variant === 'enhanced'
@@ -1106,7 +1094,9 @@ describe(`sbb-calendar`, () => {
 
             // Open year selection
             element
-              .shadowRoot!.querySelector<HTMLButtonElement>('button.sbb-calendar__date-selection')!
+              .shadowRoot!.querySelector<HTMLButtonElement>(
+                '.sbb-calendar__control[icon-name="chevron-small-up-small"]',
+              )!
               .click();
 
             await waitForTransition(element);
@@ -1124,32 +1114,34 @@ describe(`sbb-calendar`, () => {
               element.shadowRoot!.querySelectorAll('sbb-calendar-month'),
             );
 
-            // Check if January 2024 is clickable (first possible)
-            const january2024Button = monthButtonArray.find((e) => e.value === '2024-01')!;
-            expect(january2024Button).not.to.have.attribute('disabled');
-
             // Check if November 2023 is clickable
             const november2023Button = monthButtonArray.find((e) => e.value === '2023-11')!;
             expect(november2023Button).not.to.have.attribute('disabled');
 
             // Navigate to max page
-            await goToNextView(element);
-            await goToNextView(element);
+            for (let i = 0; i < 2; i++) {
+              const nextButton = element.shadowRoot!.querySelector<SbbSecondaryButtonElement>(
+                '.sbb-calendar__month-view sbb-secondary-button[icon-name="chevron-small-right-small"]',
+              )!;
+
+              nextButton.click();
+              await waitForTransition(element);
+            }
 
             const nextButton = element.shadowRoot!.querySelector<SbbSecondaryButtonElement>(
-              'sbb-secondary-button#sbb-calendar__controls-next',
+              '.sbb-calendar__month-view sbb-secondary-button[icon-name="chevron-small-right-small"]',
             )!;
             expect(nextButton).to.have.attribute('disabled');
 
-            // Check if December 2026 is clickable (last possible)
-            const december2026Button = monthButtonArray.find((e) => e.value === '2026-12')!;
-            expect(december2026Button).not.to.have.attribute('disabled');
+            // Check if December 2025 is clickable (last possible)
+            const december2025Button = monthButtonArray.find((e) => e.value === '2025-12')!;
+            expect(december2025Button).not.to.have.attribute('disabled');
           });
 
           describe('keyboard navigation', () => {
             beforeEach(async () => {
               element = await fixture(html`
-                <sbb-calendar selected="2025-01-31" wide>
+                <sbb-calendar value="2025-01-31" amount="2">
                   ${variant === 'default'
                     ? nothing
                     : variant === 'enhanced'
@@ -1235,7 +1227,7 @@ describe(`sbb-calendar`, () => {
         describe('vertical', () => {
           beforeEach(async () => {
             element = await fixture(html`
-              <sbb-calendar selected="2025-01-29" orientation="vertical" wide>
+              <sbb-calendar value="2025-01-29" orientation="vertical" amount="2">
                 ${variant === 'default'
                   ? nothing
                   : variant === 'enhanced'
@@ -1323,14 +1315,13 @@ describe(`sbb-calendar`, () => {
       describe('keyboard navigation for year view', () => {
         beforeEach(async () => {
           element = await fixture(
-            html`<sbb-calendar selected="2023-01-15"
+            html`<sbb-calendar value="2023-01-15"
               >${variant === 'enhanced' ? createSlottedDays(2023, 1, true) : nothing}</sbb-calendar
             >`,
           );
 
-          const yearSelectionButton: HTMLElement = element.shadowRoot!.querySelector(
-            '.sbb-calendar__date-selection',
-          )!;
+          const yearSelectionButton: HTMLElement =
+            element.shadowRoot!.querySelector(yearButtonSelector)!;
 
           expect(yearSelectionButton).not.to.be.null;
           yearSelectionButton.click();
@@ -1353,7 +1344,7 @@ describe(`sbb-calendar`, () => {
 
         it('it should focus on the first year if selected year is not in the view', async () => {
           const nextYearButton: HTMLElement = element.shadowRoot!.querySelector(
-            '#sbb-calendar__controls-next',
+            '.sbb-calendar__year-view sbb-secondary-button[icon-name="chevron-small-right-small"]',
           )!;
           nextYearButton.click();
           await waitForLitRender(element);
@@ -1446,7 +1437,7 @@ describe(`sbb-calendar`, () => {
         // selected date is 2025-01-22, Wednesday
         beforeEach(async () => {
           element = await fixture(html`
-            <sbb-calendar selected="2025-01-22">
+            <sbb-calendar value="2025-01-22">
               ${variant === 'default'
                 ? nothing
                 : variant === 'enhanced'
@@ -1481,7 +1472,7 @@ describe(`sbb-calendar`, () => {
           beforeEach(async () => {
             await setViewport({ width: sbbBreakpointLargeMinPx, height: 1000 });
             element = await fixture(html`
-              <sbb-calendar selected="2025-01-22" wide orientation="horizontal">
+              <sbb-calendar value="2025-01-22" amount="2" orientation="horizontal">
                 ${variant === 'default'
                   ? nothing
                   : variant === 'enhanced'
@@ -1571,7 +1562,7 @@ describe(`sbb-calendar`, () => {
           beforeEach(async () => {
             await setViewport({ width: sbbBreakpointLargeMinPx, height: 1000 });
             element = await fixture(html`
-              <sbb-calendar selected="2025-01-22" wide orientation="vertical">
+              <sbb-calendar value="2025-01-22" amount="2" orientation="vertical">
                 ${variant === 'default'
                   ? nothing
                   : variant === 'enhanced'
@@ -1664,7 +1655,7 @@ describe(`sbb-calendar`, () => {
         describe('horizontal', () => {
           it('renders', async () => {
             const calendar: SbbCalendarElement = await fixture(html`
-              <sbb-calendar selected="2025-04-08T00:00:00" week-numbers>
+              <sbb-calendar value="2025-04-08T00:00:00" week-numbers>
                 ${variant === 'default'
                   ? nothing
                   : variant === 'enhanced'
@@ -1693,7 +1684,7 @@ describe(`sbb-calendar`, () => {
 
           it('renders multiple', async () => {
             const calendar: SbbCalendarElement = await fixture(html`
-              <sbb-calendar selected="2025-04-08T00:00:00" week-numbers multiple>
+              <sbb-calendar value="2025-04-08T00:00:00" week-numbers multiple>
                 ${variant === 'default'
                   ? nothing
                   : variant === 'enhanced'
@@ -1806,7 +1797,7 @@ describe(`sbb-calendar`, () => {
           it('renders multiple wide', async () => {
             await setViewport({ width: sbbBreakpointLargeMinPx, height: 1000 });
             const calendar: SbbCalendarElement = await fixture(html`
-              <sbb-calendar selected="2025-04-08T00:00:00" wide week-numbers multiple>
+              <sbb-calendar value="2025-04-08T00:00:00" amount="2" week-numbers multiple>
                 ${variant === 'default'
                   ? nothing
                   : variant === 'enhanced'
@@ -1828,52 +1819,41 @@ describe(`sbb-calendar`, () => {
             const cells = Array.from(rows, (e) => e.querySelector('td')!);
             // In wide mode, we have two months displayed, so we have to consider the number of weeks in April and May
             expect(cells.length).to.be.equal(10);
-            expect(
-              cells[0].querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!
-                .value,
-            ).to.be.equal('14');
-            expect(
-              cells[1].querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!
-                .value,
-            ).to.be.equal('15');
-            expect(
-              cells[4].querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!
-                .value,
-            ).to.be.equal('18');
-            expect(
-              cells[5].querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!
-                .value,
-            ).to.be.equal('18');
-            expect(
-              cells[9].querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!
-                .value,
-            ).to.be.equal('22');
+            const readValue = (cell: HTMLElement): string | null =>
+              cell.querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!.value;
 
-            // Clicking on the last week button must select all the days of the week, including the ones in the next month
+            expect(readValue(cells[0])).to.be.equal('14');
+            expect(readValue(cells[1])).to.be.equal('15');
+            expect(readValue(cells[4])).to.be.equal('18');
+            expect(readValue(cells[5])).to.be.equal('18');
+            expect(readValue(cells[9])).to.be.equal('22');
+
+            // Clicking on the last week button must select all the days of the week in the current month
             const lastButtonFirstMonth =
               cells[4].querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!;
             lastButtonFirstMonth.click();
             await selectedSpy.calledOnce();
             let selectedDates = (selectedSpy.lastEvent as SbbDateSelectedEvent<Date>)
               .dateSelected as Date[];
-            expect(selectedDates.length).to.be.equal(8);
+            expect(selectedDates.length).to.be.equal(4);
             expect(toIso8601(selectedDates[0])).to.be.equal('2025-04-08');
             expect(toIso8601(selectedDates[1])).to.be.equal('2025-04-28');
             expect(toIso8601(selectedDates[2])).to.be.equal('2025-04-29');
-            expect(toIso8601(selectedDates[6])).to.be.equal('2025-05-03');
-            expect(toIso8601(selectedDates[7])).to.be.equal('2025-05-04');
+            expect(toIso8601(selectedDates[3])).to.be.equal('2025-04-30');
 
-            /**
-             * Clicking on the first week button in the next month should not change the selection,  since the dates are the same as before.
-             */
+            // Clicking on the first week button in the next month should append the remaining dates in the week.
             const firstButtonSecondMonth =
               cells[5].querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!;
             firstButtonSecondMonth.click();
             expect(selectedSpy.calledTimes(2));
             selectedDates = (selectedSpy.lastEvent as SbbDateSelectedEvent<Date>)
               .dateSelected as Date[];
-            expect(selectedDates.length).to.be.equal(1);
+            expect(selectedDates.length).to.be.equal(8);
             expect(toIso8601(selectedDates[0])).to.be.equal('2025-04-08');
+            expect(toIso8601(selectedDates[4])).to.be.equal('2025-05-01');
+            expect(toIso8601(selectedDates[5])).to.be.equal('2025-05-02');
+            expect(toIso8601(selectedDates[6])).to.be.equal('2025-05-03');
+            expect(toIso8601(selectedDates[7])).to.be.equal('2025-05-04');
 
             // Clicks on the first button of the first month does not select dates in the previous (not rendered) one
             const firstButton =
@@ -1882,33 +1862,31 @@ describe(`sbb-calendar`, () => {
             await selectedSpy.calledTimes(3);
             selectedDates = (selectedSpy.lastEvent as SbbDateSelectedEvent<Date>)
               .dateSelected as Date[];
-            expect(selectedDates.length).to.be.equal(7);
+            expect(selectedDates.length).to.be.equal(14);
             expect(toIso8601(selectedDates[0])).to.be.equal('2025-04-01');
             expect(toIso8601(selectedDates[1])).to.be.equal('2025-04-02');
             expect(toIso8601(selectedDates[5])).to.be.equal('2025-04-06');
             expect(toIso8601(selectedDates[6])).to.be.equal('2025-04-08');
 
-            // Clicking again on the first button of the second month will select dates in the last week of the previous month
+            // Clicking again on the first button of the second month will deselect dates in the first week of the second month
             firstButtonSecondMonth.click();
             await selectedSpy.calledTimes(4);
             selectedDates = (selectedSpy.lastEvent as SbbDateSelectedEvent<Date>)
               .dateSelected as Date[];
-            expect(selectedDates.length).to.be.equal(14);
+            expect(selectedDates.length).to.be.equal(10);
             expect(toIso8601(selectedDates[0])).to.be.equal('2025-04-01');
             expect(toIso8601(selectedDates[1])).to.be.equal('2025-04-02');
             expect(toIso8601(selectedDates[5])).to.be.equal('2025-04-06');
             expect(toIso8601(selectedDates[6])).to.be.equal('2025-04-08');
             expect(toIso8601(selectedDates[7])).to.be.equal('2025-04-28');
             expect(toIso8601(selectedDates[9])).to.be.equal('2025-04-30');
-            expect(toIso8601(selectedDates[10])).to.be.equal('2025-05-01');
-            expect(toIso8601(selectedDates[13])).to.be.equal('2025-05-04');
           });
         });
 
         describe('vertical', () => {
           it('renders', async () => {
             const calendar: SbbCalendarElement = await fixture(html`
-              <sbb-calendar selected="2025-04-08" orientation="vertical" week-numbers>
+              <sbb-calendar value="2025-04-08" orientation="vertical" week-numbers>
                 ${variant === 'default'
                   ? nothing
                   : variant === 'enhanced'
@@ -1943,7 +1921,7 @@ describe(`sbb-calendar`, () => {
           it('renders multiple', async () => {
             const calendar: SbbCalendarElement = await fixture(html`
               <sbb-calendar
-                selected="2025-04-08T00:00:00"
+                value="2025-04-08T00:00:00"
                 orientation="vertical"
                 week-numbers
                 multiple
@@ -2077,11 +2055,11 @@ describe(`sbb-calendar`, () => {
             await setViewport({ width: sbbBreakpointLargeMinPx, height: 1000 });
             const calendar: SbbCalendarElement = await fixture(html`
               <sbb-calendar
-                selected="2025-04-08T00:00:00"
+                value="2025-04-08T00:00:00"
                 orientation="vertical"
                 week-numbers
                 multiple
-                wide
+                amount="2"
               >
                 ${variant === 'default'
                   ? nothing
@@ -2101,62 +2079,48 @@ describe(`sbb-calendar`, () => {
 
             // In vertical variant, there's a table header with the week numbers as cells
             const thead = calendar.shadowRoot!.querySelectorAll('thead');
-            // In wide variant we have two tables with two separate headers
             expect(thead.length).to.be.equal(2);
-            // The first header has a cell more than the second above the weekdays
             const cellsPrev = thead[0].querySelectorAll('th');
             expect(cellsPrev.length).to.be.equal(6);
             const cellsNext = thead[1].querySelectorAll('th');
-            expect(cellsNext.length).to.be.equal(5);
-            expect(
-              cellsPrev[1].querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!
-                .value,
-            ).to.be.equal('14');
-            expect(
-              cellsPrev[2].querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!
-                .value,
-            ).to.be.equal('15');
-            expect(
-              cellsPrev[5].querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!
-                .value,
-            ).to.be.equal('18');
-            expect(
-              cellsNext[0].querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!
-                .value,
-            ).to.be.equal('18');
-            expect(
-              cellsNext[1].querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!
-                .value,
-            ).to.be.equal('19');
-            expect(
-              cellsNext[4].querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!
-                .value,
-            ).to.be.equal('22');
+            expect(cellsNext.length).to.be.equal(6);
+            const readValue = (cell: HTMLElement): string | null =>
+              cell.querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!.value;
+            expect(readValue(cellsPrev[1])).to.be.equal('14');
+            expect(readValue(cellsPrev[2])).to.be.equal('15');
+            expect(readValue(cellsPrev[5])).to.be.equal('18');
+            expect(readValue(cellsNext[1])).to.be.equal('18');
+            expect(readValue(cellsNext[2])).to.be.equal('19');
+            expect(readValue(cellsNext[5])).to.be.equal('22');
 
-            // Clicking on the last week button must select all the days of the week, including the ones in the next month
+            // Clicking on the last week button must select all the days of the week in the current month
             const lastButtonFirstMonth =
               cellsPrev[5].querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!;
             lastButtonFirstMonth.click();
             await selectedSpy.calledOnce();
             let selectedDates = (selectedSpy.lastEvent as SbbDateSelectedEvent<Date>)
               .dateSelected as Date[];
-            expect(selectedDates.length).to.be.equal(8);
+            expect(selectedDates.length).to.be.equal(4);
             expect(toIso8601(selectedDates[0])).to.be.equal('2025-04-08');
             expect(toIso8601(selectedDates[1])).to.be.equal('2025-04-28');
             expect(toIso8601(selectedDates[2])).to.be.equal('2025-04-29');
-            expect(toIso8601(selectedDates[6])).to.be.equal('2025-05-03');
-            expect(toIso8601(selectedDates[7])).to.be.equal('2025-05-04');
+            expect(toIso8601(selectedDates[3])).to.be.equal('2025-04-30');
 
-            // Clicking on the first week button in the next month should not change the selection,
-            // since the dates are the same as before
+            // Clicking on the first week button in the next month additionally
+            // select all the days of the week in the next month
             const firstButtonSecondMonth =
-              cellsNext[0].querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!;
+              cellsNext[1].querySelector<SbbCalendarWeeknumberElement>('sbb-calendar-weeknumber')!;
             firstButtonSecondMonth.click();
             expect(selectedSpy.calledTimes(2));
             selectedDates = (selectedSpy.lastEvent as SbbDateSelectedEvent<Date>)
               .dateSelected as Date[];
-            expect(selectedDates.length).to.be.equal(1);
+            expect(selectedDates.length).to.be.equal(8);
             expect(toIso8601(selectedDates[0])).to.be.equal('2025-04-08');
+            expect(toIso8601(selectedDates[1])).to.be.equal('2025-04-28');
+            expect(toIso8601(selectedDates[4])).to.be.equal('2025-05-01');
+            expect(toIso8601(selectedDates[5])).to.be.equal('2025-05-02');
+            expect(toIso8601(selectedDates[6])).to.be.equal('2025-05-03');
+            expect(toIso8601(selectedDates[7])).to.be.equal('2025-05-04');
 
             // Clicks on the first button of the first month does not select dates in the previous (not rendered) one
             const firstButton =
@@ -2165,26 +2129,25 @@ describe(`sbb-calendar`, () => {
             await selectedSpy.calledTimes(3);
             selectedDates = (selectedSpy.lastEvent as SbbDateSelectedEvent<Date>)
               .dateSelected as Date[];
-            expect(selectedDates.length).to.be.equal(7);
+            expect(selectedDates.length).to.be.equal(14);
             expect(toIso8601(selectedDates[0])).to.be.equal('2025-04-01');
             expect(toIso8601(selectedDates[1])).to.be.equal('2025-04-02');
             expect(toIso8601(selectedDates[5])).to.be.equal('2025-04-06');
             expect(toIso8601(selectedDates[6])).to.be.equal('2025-04-08');
 
-            // Clicking again on the first button of the second month will select dates in the last week of the previous month
+            // Clicking again on the first button of the second month will select the dates in the first week of the second month
             firstButtonSecondMonth.click();
             await selectedSpy.calledTimes(4);
             selectedDates = (selectedSpy.lastEvent as SbbDateSelectedEvent<Date>)
               .dateSelected as Date[];
-            expect(selectedDates.length).to.be.equal(14);
+            expect(selectedDates.length).to.be.equal(10);
             expect(toIso8601(selectedDates[0])).to.be.equal('2025-04-01');
             expect(toIso8601(selectedDates[1])).to.be.equal('2025-04-02');
             expect(toIso8601(selectedDates[2])).to.be.equal('2025-04-03');
             expect(toIso8601(selectedDates[6])).to.be.equal('2025-04-08');
             expect(toIso8601(selectedDates[7])).to.be.equal('2025-04-28');
             expect(toIso8601(selectedDates[8])).to.be.equal('2025-04-29');
-            expect(toIso8601(selectedDates[12])).to.be.equal('2025-05-03');
-            expect(toIso8601(selectedDates[13])).to.be.equal('2025-05-04');
+            expect(toIso8601(selectedDates[9])).to.be.equal('2025-04-30');
           });
         });
       });

--- a/src/elements/calendar/calendar/calendar.ssr.spec.ts
+++ b/src/elements/calendar/calendar/calendar.ssr.spec.ts
@@ -14,7 +14,7 @@ describe(`sbb-calendar ssr`, () => {
     // This test seems flaky for unknown reason, so we extend the timeout for this specific test.
     this.timeout(20000);
     root = await ssrHydratedFixture(
-      html`<sbb-calendar selected="2023-01-20T00:00:00"></sbb-calendar>`,
+      html`<sbb-calendar value="2023-01-20T00:00:00"></sbb-calendar>`,
       { modules: ['../../calendar.ts'] },
     );
   });
@@ -24,6 +24,9 @@ describe(`sbb-calendar ssr`, () => {
   });
 
   it('renders shadow DOM', () => {
-    assert.instanceOf(root.shadowRoot?.querySelector('.sbb-calendar__controls'), HTMLDivElement);
+    assert.instanceOf(
+      root.shadowRoot?.querySelector('.sbb-calendar__table-header'),
+      HTMLDivElement,
+    );
   });
 });

--- a/src/elements/calendar/calendar/calendar.visual.spec.ts
+++ b/src/elements/calendar/calendar/calendar.visual.spec.ts
@@ -8,7 +8,6 @@ import {
   visualDiffDefault,
   visualDiffFocus,
   visualDiffHover,
-  visualDiffStandardStates,
   visualRegressionFixture,
 } from '../../core/testing/private.ts';
 import { defaultDateAdapter } from '../../core.ts';
@@ -49,14 +48,6 @@ describe('sbb-calendar', () => {
 
   const dayButtonCases = {
     selected: [false, true],
-    emulateMedia: [
-      { forcedColors: false, darkMode: false },
-      { forcedColors: true, darkMode: false },
-      { forcedColors: false, darkMode: true },
-    ],
-  };
-
-  const changeMonthButtonCases = {
     emulateMedia: [
       { forcedColors: false, darkMode: false },
       { forcedColors: true, darkMode: false },
@@ -216,7 +207,7 @@ describe('sbb-calendar', () => {
                 );
               }
 
-              for (const view of ['year', 'month']) {
+              for (const view of ['year', 'month'] satisfies SbbCalendarElement['view'][]) {
                 it(
                   `view=${view}`,
                   visualDiffDefault.with(async (setup) => {
@@ -279,32 +270,6 @@ describe('sbb-calendar', () => {
                 selected
                   ? setup.snapshotElement.querySelector('sbb-calendar-day[slot="2023-01-20"]')!
                   : setup.snapshotElement.querySelector('sbb-calendar-day[slot="2023-01-01"]')!,
-              );
-            }),
-          );
-        }
-      });
-    });
-
-    describe('change month button', () => {
-      describeEach(changeMonthButtonCases, ({ emulateMedia: { forcedColors, darkMode } }) => {
-        let element: SbbCalendarElement, root: HTMLElement;
-
-        beforeEach(async function () {
-          root = await visualRegressionFixture(html`<sbb-calendar></sbb-calendar>`, {
-            darkMode,
-            forcedColors,
-          });
-          element = root.querySelector('sbb-calendar')!;
-        });
-
-        for (const state of visualDiffStandardStates) {
-          it(
-            state.name,
-            state.with((setup) => {
-              setup.withSnapshotElement(root);
-              setup.withStateElement(
-                element.shadowRoot!.querySelector('button.sbb-calendar__controls-change-date')!,
               );
             }),
           );

--- a/src/elements/calendar/calendar/calendar.visual.spec.ts
+++ b/src/elements/calendar/calendar/calendar.visual.spec.ts
@@ -64,7 +64,10 @@ describe('sbb-calendar', () => {
     ],
   };
 
-  for (const orientation of ['horizontal', 'vertical']) {
+  for (const orientation of [
+    'horizontal',
+    'vertical',
+  ] satisfies SbbCalendarElement['orientation'][]) {
     describeViewports({ viewports: ['zero', 'large', 'ultra'] }, () => {
       for (const variant of ['default', 'enhanced']) {
         describe(`variant=${variant}`, () => {

--- a/src/elements/calendar/calendar/calendar.visual.spec.ts
+++ b/src/elements/calendar/calendar/calendar.visual.spec.ts
@@ -20,9 +20,10 @@ import '../../calendar.ts';
 
 describe('sbb-calendar', () => {
   let todayStub: SinonStub;
+  const today = new Date(2023, 0, 12, 0, 0, 0);
 
   before(() => {
-    todayStub = stub(defaultDateAdapter, 'today').returns(new Date(2023, 0, 12, 0, 0, 0));
+    todayStub = stub(defaultDateAdapter, 'today').returns(today);
   });
 
   after(() => {
@@ -76,7 +77,7 @@ describe('sbb-calendar', () => {
                     await setup.withFixture(html`
                       <sbb-calendar
                         orientation=${orientation}
-                        .selected=${new Date(2023, 0, 20)}
+                        .value=${new Date(2023, 0, 20)}
                         .min=${min.value ? defaultDateAdapter.toIso8601(min.value) : nothing}
                         .max=${max.value ? defaultDateAdapter.toIso8601(max.value) : nothing}
                         >${variant === 'default'
@@ -90,8 +91,8 @@ describe('sbb-calendar', () => {
             }
           });
 
-          for (const wide of [false, true]) {
-            describe(`orientation=${orientation} wide=${wide}`, () => {
+          for (const amount of [1, 2, 13]) {
+            describe(`orientation=${orientation} amount=${amount}`, () => {
               it(
                 'dynamic width',
                 visualDiffDefault.with(async (setup) => {
@@ -99,14 +100,18 @@ describe('sbb-calendar', () => {
                     <sbb-calendar
                       style="width: 900px"
                       orientation=${orientation}
-                      ?wide=${wide}
-                      .selected=${new Date(2023, 0, 20)}
+                      amount=${amount}
+                      .value=${new Date(2023, 0, 20)}
                       >${variant === 'default'
                         ? nothing
-                        : wide
-                          ? html`${createSlottedDays(2023, 1, true)}
-                            ${createSlottedDays(2023, 2, true)}`
-                          : createSlottedDays(2023, 1, true)}
+                        : html`${Array.from({ length: amount }, (_, i) => {
+                            const date = defaultDateAdapter.addCalendarMonths(today, i);
+                            return createSlottedDays(
+                              defaultDateAdapter.getYear(date),
+                              defaultDateAdapter.getMonth(date),
+                              true,
+                            );
+                          })}`}
                     </sbb-calendar>
                   `);
                 }),
@@ -119,14 +124,18 @@ describe('sbb-calendar', () => {
                     <sbb-calendar
                       style="width: 100%"
                       orientation=${orientation}
-                      ?wide=${wide}
-                      .selected=${new Date(2023, 0, 20)}
+                      amount=${amount}
+                      .value=${new Date(2023, 0, 20)}
                       >${variant === 'default'
                         ? nothing
-                        : wide
-                          ? html`${createSlottedDays(2023, 1, true)}
-                            ${createSlottedDays(2023, 2, true)}`
-                          : createSlottedDays(2023, 1, true)}
+                        : html`${Array.from({ length: amount }, (_, i) => {
+                            const date = defaultDateAdapter.addCalendarMonths(today, i);
+                            return createSlottedDays(
+                              defaultDateAdapter.getYear(date),
+                              defaultDateAdapter.getMonth(date),
+                              true,
+                            );
+                          })}`}
                     </sbb-calendar>
                   `);
 
@@ -157,15 +166,19 @@ describe('sbb-calendar', () => {
                       <sbb-calendar
                         orientation=${orientation}
                         ?multiple=${multiple}
-                        ?wide=${wide}
-                        .selected=${selected}
+                        amount=${amount}
+                        .value=${selected}
                         week-numbers
                         >${variant === 'default'
                           ? nothing
-                          : wide
-                            ? html`${createSlottedDays(2023, 1, true)}
-                              ${createSlottedDays(2023, 2, true)}`
-                            : createSlottedDays(2023, 1, true)}
+                          : html`${Array.from({ length: amount }, (_, i) => {
+                              const date = defaultDateAdapter.addCalendarMonths(today, i);
+                              return createSlottedDays(
+                                defaultDateAdapter.getYear(date),
+                                defaultDateAdapter.getMonth(date),
+                                true,
+                              );
+                            })}`}
                       </sbb-calendar>
                     `);
                   }),
@@ -179,17 +192,21 @@ describe('sbb-calendar', () => {
                     await setup.withFixture(html`
                       <sbb-calendar
                         orientation=${orientation}
-                        ?wide=${wide}
+                        amount=${amount}
                         .min=${defaultDateAdapter.toIso8601(new Date(2023, 0, 13))}
                         .max=${defaultDateAdapter.toIso8601(new Date(2023, 1, 17))}
-                        .selected=${new Date(2023, 0, 20)}
+                        .value=${new Date(2023, 0, 20)}
                         .dateFilter=${fn.dateFilter}
                         >${variant === 'default'
                           ? nothing
-                          : wide
-                            ? html`${createSlottedDays(2023, 1, true)}
-                              ${createSlottedDays(2023, 2, true)}`
-                            : createSlottedDays(2023, 1, true)}
+                          : html`${Array.from({ length: amount }, (_, i) => {
+                              const date = defaultDateAdapter.addCalendarMonths(today, i);
+                              return createSlottedDays(
+                                defaultDateAdapter.getYear(date),
+                                defaultDateAdapter.getMonth(date),
+                                true,
+                              );
+                            })}`}
                       </sbb-calendar>
                     `);
                   }),
@@ -204,15 +221,19 @@ describe('sbb-calendar', () => {
                       <sbb-calendar
                         orientation=${orientation}
                         view=${view}
-                        ?wide=${wide}
-                        .selected=${new Date(2023, 0, 20)}
+                        amount=${amount}
+                        .value=${new Date(2023, 0, 20)}
                       >
                         ${variant === 'default'
                           ? nothing
-                          : wide
-                            ? html`${createSlottedDays(2023, 1, true)}
-                              ${createSlottedDays(2023, 2, true)}`
-                            : createSlottedDays(2023, 1, true)}
+                          : html`${Array.from({ length: amount }, (_, i) => {
+                              const date = defaultDateAdapter.addCalendarMonths(today, i);
+                              return createSlottedDays(
+                                defaultDateAdapter.getYear(date),
+                                defaultDateAdapter.getMonth(date),
+                                true,
+                              );
+                            })}`}
                       </sbb-calendar>
                     `);
                   }),
@@ -234,7 +255,7 @@ describe('sbb-calendar', () => {
           const selectedDate = new Date(2023, 0, 20);
           root = await visualRegressionFixture(
             html`<sbb-calendar
-              .selected=${selectedDate}
+              .value=${selectedDate}
               .max=${defaultDateAdapter.toIso8601(new Date(2023, 0, 22))}
             ></sbb-calendar>`,
             {

--- a/src/elements/calendar/common/calendar-cell-base-element.scss
+++ b/src/elements/calendar/common/calendar-cell-base-element.scss
@@ -91,17 +91,18 @@
 .sbb-calendar-month {
   height: var(--sbb-calendar-cell-year-month-height);
   width: var(--sbb-calendar-cell-year-month-width);
+}
 
+:is(.sbb-calendar-year, .sbb-calendar-month, .sbb-calendar-day__value) {
   :host(:state(crossed-out)) & {
     &::after {
+      @include sbb.absolute-center-x-y;
+
       content: '';
       height: var(--sbb-calendar-cell-disabled-height);
       width: var(--sbb-calendar-cell-disabled-width);
-      position: absolute;
       background-color: var(--sbb-calendar-cell-disabled-color);
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%) rotate(-45deg);
+      rotate: -45deg;
     }
   }
 }

--- a/src/elements/calendar/common/calendar-cell-base-element.scss
+++ b/src/elements/calendar/common/calendar-cell-base-element.scss
@@ -80,7 +80,7 @@
 }
 
 .sbb-action-base {
-  display: inline-flex;
+  display: flex;
   flex-direction: column;
   justify-content: center;
   height: 100%;

--- a/src/elements/calendar/common/calendar-cell-base-element.scss
+++ b/src/elements/calendar/common/calendar-cell-base-element.scss
@@ -33,7 +33,7 @@
   outline: 0;
 }
 
-:host(:not(:disabled):active) {
+:host(:not(:disabled):where(:state(active), :active)) {
   --sbb-calendar-cell-background-color: var(--sbb-calendar-cell-background-color-active);
 }
 
@@ -67,7 +67,7 @@
     transition-property: background-color;
     z-index: -1;
 
-    :host(:not(:disabled):active) & {
+    :host(:not(:disabled):where(:state(active), :active)) & {
       @media (forced-colors: active) {
         @include sbb.focus-outline;
 
@@ -78,7 +78,7 @@
     }
   }
 
-  :host(:not(:active, :disabled):hover) & {
+  :host(:not(:active, :state(active), :disabled):hover) & {
     @include sbb.hover-mq($hover: true) {
       --sbb-calendar-cell-background-color: var(--sbb-calendar-cell-background-color-hover);
 

--- a/src/elements/calendar/common/calendar-cell-base-element.scss
+++ b/src/elements/calendar/common/calendar-cell-base-element.scss
@@ -1,27 +1,50 @@
 @use '../../core/styles' as sbb;
 
 :host {
+  --sbb-focus-outline-offset: #{sbb.px-to-rem-build(2)};
+
   display: block;
+  font-size: var(--sbb-calendar-cell-font-size);
+  letter-spacing: var(--sbb-typo-letter-spacing-text);
+  cursor: var(--sbb-calendar-cell-cursor);
+  color: var(--sbb-calendar-cell-color);
 
-  --sbb-calendar-cell-transition-duration: var(
-    --sbb-disable-animation-duration,
-    var(--sbb-animation-duration-2x)
-  );
-  --sbb-calendar-cell-border-radius: calc(
-    var(--sbb-border-radius-4x) + var(--sbb-calendar-cell-border-width)
-  );
+  // Match Figma Design
+  border-radius: calc(var(--sbb-border-radius-4x) + var(--sbb-calendar-cell-border-width));
 
-  @media (forced-colors: active) {
-    --sbb-calendar-cell-border: transparent;
-  }
+  // Used for visual separation
+  margin: var(--sbb-calendar-cell-margin);
+
+  // Pre-serve spacing for border. Transparent border can't be used because with forced colors it will be always displayed.
+  padding: var(--sbb-calendar-cell-border-width);
+  transition-duration: var(--sbb-calendar-cell-transition-duration);
+  transition-timing-function: var(--sbb-calendar-cell-transition-easing-function);
+  transition-property: background-color;
+}
+
+:host(:is(sbb-calendar-weekday, sbb-calendar-weeknumber)) {
+  --sbb-calendar-cell-font-size: var(--sbb-text-font-size-xs);
+  --sbb-calendar-day-height: var(--sbb-calendar-day-size);
+
+  color: var(--sbb-calendar-header-color);
+}
+
+:host(:is(sbb-calendar-day, sbb-calendar-weekday, sbb-calendar-weeknumber)) {
+  height: var(--sbb-calendar-day-height);
+  width: var(--sbb-calendar-day-width);
+}
+
+:host(:focus-visible) {
+  @include sbb.focus-outline;
 }
 
 :host(:state(current)) {
-  --sbb-calendar-cell-font-weight: bold;
+  font-weight: bold;
 }
 
 :host(:state(selected)) {
-  --sbb-calendar-cell-border: var(--sbb-calendar-cell-border-width) solid var(--sbb-border-color-2);
+  border: var(--sbb-calendar-cell-border-width) solid var(--sbb-calendar-cell-border-color-selected);
+  padding: 0;
 }
 
 :host(:disabled) {
@@ -29,79 +52,40 @@
   --sbb-calendar-cell-cursor: unset;
 }
 
-:host(:focus-visible) {
-  outline: 0;
+:host(:not(:disabled, :where(:state(active), :active)):hover) {
+  @include sbb.hover-mq($hover: true) {
+    background-color: var(--sbb-calendar-cell-background-color-hover);
+  }
+}
+
+:host(:not(:disabled):hover) {
+  @include sbb.hover-mq($hover: true) {
+    @media (forced-colors: active) {
+      @include sbb.focus-outline;
+
+      // Basically the focus-outline mixin is made for use with focus-visible.
+      // As we use it here with hover, we have to ensure that the outline is not overridden when mouse or touch is in use.
+      --sbb-focus-outline-style: initial;
+    }
+  }
 }
 
 :host(:not(:disabled):where(:state(active), :active)) {
-  --sbb-calendar-cell-background-color: var(--sbb-calendar-cell-background-color-active);
+  background-color: var(--sbb-calendar-cell-background-color-active);
 }
 
 .sbb-action-base {
   display: inline-flex;
+  flex-direction: column;
   justify-content: center;
-  align-items: center;
-  position: relative;
-  font-size: var(--sbb-calendar-cell-font-size);
-  font-weight: var(--sbb-calendar-cell-font-weight);
-  letter-spacing: var(--sbb-typo-letter-spacing-text);
-  cursor: var(--sbb-calendar-cell-cursor);
-  color: var(--sbb-calendar-cell-color);
-  border-radius: var(--sbb-calendar-cell-border-radius);
-
-  :host(:focus-visible) & {
-    @include sbb.focus-outline;
-
-    --sbb-focus-outline-offset: #{sbb.px-to-rem-build(1)};
-  }
-
-  &::before {
-    content: '';
-    position: absolute;
-    background-color: var(--sbb-calendar-cell-background-color);
-    inset: var(--sbb-calendar-cell-inset);
-    border: var(--sbb-calendar-cell-border);
-    border-radius: var(--sbb-calendar-cell-border-radius);
-    transition-duration: var(--sbb-calendar-cell-transition-duration);
-    transition-timing-function: var(--sbb-calendar-cell-transition-easing-function);
-    transition-property: background-color;
-    z-index: -1;
-
-    :host(:not(:disabled):where(:state(active), :active)) & {
-      @media (forced-colors: active) {
-        @include sbb.focus-outline;
-
-        // Basically the focus-outline mixin is made for use with focus-visible.
-        // As we use it here with :active, we have to ensure that the outline is not overridden when mouse or touch is in use.
-        --sbb-focus-outline-style: initial;
-      }
-    }
-  }
-
-  :host(:not(:active, :state(active), :disabled):hover) & {
-    @include sbb.hover-mq($hover: true) {
-      --sbb-calendar-cell-background-color: var(--sbb-calendar-cell-background-color-hover);
-
-      &::before {
-        @media (forced-colors: active) {
-          @include sbb.focus-outline;
-
-          --sbb-focus-outline-offset: #{sbb.px-to-rem-build(1)};
-
-          // Basically the focus-outline mixin is made for use with focus-visible.
-          // As we use it here with hover, we have to ensure that the outline is not overridden when mouse or touch is in use.
-          --sbb-focus-outline-style: initial;
-        }
-      }
-    }
-  }
+  height: 100%;
+  width: 100%;
 }
 
 .sbb-calendar-year,
 .sbb-calendar-month {
   height: var(--sbb-calendar-cell-year-month-height);
   width: var(--sbb-calendar-cell-year-month-width);
-  padding-block-end: var(--sbb-calendar-cell-padding);
 
   :host(:state(crossed-out)) & {
     &::after {
@@ -115,14 +99,4 @@
       transform: translate(-50%, -50%) rotate(-45deg);
     }
   }
-}
-
-.sbb-calendar-weekday,
-.sbb-calendar-weeknumber {
-  --sbb-calendar-cell-font-size: var(--sbb-text-font-size-xs);
-  --sbb-calendar-cell-font-weight: normal;
-
-  height: var(--sbb-calendar-day-width);
-  width: var(--sbb-calendar-day-width);
-  color: var(--sbb-calendar-header-color);
 }

--- a/src/elements/calendar/common/calendar-cell-base-element.scss
+++ b/src/elements/calendar/common/calendar-cell-base-element.scss
@@ -48,6 +48,7 @@
   cursor: var(--sbb-calendar-cell-cursor);
   color: var(--sbb-calendar-cell-color);
   border-radius: var(--sbb-calendar-cell-border-radius);
+  z-index: 0;
 
   :host(:focus-visible) & {
     @include sbb.focus-outline;

--- a/src/elements/calendar/common/calendar-cell-base-element.scss
+++ b/src/elements/calendar/common/calendar-cell-base-element.scss
@@ -2,6 +2,10 @@
 
 :host {
   --sbb-focus-outline-offset: #{sbb.px-to-rem-build(2)};
+  --sbb-calendar-cell-transition-duration: var(
+    --sbb-disable-animation-duration,
+    var(--sbb-animation-duration-2x)
+  );
 
   display: block;
   font-size: var(--sbb-calendar-cell-font-size);

--- a/src/elements/calendar/common/calendar-cell-base-element.scss
+++ b/src/elements/calendar/common/calendar-cell-base-element.scss
@@ -17,6 +17,7 @@
 
   // Pre-serve spacing for border. Transparent border can't be used because with forced colors it will be always displayed.
   padding: var(--sbb-calendar-cell-border-width);
+  background-clip: content-box;
   transition-duration: var(--sbb-calendar-cell-transition-duration);
   transition-timing-function: var(--sbb-calendar-cell-transition-easing-function);
   transition-property: background-color;
@@ -34,10 +35,6 @@
   width: var(--sbb-calendar-day-width);
 }
 
-:host(:focus-visible) {
-  @include sbb.focus-outline;
-}
-
 :host(:state(current)) {
   font-weight: bold;
 }
@@ -50,6 +47,10 @@
 :host(:disabled) {
   --sbb-calendar-cell-color: var(--sbb-calendar-cell-disabled-color);
   --sbb-calendar-cell-cursor: unset;
+}
+
+:host(:focus-visible) {
+  @include sbb.focus-outline;
 }
 
 :host(:not(:disabled, :where(:state(active), :active)):hover) {

--- a/src/elements/calendar/common/calendar-cell-base-element.scss
+++ b/src/elements/calendar/common/calendar-cell-base-element.scss
@@ -48,7 +48,6 @@
   cursor: var(--sbb-calendar-cell-cursor);
   color: var(--sbb-calendar-cell-color);
   border-radius: var(--sbb-calendar-cell-border-radius);
-  z-index: 0;
 
   :host(:focus-visible) & {
     @include sbb.focus-outline;

--- a/src/elements/calendar/common/calendar-cell-base-element.ts
+++ b/src/elements/calendar/common/calendar-cell-base-element.ts
@@ -27,7 +27,7 @@ export abstract class SbbCalendarCellBaseElement<T = Date> extends SbbDisabledMi
         dateFilter: (component) => this.setDisabledFilteredState(component),
         min: (component) => this.setDisabledFilteredState(component),
         max: (component) => this.setDisabledFilteredState(component),
-        selected: (component) => this.setSelectedState(component),
+        value: (component) => this.setSelectedState(component),
       }),
     );
   }

--- a/src/elements/calendar/readme.md
+++ b/src/elements/calendar/readme.md
@@ -17,11 +17,11 @@ The slot name is mandatory, and it requires a date in ISO8601 format (e.g. 2025-
 ```
 
 The `<sbb-calendar>` creates its own slots based on the month to be displayed;
-during initialization, the month is the current one (if there's no `selected` date).
+during initialization, the month is the current one (if there's no date assigned to `value`).
 So for the first render, the slotted `<sbb-calendar-day>` elements must match that month.
-When using an `amount` greater than 1, additional `<sbb-calendar-day>` must be rendered
-for each month (they must not be grouped, but just sequentially rendered as direct children
-of the `<sbb-calendar>` element).
+The `amount` property can be used to display more than one month; in this case, additional
+`<sbb-calendar-day>` must be rendered for each month (they must not be grouped, just
+sequentially rendered as direct children of the `<sbb-calendar>` element).
 
 Each time the month changes due to user interaction with the previous/next month buttons,
 or via selecting a different year and then a month, a `monthchange` event is emitted, typed as
@@ -42,8 +42,8 @@ and slot the `<sbb-calendar-day>`s of the chosen month.
 ```
 
 ```html
-<!-- Slot days based on the current date, or the selected one if available.-->
-<sbb-calendar selected="2025-01-15" @monthchange="(event) => monthChangeHandler(event)">
+<!-- Slot days based on the current or defined date. -->
+<sbb-calendar value="2025-01-15" @monthchange="(event) => monthChangeHandler(event)">
   <sbb-calendar-day slot="2025-01-01">
     <span class="sbb-text-xxs my-custom-content"> 19.99 </span>
   </sbb-calendar-day>
@@ -80,14 +80,14 @@ function monthChangeHandler(event: SbbMonthChangeEvent): void {
 The `<sbb-calendar-day>` component has a `current` state, which is set if the slot name matches
 the current day.
 
-Also, it has other states based on the properties of the parent `<sbb-calendar>`.
+It also has other states based on the properties of the parent `<sbb-calendar>`.
 The disabled and the crossed-out states are based on the value of the `min`, `max` and `dateFilter`
-properties, while the selected matches the parent `selected` properties, including the multiple
+properties, while `selected` matches the parent `value` property, including the multiple
 variant.
 
 ## Configuration
 
-It's possible to set a date using the `dateSelected` property. Also, it's possible to place limits
+It's possible to set a date using the `value` property. Also, it's possible to place limits
 on the selection using the two properties named `min` and `max`. For these three properties, the
 accepted formats are:
 
@@ -98,11 +98,11 @@ accepted formats are:
 It's recommended to set the time to 00:00:00.
 
 ```html
-<sbb-calendar min="1599955200" max="1699920000" selected="1649980800"></sbb-calendar>
+<sbb-calendar min="1599955200" max="1699920000" value="1649980800"></sbb-calendar>
 ```
 
 By default, the component takes, in order of priority,
-the `dateSelected` property or the current date to calculate which month it has to show.
+the `value` property or the current date to calculate which month it has to show.
 It's possible to move to the previous/next month using the two buttons at the top of the component.
 
 It's also possible to select a specific date by clicking on the month label between the buttons:
@@ -114,9 +114,9 @@ The `<sbb-calendar>` can be directly displayed in one of these modalities using 
 (default: `day`).
 
 ```html
-<sbb-calendar selected="1585699200" view="month"></sbb-calendar>
+<sbb-calendar value="1585699200" view="month"></sbb-calendar>
 
-<sbb-calendar selected="1585699200" view="year"></sbb-calendar>
+<sbb-calendar value="1585699200" view="year"></sbb-calendar>
 ```
 
 The `<sbb-calendar>` uses two different components to render years and months in their view,
@@ -141,7 +141,7 @@ const dateFilterFn: (d: Day) => boolean = d.getDay() !== 6 && d.getDay() !== 0;
 
 By default, the component allows selecting a single date:
 this behavior can be changed by setting the `multiple` attribute to true.
-In this case the `selected` property, if set, must be an array; moreover,
+In this case the `value` property, if set, must be an array; moreover,
 the days of the week become clickable, allowing to select an entire column
 (e.g. all the Mondays, all the Tuesdays and so on).
 Additionally it is possible to select a range of dates, by clicking on a
@@ -165,7 +165,7 @@ in the `year` view, or a list of months in the `month` view.
 When setting the `amount` to a value greater than 1, it will display the given amount of months.
 
 ```html
-<sbb-calendar wide="true" selected="1699920000"></sbb-calendar>
+<sbb-calendar wide="true" value="1699920000"></sbb-calendar>
 ```
 
 It's also possible to change the orientation of dates by setting the `orientation` property to
@@ -189,8 +189,8 @@ possible to display the ISO week dates perpendicularly to week days,so on the le
 
 ## Events
 
-Consumers can listen to the `dateselected` event on the `<sbb-calendar>` component to intercept the selected date/dates
-which can be read from the `event.dateSelected` property.
+The `change` event is dispatched every time a user selects or deselects a date.
+
 Check the [Slot and day customization](docs/elements-calendar--docs#slots-and-day-customization) paragraph
 for more information about the `monthchange` event.
 
@@ -270,7 +270,7 @@ For accessibility purposes, the component is rendered as a native table element 
 
 | Name                | Attribute      | Privacy | Type                                     | Default        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ------------------- | -------------- | ------- | ---------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `amount`            | `amount`       | public  | `number`                                 | `1`            |                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `amount`            | `amount`       | public  | `number`                                 | `1`            | The amount of months to display in this calendar.                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `dateFilter`        | `date-filter`  | public  | `((date: T \| null) => boolean) \| null` | `null`         | A function used to filter out dates.                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | `form`              | -              | public  | `HTMLFormElement \| null`                |                | Returns the form owner of this element.                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `max`               | `max`          | public  | `T \| null`                              | `null`         | The maximum valid date. Accepts a date object or null. Accepts an ISO8601 formatted string (e.g. 2024-12-24) as attribute.                                                                                                                                                                                                                                                                                                                              |

--- a/src/elements/calendar/readme.md
+++ b/src/elements/calendar/readme.md
@@ -1,7 +1,5 @@
 The `<sbb-calendar>` component displays a calendar that allows the user to select a date.
 
-This is used internally in the datepicker component, but it can be used on its own.
-
 ```html
 <sbb-calendar></sbb-calendar>
 ```
@@ -21,12 +19,15 @@ The slot name is mandatory, and it requires a date in ISO8601 format (e.g. 2025-
 The `<sbb-calendar>` creates its own slots based on the month to be displayed;
 during initialization, the month is the current one (if there's no `selected` date).
 So for the first render, the slotted `<sbb-calendar-day>` elements must match that month.
-For `wide` mode, also the following one must be taken into account.
+When using an `amount` greater than 1, additional `<sbb-calendar-day>` must be rendered
+for each month (they must not be grouped, but just sequentially rendered as direct children
+of the `<sbb-calendar>` element).
 
 Each time the month changes due to user interaction with the previous/next month buttons,
-or via selecting a different year and then a month, a `monthchange` event is emitted, typed as `SbbMonthChangeEvent`.
-The event has a `range: Day[]` property, which can be accessed to have information about the days to render.
-Consumers can listen to this event to dynamically create and slot the `<sbb-calendar-day>`s of the chosen month.
+or via selecting a different year and then a month, a `monthchange` event is emitted, typed as
+`SbbMonthChangeEvent`. The event has a `range: Day[]` property, which can be accessed to have
+information about the days to render. Consumers can listen to this event to dynamically create
+and slot the `<sbb-calendar-day>`s of the chosen month.
 
 <!-- #region calendar-day-example -->
 
@@ -57,18 +58,18 @@ Consumers can listen to this event to dynamically create and slot the `<sbb-cale
 ```
 
 ```ts
-function monthChangeHandler(e: SbbMonthChangeEvent): void {
-  const calendar = e.target;
+function monthChangeHandler(event: SbbMonthChangeEvent): void {
+  const calendar = event.target;
   // Remove slotted days to keep the DOM clean.
   Array.from(calendar.children).forEach((e) => e.remove());
   // Add the new days
-  e.range.map((day) => {
+  for (const day of event.range) {
     const child = document.createElement('sbb-calendar-day');
     // The day.value property is the date in ISO8601 format,
     // the correct one for the `<sbb-calendar-day>`'s slot property.
     child.setAttribute('slot', day.value);
     calendar.appendChild(child);
-  });
+  }
 }
 ```
 
@@ -76,16 +77,19 @@ function monthChangeHandler(e: SbbMonthChangeEvent): void {
 
 ### States
 
-The `<sbb-calendar-day>` component has a `current` state, which is set if the slot name matches the current day.
+The `<sbb-calendar-day>` component has a `current` state, which is set if the slot name matches
+the current day.
 
 Also, it has other states based on the properties of the parent `<sbb-calendar>`.
-The disabled and the crossed-out states are based on the value of the `min`, `max` and `dateFilter` properties,
-while the selected matches the parent `selected` properties, including the multiple variant.
+The disabled and the crossed-out states are based on the value of the `min`, `max` and `dateFilter`
+properties, while the selected matches the parent `selected` properties, including the multiple
+variant.
 
 ## Configuration
 
-It's possible to set a date using the `dateSelected` property. Also, it's possible to place limits on the selection
-using the two properties named `min` and `max`. For these three properties, the accepted formats are:
+It's possible to set a date using the `dateSelected` property. Also, it's possible to place limits
+on the selection using the two properties named `min` and `max`. For these three properties, the
+accepted formats are:
 
 - Date objects
 - ISO String
@@ -102,10 +106,12 @@ the `dateSelected` property or the current date to calculate which month it has 
 It's possible to move to the previous/next month using the two buttons at the top of the component.
 
 It's also possible to select a specific date by clicking on the month label between the buttons:
-this action opens a list of twenty-four selectable years, and, after the year selection, the list of months of that year.
-Clicking on an element will set the month and restore the first view, allowing to select the desired day.
+this action opens a list of twenty-four selectable years, and, after the year selection, the list
+of months of that year. Clicking on an element will set the month and restore the first view,
+allowing to select the desired day.
 
-The `<sbb-calendar>` can be directly displayed in one of these modalities using the `view` property (default: `day`).
+The `<sbb-calendar>` can be directly displayed in one of these modalities using the `view` property
+(default: `day`).
 
 ```html
 <sbb-calendar selected="1585699200" view="month"></sbb-calendar>
@@ -118,8 +124,9 @@ named `<sbb-calendar-month>` and `<sbb-calendar-year>`.
 These are 'internal-use-only' components, and they are **not** meant to be used by consumers.
 
 Unwanted dates can be filtered out using the `dateFilter` property.
-Note that the `dateFilter` function should not be used as a replacement for the `min` and `max` properties.
-The `dateFilter` is applied in all the views, so if some months or years are not allowed they will be displayed as disabled in the corresponding view.
+Note that the `dateFilter` function should not be used as a replacement for the `min` and `max`
+properties. The `dateFilter` is applied in all the views, so if some months or years are not
+allowed they will be displayed as disabled in the corresponding view.
 
 ```ts
 /** Returns only working days (Mon-Fri). */
@@ -144,7 +151,8 @@ date and then Shift clicking on another date.
 <sbb-calendar multiple></sbb-calendar>
 ```
 
-If the `week-numbers` property is set, the ISO week dates are also clickable, allowing to select all the days in the week.
+If the `week-numbers` property is set, the ISO week dates are also clickable, allowing to select
+all the days in the week.
 
 ```html
 <sbb-calendar multiple week-numbers></sbb-calendar>
@@ -152,36 +160,32 @@ If the `week-numbers` property is set, the ISO week dates are also clickable, al
 
 ## Style
 
-The component displays by default a single month in the `day` view, or a list of twenty-four years in the `year` view,
-or a list of months in the `month` view;
-however, setting the `wide` property to `true` it's possible to duplicate the view, showing, respectively, two consecutive months or
-two sets of twenty-four years or the list of the twelve months for two consecutive years.
+The component displays by default a single month in the `day` view, a list of twenty-four years
+in the `year` view, or a list of months in the `month` view.
+When setting the `amount` to a value greater than 1, it will display the given amount of months.
 
 ```html
 <sbb-calendar wide="true" selected="1699920000"></sbb-calendar>
 ```
 
-It's also possible to change the orientation of dates by setting the `orientation` property to `vertical`.
-In this variant, the weekdays are displayed on the left side of the component and the days progress along the vertical direction.
+It's also possible to change the orientation of dates by setting the `orientation` property to
+`vertical`. In this variant, the weekdays are displayed on the left side of the component and the
+days progress along the vertical direction.
 This visual change is applied only to the day view.
 
 ```html
 <sbb-calendar orientation="vertical"></sbb-calendar>
 ```
 
-In both orientations, the week days are always displayed;
-using the `week-numbers` property, it's possible to display the ISO week dates perpendicularly to week days,
-so on the left side in `horizontal` and on top in `vertical`.
+In both orientations, the week days are always displayed. Using the `week-numbers` property, it's
+possible to display the ISO week dates perpendicularly to week days,so on the left side in
+`horizontal` and on top in `vertical`.
 
 ```html
 <sbb-calendar week-numbers></sbb-calendar>
 
 <sbb-calendar orientation="vertical" week-numbers></sbb-calendar>
 ```
-
-Two more components, named `<sbb-calendar-weeknumber>` and `<sbb-calendar-weekday>`, are used to render
-a single week number and a single week day cell.
-These are 'internal-use-only' components too, and they are **not** meant to be used by consumers.
 
 ## Events
 
@@ -199,29 +203,29 @@ pressing the `<kbd>Home</kbd>` when the first day of the month is disabled will 
 
 ### Horizontal orientation
 
-| Keyboard               | Action                                                                                                                                         |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| <kbd>Left Arrow</kbd>  | Go to previous day.                                                                                                                            |
-| <kbd>Right Arrow</kbd> | Go to next day.                                                                                                                                |
-| <kbd>Up Arrow</kbd>    | Go to the same day in the previous week (eg. from Monday to previous Monday).<br/>In `wide` mode it's possible to move between the two months. |
-| <kbd>Down Arrow</kbd>  | Go to the same day in the next week (eg. from Monday to next Monday).<br/>In `wide` mode it's possible to move between the two months.         |
-| <kbd>Home</kbd>        | Go to the first day of the month.                                                                                                              |
-| <kbd>End</kbd>         | Go to the last day of the month.                                                                                                               |
-| <kbd>Page Up</kbd>     | Go to the same day in the first week (eg. from Monday to the first Monday of the month).                                                       |
-| <kbd>Page Down</kbd>   | Go to the same day in the last week (eg. from Monday to the last Monday of the month).                                                         |
+| Keyboard               | Action                                                                                   |
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| <kbd>Left Arrow</kbd>  | Go to previous day.                                                                      |
+| <kbd>Right Arrow</kbd> | Go to next day.                                                                          |
+| <kbd>Up Arrow</kbd>    | Go to the same day in the previous week (eg. from Monday to previous Monday).            |
+| <kbd>Down Arrow</kbd>  | Go to the same day in the next week (eg. from Monday to next Monday).                    |
+| <kbd>Home</kbd>        | Go to the first day of the month.                                                        |
+| <kbd>End</kbd>         | Go to the last day of the month.                                                         |
+| <kbd>Page Up</kbd>     | Go to the same day in the first week (eg. from Monday to the first Monday of the month). |
+| <kbd>Page Down</kbd>   | Go to the same day in the last week (eg. from Monday to the last Monday of the month).   |
 
 ### Vertical orientation
 
-| Keyboard               | Action                                                                                                                                 |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| <kbd>Left Arrow</kbd>  | Go to the same day in the next week (eg. from Monday to next Monday).<br/>In `wide` mode it's possible to move between the two months. |
-| <kbd>Right Arrow</kbd> | Go to the same day in the next week (eg. from Monday to next Monday).<br/>In `wide` mode it's possible to move between the two months. |
-| <kbd>Up Arrow</kbd>    | Go to previous day.                                                                                                                    |
-| <kbd>Down Arrow</kbd>  | Go to next day.                                                                                                                        |
-| <kbd>Home</kbd>        | Go to the first day of the month.                                                                                                      |
-| <kbd>End</kbd>         | Go to the last day of the month.                                                                                                       |
-| <kbd>Page Up</kbd>     | Go to the first day of the week (eg. from any day to Monday of the same week).                                                         |
-| <kbd>Page Down</kbd>   | Go to the last day of the week (eg. from any day to Sunday of the same week).                                                          |
+| Keyboard               | Action                                                                         |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| <kbd>Left Arrow</kbd>  | Go to the same day in the next week (eg. from Monday to next Monday).          |
+| <kbd>Right Arrow</kbd> | Go to the same day in the next week (eg. from Monday to next Monday).          |
+| <kbd>Up Arrow</kbd>    | Go to previous day.                                                            |
+| <kbd>Down Arrow</kbd>  | Go to next day.                                                                |
+| <kbd>Home</kbd>        | Go to the first day of the month.                                              |
+| <kbd>End</kbd>         | Go to the last day of the month.                                               |
+| <kbd>Page Up</kbd>     | Go to the first day of the week (eg. from any day to Monday of the same week). |
+| <kbd>Page Down</kbd>   | Go to the last day of the week (eg. from any day to Sunday of the same week).  |
 
 ## Accessibility
 
@@ -264,29 +268,39 @@ For accessibility purposes, the component is rendered as a native table element 
 
 #### Properties
 
-| Name          | Attribute      | Privacy | Type                                     | Default        | Description                                                                                                                |
-| ------------- | -------------- | ------- | ---------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `dateFilter`  | `date-filter`  | public  | `((date: T \| null) => boolean) \| null` | `null`         | A function used to filter out dates.                                                                                       |
-| `max`         | `max`          | public  | `T \| null`                              | `null`         | The maximum valid date. Accepts a date object or null. Accepts an ISO8601 formatted string (e.g. 2024-12-24) as attribute. |
-| `min`         | `min`          | public  | `T \| null`                              | `null`         | The minimum valid date. Accepts a date object or null. Accepts an ISO8601 formatted string (e.g. 2024-12-24) as attribute. |
-| `multiple`    | `multiple`     | public  | `boolean`                                | `false`        | Whether the calendar allows for multiple date selection.                                                                   |
-| `orientation` | `orientation`  | public  | `'horizontal' \| 'vertical'`             | `'horizontal'` | The orientation of days in the calendar.                                                                                   |
-| `selected`    | `selected`     | public  | `T \| T[] \| null`                       | `null`         | The selected date: accepts a date object, or, if `multiple`, an array of dates.                                            |
-| `view`        | `view`         | public  | `'day' \| 'month' \| 'year'`             | `'day'`        | The initial view of the calendar which should be displayed on opening.                                                     |
-| `weekNumbers` | `week-numbers` | public  | `boolean`                                | `false`        | Whether it has to display the week numbers in addition to week days.                                                       |
-| `wide`        | `wide`         | public  | `boolean`                                | `false`        | If set to true, two months are displayed                                                                                   |
+| Name                | Attribute      | Privacy | Type                                     | Default        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ------------------- | -------------- | ------- | ---------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `amount`            | `amount`       | public  | `number`                                 | `1`            |                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `dateFilter`        | `date-filter`  | public  | `((date: T \| null) => boolean) \| null` | `null`         | A function used to filter out dates.                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `form`              | -              | public  | `HTMLFormElement \| null`                |                | Returns the form owner of this element.                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `max`               | `max`          | public  | `T \| null`                              | `null`         | The maximum valid date. Accepts a date object or null. Accepts an ISO8601 formatted string (e.g. 2024-12-24) as attribute.                                                                                                                                                                                                                                                                                                                              |
+| `min`               | `min`          | public  | `T \| null`                              | `null`         | The minimum valid date. Accepts a date object or null. Accepts an ISO8601 formatted string (e.g. 2024-12-24) as attribute.                                                                                                                                                                                                                                                                                                                              |
+| `multiple`          | `multiple`     | public  | `boolean`                                | `false`        | Whether the calendar allows for multiple date selection.                                                                                                                                                                                                                                                                                                                                                                                                |
+| `name`              | `name`         | public  | `string`                                 |                | Name of the form element. Will be read from name attribute.                                                                                                                                                                                                                                                                                                                                                                                             |
+| `orientation`       | `orientation`  | public  | `'horizontal' \| 'vertical'`             | `'horizontal'` | The orientation of days in the calendar.                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `validationMessage` | -              | public  | `string`                                 |                | Returns the current error message, if available, which corresponds to the current validation state. Please note that only one message is returned at a time (e.g. if multiple validity states are invalid, only the chronologically first one is returned until it is fixed, at which point the next message might be returned, if it is still applicable). Also, a custom validity message (see below) has precedence over native validation messages. |
+| `validity`          | -              | public  | `ValidityState`                          |                | Returns the ValidityState object for this element.                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `value`             | `value`        | public  | `T \| T[] \| null`                       | `null`         | The selected date: accepts a date object, or, if `multiple`, an array of dates.                                                                                                                                                                                                                                                                                                                                                                         |
+| `view`              | `view`         | public  | `'day' \| 'month' \| 'year'`             | `'day'`        | The initial view of the calendar which should be displayed on opening.                                                                                                                                                                                                                                                                                                                                                                                  |
+| `weekNumbers`       | `week-numbers` | public  | `boolean`                                | `false`        | Whether it has to display the week numbers in addition to week days.                                                                                                                                                                                                                                                                                                                                                                                    |
+| `willValidate`      | -              | public  | `boolean`                                |                | Returns true if this element will be validated when the form is submitted; false otherwise.                                                                                                                                                                                                                                                                                                                                                             |
 
 #### Methods
 
-| Name            | Privacy | Description                                                         | Parameters | Return | Inherited From |
-| --------------- | ------- | ------------------------------------------------------------------- | ---------- | ------ | -------------- |
-| `resetPosition` | public  | Resets the active month according to the new state of the calendar. |            | `void` |                |
+| Name                | Privacy | Description                                                                                                                                                                                | Parameters        | Return    | Inherited From         |
+| ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------- | --------- | ---------------------- |
+| `checkValidity`     | public  | Returns true if this element has no validity problems; false otherwise. Fires an invalid event at the element in the latter case.                                                          |                   | `boolean` | SbbFormAssociatedMixin |
+| `reportValidity`    | public  | Returns true if this element has no validity problems; otherwise, returns false, fires an invalid event at the element, and (if the event isn't canceled) reports the problem to the user. |                   | `boolean` | SbbFormAssociatedMixin |
+| `resetPosition`     | public  | Resets the active month according to the new state of the calendar.                                                                                                                        |                   | `void`    |                        |
+| `setCustomValidity` | public  | Sets the custom validity message for this element. Use the empty string to indicate that the element does not have a custom validity error.                                                | `message: string` | `void`    | SbbFormAssociatedMixin |
 
 #### Events
 
 | Name           | Type                      | Description                                                                                     | Inherited From |
 | -------------- | ------------------------- | ----------------------------------------------------------------------------------------------- | -------------- |
+| `change`       | `Event`                   | Event emitted on user selection.                                                                |                |
 | `dateselected` | `SbbDateSelectedEvent<T>` | Event emitted on date selection.                                                                |                |
+| `input`        | `InputEvent`              | Event emitted on user selection.                                                                |                |
 | `monthchange`  | `SbbMonthChangeEvent`     | Emits when the month changes. The `range` property contains the days array of the chosen month. |                |
 
 #### Slots

--- a/src/elements/core/decorators/id-reference.ts
+++ b/src/elements/core/decorators/id-reference.ts
@@ -149,6 +149,7 @@ export const idReference = <C extends Interface<ReactiveElement>, V>() => {
                   ? `#${value.id}`
                   : value.classList.value
                       .split(' ')
+                      .filter((c) => !!c)
                       .map((c) => `.${c}`)
                       .join('');
                 console.warn(

--- a/src/elements/core/i18n/i18n.ts
+++ b/src/elements/core/i18n/i18n.ts
@@ -515,10 +515,10 @@ export const i18nYearMonthSelection: Record<string, string> = {
 };
 
 export const i18nCalendarDateSelection: Record<string, string> = {
-  de: 'Datum auswählen',
-  en: 'Choose date',
-  fr: 'Choisir une date',
-  it: 'Seleziona una data',
+  de: 'Wechsel zur Datumsauswahl',
+  en: 'Change to date selection',
+  fr: 'Passer à la sélection de date',
+  it: 'Passare alla selezione della data',
 };
 
 export const i18nNextYearRange = (yearRange: number): Record<string, string> => ({

--- a/src/elements/core/styles/_theme.scss
+++ b/src/elements/core/styles/_theme.scss
@@ -279,6 +279,7 @@ $theme: 'standard' !default;
     @include sbb-css-tokens.forced-colors;
     @include alert.forced-colors;
     @include breadcrumb.forced-colors;
+    @include calendar.forced-colors;
     @include card.forced-colors;
     @include expansion-panel.forced-colors;
     @include form-field.forced-colors;

--- a/src/elements/datepicker/datepicker/datepicker.component.ts
+++ b/src/elements/datepicker/datepicker/datepicker.component.ts
@@ -164,7 +164,7 @@ export class SbbDatepickerElement<T = Date>
           if (this.input) {
             this.input.valueAsDate = value;
             this.input.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }));
-            this.input.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+            this.input.dispatchEvent(new Event('change', { bubbles: true }));
             // Emit blur event when value is changed programmatically to notify
             // frameworks that rely on that event to update form status.
             this.input.dispatchEvent(new Event('blur', { composed: true }));

--- a/src/elements/datepicker/datepicker/datepicker.component.ts
+++ b/src/elements/datepicker/datepicker/datepicker.component.ts
@@ -7,9 +7,8 @@ import {
   type PropertyValues,
   type TemplateResult,
 } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 
-import type { SbbDateSelectedEvent } from '../../calendar.pure.ts';
 import { SbbCalendarElement } from '../../calendar.pure.ts';
 import {
   type DateAdapter,
@@ -20,6 +19,8 @@ import {
   readConfig,
   type SbbElementType,
   SbbLanguageController,
+  SbbMediaMatcherController,
+  SbbMediaQueryBreakpointLargeAndAbove,
   SbbUpdateSchedulerMixin,
   screenReaderOnlyStyles,
 } from '../../core.ts';
@@ -64,6 +65,12 @@ export class SbbDatepickerElement<T = Date>
   private _dateAdapter: DateAdapter<T> = readConfig().datetime?.dateAdapter ?? defaultDateAdapter;
   private _language = new SbbLanguageController(this);
   private _ready = false;
+  private _mediaMatcher = new SbbMediaMatcherController(this, {
+    [SbbMediaQueryBreakpointLargeAndAbove]: (m) => (this._isBreakpointLargeOrAbove = m),
+  });
+
+  @state() private accessor _isBreakpointLargeOrAbove: boolean =
+    this._mediaMatcher.matches(SbbMediaQueryBreakpointLargeAndAbove) ?? false;
 
   public constructor() {
     super();
@@ -150,11 +157,12 @@ export class SbbDatepickerElement<T = Date>
         .min=${this.input?.min ?? null}
         .max=${this.input?.max ?? null}
         .dateFilter=${this.input?.dateFilter ?? null}
-        .selected=${this.input?.valueAsDate ?? null}
-        ?wide=${this.wide}
-        @dateselected=${(d: SbbDateSelectedEvent<T>) => {
+        .value=${this.input?.valueAsDate ?? null}
+        .amount=${this.wide && this._isBreakpointLargeOrAbove ? 2 : 1}
+        @change=${(event: Event) => {
+          const value = (event.target as SbbCalendarElement<T>).value as T | null;
           if (this.input) {
-            this.input.valueAsDate = d.dateSelected as T;
+            this.input.valueAsDate = value;
             this.input.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }));
             this.input.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
             // Emit blur event when value is changed programmatically to notify

--- a/src/elements/datepicker/datepicker/datepicker.spec.ts
+++ b/src/elements/datepicker/datepicker/datepicker.spec.ts
@@ -9,7 +9,6 @@ import {
   type SbbCalendarDayElement,
   type SbbCalendarYearElement,
   type SbbCalendarElement,
-  SbbDateSelectedEvent,
 } from '../../calendar.ts';
 import {
   fixture,
@@ -173,11 +172,12 @@ describe(`sbb-datepicker`, () => {
     expect(datepicker).to.match(':state(state-opened)');
 
     const calendar = datepicker.shadowRoot!.querySelector('sbb-calendar')!;
-    calendar.dispatchEvent(new SbbDateSelectedEvent(new Date('2022-01-01')));
+    calendar.value = new Date(2022, 0, 1, 0, 0, 0, 0);
+    calendar.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
     await waitForLitRender(datepicker);
 
     expect(input.value).to.be.equal('Sa, 01.01.2022');
-    expect(defaultDateAdapter.toIso8601((calendar.selected as Date)!)).to.be.equal('2022-01-01');
+    expect(defaultDateAdapter.toIso8601((calendar.value as Date)!)).to.be.equal('2022-01-01');
     expect(changeSpy.count).to.be.equal(1);
     expect(blurSpy.count).to.be.equal(1);
 
@@ -188,7 +188,7 @@ describe(`sbb-datepicker`, () => {
     await waitForLitRender(toggle);
 
     expect(input.value).to.be.equal('');
-    expect(calendar.selected).to.be.null;
+    expect(calendar.value).to.be.null;
   });
 
   it('handles view property', async function (this: Context) {
@@ -217,7 +217,7 @@ describe(`sbb-datepicker`, () => {
 
     // Year view should be active
     const calendar = datepicker.shadowRoot!.querySelector('sbb-calendar')!;
-    expect(calendar.shadowRoot!.querySelector('.sbb-calendar__table-year-view')!).not.to.be.null;
+    expect(calendar.shadowRoot!.querySelector('.sbb-calendar__year-view')!).not.to.be.null;
 
     // Select year
     calendar.shadowRoot!.querySelectorAll('sbb-calendar-year')[4].click();
@@ -235,17 +235,20 @@ describe(`sbb-datepicker`, () => {
     await waitForCondition(() => !calendar.matches(':state(transition)'));
 
     // Expect selected date and closed calendar
-    expect(defaultDateAdapter.toIso8601((calendar.selected as Date)!)).to.be.equal('2020-05-05');
+    expect(defaultDateAdapter.toIso8601((calendar.value as Date)!)).to.be.equal('2020-05-05');
     await closeSpy.calledOnce();
 
     // Open again
     datepicker.open();
+    await waitForLitRender(root);
     await openSpy.calledTimes(2);
 
     // Should open with year view again
-    expect(calendar.shadowRoot!.querySelector('.sbb-calendar__table-year-view')!).not.to.be.null;
+    expect(calendar.shadowRoot!.querySelector('.sbb-calendar__year-view')!).not.to.be.null;
     expect(
-      calendar.shadowRoot!.querySelector<SbbCalendarYearElement>(':state(selected)')!.value,
+      calendar.shadowRoot!.querySelector<SbbCalendarYearElement>(
+        '.sbb-calendar__year-view :state(selected)',
+      )!.value,
     ).to.be.equal('2020');
 
     // Close again
@@ -261,10 +264,10 @@ describe(`sbb-datepicker`, () => {
     await openSpy.calledTimes(3);
 
     // Month view should be active and correct year preselected
-    expect(calendar.shadowRoot!.querySelector('.sbb-calendar__table-month-view')!).not.to.be.null;
+    expect(calendar.shadowRoot!.querySelector('.sbb-calendar__month-view')!).not.to.be.null;
     expect(
       calendar
-        .shadowRoot!.querySelector('.sbb-calendar__controls-change-date')!
+        .shadowRoot!.querySelector('.sbb-calendar__month-view .sbb-calendar__table-header span')!
         .textContent!.trim(),
     ).to.be.equal('2020');
   });
@@ -290,16 +293,16 @@ describe(`sbb-datepicker`, () => {
     await aTimeout(0);
 
     const calendar = datepicker.shadowRoot!.querySelector<SbbCalendarElement>('sbb-calendar')!;
-    expect(calendar.wide, 'calendar.wide').to.be.false;
+    expect(calendar.amount, 'calendar.amount').to.be.equal(1);
     expect(
-      calendar.shadowRoot!.querySelectorAll('.sbb-calendar__controls-change-date')!.length,
+      calendar.shadowRoot!.querySelectorAll('.sbb-calendar__table-wrapper')!.length,
     ).to.be.equal(1);
 
     datepicker.wide = true;
     await waitForLitRender(element);
-    expect(calendar.wide, 'calendar.wide').to.be.true;
+    expect(calendar.amount, 'calendar.amount').to.be.equal(2);
     expect(
-      calendar.shadowRoot!.querySelectorAll('.sbb-calendar__controls-change-date')!.length,
+      calendar.shadowRoot!.querySelectorAll('.sbb-calendar__table-wrapper')!.length,
     ).to.be.equal(2);
 
     datepicker.input!.dateFilter = (d) => d?.getFullYear() !== 2022;
@@ -451,7 +454,7 @@ describe(`sbb-datepicker`, () => {
     });
 
     it('updates trigger connected by id', async () => {
-      input.id = '';
+      input.removeAttribute('id');
       await waitForLitRender(root);
       expect(element.input).to.be.equal(null);
 
@@ -461,10 +464,11 @@ describe(`sbb-datepicker`, () => {
     });
 
     it('accepts trigger as HTML Element', async () => {
-      input.id = '';
+      input.removeAttribute('id');
       await waitForLitRender(element);
       expect(element.input).to.be.equal(null);
 
+      element.removeAttribute('input');
       element.input = input;
       await waitForLitRender(element);
       expect(element.input).to.be.equal(input);

--- a/src/elements/datepicker/datepicker/datepicker.visual.spec.ts
+++ b/src/elements/datepicker/datepicker/datepicker.visual.spec.ts
@@ -95,6 +95,31 @@ describe(`sbb-datepicker`, () => {
       );
     });
 
+    it(
+      'wide',
+      visualDiffDefault.with(async (setup) => {
+        await setup.withFixture(
+          html`
+            <div style="display: flex; gap: 0.25rem;">
+              <sbb-datepicker-previous-day input="datepicker-input"></sbb-datepicker-previous-day>
+              <sbb-date-input value="12.02.2023" id="datepicker-input"></sbb-date-input>
+              <sbb-datepicker-next-day input="datepicker-input"></sbb-datepicker-next-day>
+              <sbb-datepicker-toggle
+                input="datepicker-input"
+                datepicker="datepicker"
+              ></sbb-datepicker-toggle>
+              <sbb-datepicker id="datepicker" input="datepicker-input" wide></sbb-datepicker>
+            </div>
+          `,
+          { minHeight: '600px' },
+        );
+
+        setup.withPostSetupAction(() => {
+          setup.snapshotElement.querySelector<SbbDatepickerElement>('sbb-datepicker')!.open();
+        });
+      }),
+    );
+
     for (const size of sizes) {
       it(
         `size=${size}`,


### PR DESCRIPTION
The calendar has been refactored to display multiple months. With this refactoring it has also been implemented as a form associated component.
The functionality has been slightly changed in that week number or week day button presses no longer select across months.

Closes #4020

BREAKING CHANGE: The `sbb-calendar` `wide` property has been replaced with the `amount` property and the `selected` property has been replaced with the `value` property.