### PR TITLE
build: enforce snapshot file formatting

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import { globSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -12,19 +12,14 @@ import { configs } from 'typescript-eslint';
 
 import * as eslintPluginLyne from './tools/eslint/index.ts';
 
-const ignores = [
-  'dist/**/*',
-  'coverage/**/*',
-  'tools/generate-component/**/*',
-  '**/__snapshots__/**/*',
-];
+const ignores = ['dist/**/*', 'coverage/**/*', 'tools/generate-component/**/*'];
 
 const sourceFiles = globSync(
   join(fileURLToPath(import.meta.url), '../src/{elements,elements-experimental}/**/*.ts'),
-).filter((file) =>
+).filter((file: string) =>
   ['spec', 'stories', 'private'].every((suffix) => !file.endsWith(`.${suffix}.ts`)),
 );
-const entrypoints = sourceFiles.filter((file) =>
+const entrypoints = sourceFiles.filter((file: string) =>
   readFileSync(file, 'utf-8').includes('@entrypoint'),
 );
 
@@ -142,7 +137,7 @@ export default [
             {
               target: sourceFiles,
               from: entrypoints.filter(
-                (file) => !file.endsWith('.pure.ts') && !file.endsWith('/core.ts'),
+                (file: string) => !file.endsWith('.pure.ts') && !file.endsWith('/core.ts'),
               ),
             },
           ],
@@ -213,6 +208,13 @@ export default [
       'import-x/default': 'off',
       'import-x/no-named-as-default': 'off',
       'import-x/no-named-as-default-member': 'off',
+    },
+  },
+  {
+    files: ['**/__snapshots__/**/*.js'],
+    rules: {
+      'lyne/snapshot-format-rule': 'error',
+      'no-irregular-whitespace': 'off',
     },
   },
   eslintConfigPrettier,

--- a/tools/eslint/index.ts
+++ b/tools/eslint/index.ts
@@ -20,6 +20,7 @@ export const rules = (
       'property-type-rule',
       'pure-export-rule',
       'relative-imports-rule',
+      'snapshot-format-rule',
       'test-describe-title-rule',
       'test-tabkey-rule',
     ].map((name) =>

--- a/tools/eslint/snapshot-format-rule.ts
+++ b/tools/eslint/snapshot-format-rule.ts
@@ -1,0 +1,52 @@
+import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+
+export default ESLintUtils.RuleCreator.withoutDocs({
+  create(context) {
+    return {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      AssignmentExpression(node: TSESTree.AssignmentExpression) {
+        if (node.right.type !== 'TemplateLiteral' || node.left.type !== 'MemberExpression') {
+          return;
+        }
+
+        const object = node.left.object;
+        if (object.type !== 'Identifier' || object.name !== 'snapshots') {
+          return;
+        }
+
+        // Check that there is a space directly after `=`.
+        const sourceCode = context.sourceCode;
+        const operatorToken = sourceCode.getTokenAfter(node.left);
+        const backtickToken = sourceCode.getFirstToken(node.right);
+
+        if (!operatorToken || operatorToken.value !== '=' || !backtickToken) {
+          return;
+        }
+
+        const textBetween = sourceCode.text.slice(operatorToken.range[1], backtickToken.range[0]);
+
+        if (!textBetween.startsWith(' ')) {
+          context.report({
+            node,
+            messageId: 'snapshotFormatting',
+            fix: (fixer) => fixer.insertTextAfterRange(operatorToken.range, ' '),
+          });
+        }
+      },
+    };
+  },
+  meta: {
+    docs: {
+      description:
+        'Snapshot assignments must have exactly one space between `=` and the template literal (i.e. `snapshots["..."] = \\`...\\`).',
+    },
+    messages: {
+      snapshotFormatting:
+        'Snapshot assignment must have exactly one space between `=` and the template literal.',
+    },
+    fixable: 'code',
+    type: 'layout',
+    schema: [],
+    hasSuggestions: false,
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,7 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitOverride": true,
 
-    "types": ["vite/client"],
+    "types": ["vite/client", "node"],
 
     "plugins": [
       {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,7 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitOverride": true,
 
-    "types": ["vite/client", "node"],
+    "types": ["vite/client"],
 
     "plugins": [
       {


### PR DESCRIPTION
This change helps to detect when IntelliJ accidentally did a wrong reformatting.