### PR TITLE
fix: ensure stable state for inputs while editing

### DIFF
--- a/src/elements/core/mixins/form-associated-input-mixin.ts
+++ b/src/elements/core/mixins/form-associated-input-mixin.ts
@@ -45,6 +45,7 @@ export declare abstract class SbbFormAssociatedInputMixinType extends SbbRequire
   public formResetCallback(): void;
   public formStateRestoreCallback(state: FormRestoreState | null, reason: FormRestoreReason): void;
 
+  protected isSelected(): boolean;
   protected preparePastedText(text: string): string;
   protected language: SbbLanguageController;
 }
@@ -395,6 +396,14 @@ export const SbbFormAssociatedInputMixin = <
       } else {
         this.removeValidityFlag('valueMissing');
       }
+    }
+
+    protected isSelected(): boolean {
+      if (isServer) {
+        return false;
+      }
+      const selection = window.getSelection();
+      return !!selection && selection.rangeCount > 0 && this.contains(selection.anchorNode);
     }
 
     protected preparePastedText(text: string): string {

--- a/src/elements/date-input/date-input.component.ts
+++ b/src/elements/date-input/date-input.component.ts
@@ -51,7 +51,7 @@ export class SbbDateInputElement<T = Date> extends SbbFormAssociatedInputMixin(S
     this._tryParseValue(value);
     // As long as this element has focus we delay automatically updating
     // the value with the formatted string of the parsed date.
-    if (!isServer && !this.matches(':focus') && this.valueAsDate !== null) {
+    if (!isServer && !this.isSelected() && this.valueAsDate !== null) {
       value = this._formatDate();
     }
     super.value = value;
@@ -64,7 +64,15 @@ export class SbbDateInputElement<T = Date> extends SbbFormAssociatedInputMixin(S
   @property({ attribute: false })
   public set valueAsDate(value: T | null) {
     value = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
-    if (!value) {
+    if (
+      this.isSelected() &&
+      (value === null || this._dateAdapter.sameDate(value, this._dateAdapter.parse(this.value)))
+    ) {
+      // Do nothing, as the user is currently editing the value and the parsed
+      // date is the same as the current value.
+      // This can also happen with Angular Forms Signals, as it currently
+      // continuously invokes writeValue, which assigns to this setter.
+    } else if (!value) {
       this._valueAsDate = null;
       this._valueCache = ['', null];
       this.value = '';

--- a/src/elements/date-input/date-input.spec.ts
+++ b/src/elements/date-input/date-input.spec.ts
@@ -115,6 +115,21 @@ describe('sbb-date-input', () => {
     expect(element.value).to.be.equal('undefined');
   });
 
+  it('should not update value while editing', async () => {
+    element = await fixture(html`<sbb-date-input></sbb-date-input>`);
+    element.focus();
+    typeInElement(element, '1.1.2024');
+    element.valueAsDate = new Date(2024, 0, 1);
+    expect(element.value).to.be.equal('1.1.2024');
+  });
+
+  it('should update value while not editing', async () => {
+    element = await fixture(html`<sbb-date-input></sbb-date-input>`);
+    element.value = '1.1.2024';
+    element.valueAsDate = new Date(2024, 0, 1);
+    expect(element.value).to.be.equal('Mo, 01.01.2024');
+  });
+
   describe('with no value', () => {
     beforeEach(async () => {
       element = await fixture(html`<sbb-date-input></sbb-date-input>`);

--- a/src/elements/time-input/time-input.component.ts
+++ b/src/elements/time-input/time-input.component.ts
@@ -43,7 +43,7 @@ export class SbbTimeInputElement extends SbbFormAssociatedInputMixin(SbbElement)
     this._tryParseValue(value);
     // As long as this element has focus we delay automatically updating
     // the value with the formatted string of the parsed date.
-    if (!isServer && !this.matches(':focus') && this.valueAsDate !== null) {
+    if (!isServer && !this.isSelected() && this.valueAsDate !== null) {
       value = this._formatTime();
     }
     super.value = value;
@@ -54,12 +54,18 @@ export class SbbTimeInputElement extends SbbFormAssociatedInputMixin(SbbElement)
 
   /** Formats the current input's value as date. */
   @property({ attribute: false })
-  public set valueAsDate(date: Date | null) {
-    if (date instanceof Date && !isNaN(date.valueOf())) {
-      this._valueAsTime = {
-        hours: date.getHours(),
-        minutes: date.getMinutes(),
-      };
+  public set valueAsDate(value: Date | null) {
+    const time = this._toTime(value);
+    if (
+      this.isSelected() &&
+      (time === null || this._isSameTime(time, this._parseValue(this.value)))
+    ) {
+      // Do nothing, as the user is currently editing the value and the parsed
+      // time is the same as the current value.
+      // This can also happen with Angular Forms Signals, as it currently
+      // continuously invokes writeValue, which assigns to this setter.
+    } else if (time) {
+      this._valueAsTime = time;
       const formattedValue = this._formatTime();
       if (this.value !== formattedValue) {
         this.value = formattedValue;
@@ -136,6 +142,19 @@ export class SbbTimeInputElement extends SbbFormAssociatedInputMixin(SbbElement)
     }
 
     return null;
+  }
+
+  private _toTime(value: Date | null): Time | null {
+    return value instanceof Date && !isNaN(value.valueOf())
+      ? { hours: value.getHours(), minutes: value.getMinutes() }
+      : null;
+  }
+
+  private _isSameTime(time1: Time | null, time2: Time | null): boolean {
+    return !!(
+      time1 == time2 ||
+      (time1 && time2 && time1.hours === time2.hours && time1.minutes === time2.minutes)
+    );
   }
 
   private _updateValueDateFormat(): void {

--- a/src/elements/time-input/time-input.spec.ts
+++ b/src/elements/time-input/time-input.spec.ts
@@ -200,6 +200,54 @@ describe(`sbb-time-input`, () => {
     expect(new Date(dateCalculated).getMinutes()).to.be.equal(date.getMinutes());
   });
 
+  it('should support asynchronously adding input by element reference', async () => {
+    const root = await fixture(html`
+      <div>
+        <sbb-time-input></sbb-time-input>
+      </div>
+    `);
+    element = root.querySelector<SbbTimeInputElement>('sbb-time-input')!;
+    element.valueAsDate = new Date('2023-01-01T15:00:00');
+    await waitForLitRender(element);
+
+    expect(element.value).to.be.equal('15:00');
+  });
+
+  it('should support asynchronously adding input by id', async () => {
+    const root = await fixture(html`
+      <div>
+        <sbb-time-input id="time-input"></sbb-time-input>
+        <input id="input-2" />
+      </div>
+    `);
+    element = root.querySelector<SbbTimeInputElement>('sbb-time-input')!;
+
+    element.setAttribute('input', 'input-2');
+    element.valueAsDate = new Date('2023-01-01T15:00:00');
+    await waitForLitRender(element);
+
+    expect(element.value).to.be.equal('15:00');
+  });
+
+  it('should not update value while editing', async () => {
+    element.focus();
+    typeInElement(element, '1:1');
+    const sameTime = new Date(0);
+    sameTime.setHours(1);
+    sameTime.setMinutes(1);
+    element.valueAsDate = sameTime;
+    expect(element.value).to.be.equal('1:1');
+  });
+
+  it('should update value while not editing', async () => {
+    element.value = '1:1';
+    const sameTime = new Date(0);
+    sameTime.setHours(1);
+    sameTime.setMinutes(1);
+    element.valueAsDate = sameTime;
+    expect(element.value).to.be.equal('01:01');
+  });
+
   describe('form field integration', () => {
     let formField: SbbFormFieldElement;
 
@@ -343,34 +391,5 @@ describe(`sbb-time-input`, () => {
       expect(element).not.to.match(':disabled');
       expect(element).not.to.have.attribute('disabled');
     });
-  });
-
-  it('should support asynchronously adding input by element reference', async () => {
-    const root = await fixture(html`
-      <div>
-        <sbb-time-input></sbb-time-input>
-      </div>
-    `);
-    element = root.querySelector<SbbTimeInputElement>('sbb-time-input')!;
-    element.valueAsDate = new Date('2023-01-01T15:00:00');
-    await waitForLitRender(element);
-
-    expect(element.value).to.be.equal('15:00');
-  });
-
-  it('should support asynchronously adding input by id', async () => {
-    const root = await fixture(html`
-      <div>
-        <sbb-time-input id="time-input"></sbb-time-input>
-        <input id="input-2" />
-      </div>
-    `);
-    element = root.querySelector<SbbTimeInputElement>('sbb-time-input')!;
-
-    element.setAttribute('input', 'input-2');
-    element.valueAsDate = new Date('2023-01-01T15:00:00');
-    await waitForLitRender(element);
-
-    expect(element.value).to.be.equal('15:00');
   });
 });


### PR DESCRIPTION
Currently the date and time input completely reset the value, if an assignment to valueAsDate is performed. This interrupts the typing if done during editing. This is currently an issue with the upcoming Angular Forms Signals, which continuously call writeValue and causes this problem.

Relates to sbb-design-systems/lyne-angular#316