### PR TITLE
fix: resolve title mixin naming conflict

### DIFF
--- a/src/elements/core/styles/mixins/_typo.scss
+++ b/src/elements/core/styles/mixins/_typo.scss
@@ -2,112 +2,108 @@
 // Typo: Title Style Mixins
 // ----------------------------------------------------------------------------------------------------
 
-@mixin title-rules {
+@mixin heading-rules {
   font-family: var(--sbb-typo-font-family);
   font-weight: bold;
   letter-spacing: var(--sbb-typo-letter-spacing-heading);
   line-height: var(--sbb-typo-line-height-heading);
 }
 
-@mixin title--level-1 {
+@mixin heading--level-1 {
   font-size: var(--sbb-heading-font-size-1);
 }
 
-@mixin title--level-1-spacing {
+@mixin heading--level-1-spacing {
   margin-block: var(--sbb-heading-margin-block-1);
 }
 
-@mixin title--level-2 {
+@mixin heading--level-2 {
   font-size: var(--sbb-heading-font-size-2);
 }
 
-@mixin title--level-2-spacing {
+@mixin heading--level-2-spacing {
   margin-block: var(--sbb-heading-margin-block-2);
 }
 
-@mixin title--level-3 {
+@mixin heading--level-3 {
   font-size: var(--sbb-heading-font-size-3);
 }
 
-@mixin title--level-3-spacing {
+@mixin heading--level-3-spacing {
   margin-block: var(--sbb-heading-margin-block-3);
 }
 
-@mixin title--level-4 {
+@mixin heading--level-4 {
   font-size: var(--sbb-heading-font-size-4);
 }
 
-@mixin title--level-4-spacing {
+@mixin heading--level-4-spacing {
   margin-block: var(--sbb-heading-margin-block-4);
 }
 
-@mixin title--level-5 {
+@mixin heading--level-5 {
   font-size: var(--sbb-heading-font-size-5);
 }
 
-@mixin title--level-5-spacing {
+@mixin heading--level-5-spacing {
   margin-block: var(--sbb-heading-margin-block-5);
 }
 
-@mixin title--level-6 {
+@mixin heading--level-6 {
   font-size: var(--sbb-heading-font-size-6);
   line-height: var(--sbb-typo-line-height-text);
 }
 
-@mixin title--level-6-spacing {
+@mixin heading--level-6-spacing {
   margin-block: var(--sbb-heading-margin-block-6);
 }
 
-@mixin title-1($exclude-spacing: false) {
-  @include title--level-1;
+@mixin heading-1($exclude-spacing: false) {
+  @include heading--level-1;
   @if not($exclude-spacing) {
-    @include title--level-1-spacing;
+    @include heading--level-1-spacing;
   }
-  @include title-rules;
+  @include heading-rules;
 }
 
-@mixin title-2($exclude-spacing: false) {
-  @include title--level-2;
+@mixin heading-2($exclude-spacing: false) {
+  @include heading--level-2;
   @if not($exclude-spacing) {
-    @include title--level-2-spacing;
+    @include heading--level-2-spacing;
   }
-  @include title-rules;
+  @include heading-rules;
 }
 
-@mixin title-3($exclude-spacing: false) {
-  @include title--level-3;
+@mixin heading-3($exclude-spacing: false) {
+  @include heading--level-3;
   @if not($exclude-spacing) {
-    @include title--level-3-spacing;
+    @include heading--level-3-spacing;
   }
-  @include title-rules;
+  @include heading-rules;
 }
 
-@mixin title-4($exclude-spacing: false) {
-  @include title--level-4;
+@mixin heading-4($exclude-spacing: false) {
+  @include heading--level-4;
   @if not($exclude-spacing) {
-    @include title--level-4-spacing;
+    @include heading--level-4-spacing;
   }
-  @include title-rules;
+  @include heading-rules;
 }
 
-@mixin title-5($exclude-spacing: false) {
-  @include title--level-5;
+@mixin heading-5($exclude-spacing: false) {
+  @include heading--level-5;
   @if not($exclude-spacing) {
-    @include title--level-5-spacing;
+    @include heading--level-5-spacing;
   }
-  @include title-rules;
+  @include heading-rules;
 }
 
-@mixin title-6($exclude-spacing: false) {
-  @include title--level-6;
+@mixin heading-6($exclude-spacing: false) {
+  @include heading--level-6;
   @if not($exclude-spacing) {
-    @include title--level-6-spacing;
+    @include heading--level-6-spacing;
   }
-  @include title-rules;
-}
-
-@mixin title--negative {
-  --sbb-title-color: var(--sbb-color-3-negative);
+  @include heading-rules;
 }
 
 // ----------------------------------------------------------------------------------------------------

--- a/src/elements/dialog/dialog-title/dialog-title.scss
+++ b/src/elements/dialog/dialog-title/dialog-title.scss
@@ -9,7 +9,7 @@
 }
 
 :host([negative]) {
-  @include sbb.title--negative;
+  --sbb-title-color: var(--sbb-color-3-negative);
 }
 
 // Shadow below the title bar

--- a/src/elements/journey-header/journey-header.scss
+++ b/src/elements/journey-header/journey-header.scss
@@ -17,7 +17,7 @@
 }
 
 :host([negative]) {
-  @include sbb.title--negative;
+  --sbb-title-color: var(--sbb-color-3-negative);
 }
 
 sbb-icon {

--- a/src/elements/title/title-common.scss
+++ b/src/elements/title/title-common.scss
@@ -7,7 +7,7 @@
   line-height: var(--sbb-typo-line-height-heading);
   color: var(--sbb-title-color);
 
-  @include sbb.title--level-1;
+  @include sbb.heading--level-1;
 }
 
 :host([id]) {
@@ -15,21 +15,21 @@
 }
 
 :host(:where([level='2']:not([visual-level]), [visual-level='2'])) {
-  @include sbb.title--level-2;
+  @include sbb.heading--level-2;
 }
 
 :host(:where([level='3']:not([visual-level]), [visual-level='3'])) {
-  @include sbb.title--level-3;
+  @include sbb.heading--level-3;
 }
 
 :host(:where([level='4']:not([visual-level]), [visual-level='4'])) {
-  @include sbb.title--level-4;
+  @include sbb.heading--level-4;
 }
 
 :host(:where([level='5']:not([visual-level]), [visual-level='5'])) {
-  @include sbb.title--level-5;
+  @include sbb.heading--level-5;
 }
 
 :host(:where([level='6']:not([visual-level]), [visual-level='6'])) {
-  @include sbb.title--level-6;
+  @include sbb.heading--level-6;
 }

--- a/src/elements/title/title.scss
+++ b/src/elements/title/title.scss
@@ -3,29 +3,29 @@
 :host {
   margin-block: var(--sbb-title-margin-block, 0);
 
-  @include sbb.title--level-1-spacing;
+  @include sbb.heading--level-1-spacing;
 }
 
 :host([negative]) {
-  @include sbb.title--negative;
+  --sbb-title-color: var(--sbb-color-3-negative);
 }
 
 :host(:where([level='2']:not([visual-level]), [visual-level='2'])) {
-  @include sbb.title--level-2-spacing;
+  @include sbb.heading--level-2-spacing;
 }
 
 :host(:where([level='3']:not([visual-level]), [visual-level='3'])) {
-  @include sbb.title--level-3-spacing;
+  @include sbb.heading--level-3-spacing;
 }
 
 :host(:where([level='4']:not([visual-level]), [visual-level='4'])) {
-  @include sbb.title--level-4-spacing;
+  @include sbb.heading--level-4-spacing;
 }
 
 :host(:where([level='5']:not([visual-level]), [visual-level='5'])) {
-  @include sbb.title--level-5-spacing;
+  @include sbb.heading--level-5-spacing;
 }
 
 :host(:where([level='6']:not([visual-level]), [visual-level='6'])) {
-  @include sbb.title--level-6-spacing;
+  @include sbb.heading--level-6-spacing;
 }


### PR DESCRIPTION
BREAKING CHANGE: `title-*` Sass mixins were renamed to `heading-*`