### PR TITLE
feat(calendar): add property `fixedMonth` to disable navigation

### DIFF
--- a/src/elements/calendar/calendar.stories.ts
+++ b/src/elements/calendar/calendar.stories.ts
@@ -439,6 +439,10 @@ export const CalendarEnhancedWideWeekNumbersMultiple: StoryObj = {
   },
 };
 
+export const CalendarFixedMonth: StoryObj = {
+  render: () => html`<sbb-calendar fixed-month="2023-08"></sbb-calendar>`,
+};
+
 const meta: Meta = {
   decorators: [withActions as Decorator],
   parameters: {

--- a/src/elements/calendar/calendar.stories.ts
+++ b/src/elements/calendar/calendar.stories.ts
@@ -440,7 +440,15 @@ export const CalendarEnhancedWideWeekNumbersMultiple: StoryObj = {
 };
 
 export const CalendarFixedMonth: StoryObj = {
-  render: () => html`<sbb-calendar fixed-month="2023-08"></sbb-calendar>`,
+  render: ({ amount }: Args) =>
+    html`<sbb-calendar
+      amount=${amount}
+      fixed-month="2023-08"
+      multiple
+      week-numbers
+    ></sbb-calendar>`,
+  argTypes: { amount },
+  args: { amount: 3 },
 };
 
 const meta: Meta = {

--- a/src/elements/calendar/calendar/calendar.component.ts
+++ b/src/elements/calendar/calendar/calendar.component.ts
@@ -223,6 +223,25 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
   @property({ attribute: 'date-filter' })
   public accessor dateFilter: ((date: T | null) => boolean) | null = null;
 
+  /**
+   * Set this with the format `YYYY-MM` to limit the calendar to a specific month,
+   * and prevent navigation to other months.
+   */
+  @forceType()
+  @property({ attribute: 'fixed-month' })
+  public set fixedMonth(value: string) {
+    const match = value ? value.match(/^(\d{4})-(\d{2})$/) : null;
+    this._fixedMonth = match
+      ? this._dateAdapter.createDate(Number(match[1]), Number(match[2]), 1)
+      : null;
+  }
+  public get fixedMonth(): string {
+    return this._fixedMonth
+      ? this._dateAdapter.toIso8601(this._fixedMonth).split('-').slice(0, 2).join('-')
+      : '';
+  }
+  private _fixedMonth: T | null = null;
+
   /** The orientation of days in the calendar. */
   @property({ reflect: true }) public accessor orientation: 'horizontal' | 'vertical' =
     'horizontal';
@@ -411,7 +430,11 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
       return;
     }
 
-    if (changedProperties.has('amount') || changedProperties.has('orientation')) {
+    if (
+      changedProperties.has('amount') ||
+      changedProperties.has('orientation') ||
+      changedProperties.has('fixedMonth')
+    ) {
       this.resetPosition();
     }
 
@@ -485,9 +508,10 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
       this._assignActiveDate(activeDate);
     }
 
+    const startDate = this._fixedMonth ?? this._activeDate;
     const amount = this.amount < 1 ? 1 : this.amount;
     this._weeks = Array.from({ length: amount }, (_, i) =>
-      this._createWeekRows(this._dateAdapter.addCalendarMonths(this._activeDate, i)),
+      this._createWeekRows(this._dateAdapter.addCalendarMonths(startDate, i)),
     );
     const dateFromFirstMonth = this._weeks[0][0][0].dateValue;
     this._firstVisibleDay = this._dateAdapter.toIso8601(
@@ -1527,28 +1551,30 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
   }
 
   private _createDayTableControls(monthLabel: string): TemplateResult[] {
-    return [
-      this._getArrow(
-        'left',
-        () => this._goToDifferentMonth(-1),
-        i18nPreviousMonth[this._language.current],
-        this._previousMonthDisabled(),
-      ),
-      this._getArrow(
-        'right',
-        () => this._goToDifferentMonth(1),
-        i18nNextMonth[this._language.current],
-        this._nextMonthDisabled(),
-      ),
-      this._getArrow(
-        'up',
-        () => {
-          this._resetFocus = true;
-          this._calendarView = 'year';
-        },
-        `${i18nYearMonthSelection[this._language.current]} ${monthLabel}`,
-      ),
-    ];
+    return this._fixedMonth
+      ? []
+      : [
+          this._getArrow(
+            'left',
+            () => this._goToDifferentMonth(-1),
+            i18nPreviousMonth[this._language.current],
+            this._previousMonthDisabled(),
+          ),
+          this._getArrow(
+            'right',
+            () => this._goToDifferentMonth(1),
+            i18nNextMonth[this._language.current],
+            this._nextMonthDisabled(),
+          ),
+          this._getArrow(
+            'up',
+            () => {
+              this._resetFocus = true;
+              this._calendarView = 'year';
+            },
+            `${i18nYearMonthSelection[this._language.current]} ${monthLabel}`,
+          ),
+        ];
   }
 
   /** Creates the cells for the daily view. */
@@ -1570,23 +1596,27 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
       <div class="sbb-calendar__table-wrapper sbb-calendar__month-view">
         <div class="sbb-calendar__table-header">
           <span>${this._chosenYear}</span>
-          ${this._getArrow(
-            'left',
-            () => this._goToDifferentYear(-1),
-            i18nPreviousYear[this._language.current],
-            this._previousYearDisabled(),
-          )}
-          ${this._getArrow(
-            'right',
-            () => this._goToDifferentYear(1),
-            i18nNextYear[this._language.current],
-            this._nextYearDisabled(),
-          )}
-          ${this._getArrow(
-            'down',
-            () => this._resetCalendarViewAndEmitMonthChange(),
-            i18nCalendarDateSelection[this._language.current],
-          )}
+          ${this._fixedMonth
+            ? []
+            : [
+                this._getArrow(
+                  'left',
+                  () => this._goToDifferentYear(-1),
+                  i18nPreviousYear[this._language.current],
+                  this._previousYearDisabled(),
+                ),
+                this._getArrow(
+                  'right',
+                  () => this._goToDifferentYear(1),
+                  i18nNextYear[this._language.current],
+                  this._nextYearDisabled(),
+                ),
+                this._getArrow(
+                  'down',
+                  () => this._resetCalendarViewAndEmitMonthChange(),
+                  i18nCalendarDateSelection[this._language.current],
+                ),
+              ]}
           <span class="sbb-screen-reader-only" role="status">${this._chosenYear}</span>
         </div>
         <table class="sbb-calendar__table">
@@ -1640,23 +1670,27 @@ export class SbbCalendarElement<T = Date> extends SbbFormAssociatedMixin(SbbElem
       <div class="sbb-calendar__table-wrapper sbb-calendar__year-view">
         <div class="sbb-calendar__table-header">
           <span>${yearLabel}</span>
-          ${this._getArrow(
-            'left',
-            () => this._goToDifferentYearRange(-YEARS_PER_PAGE),
-            i18nPreviousYearRange(YEARS_PER_PAGE)[this._language.current],
-            this._previousYearRangeDisabled(),
-          )}
-          ${this._getArrow(
-            'right',
-            () => this._goToDifferentYearRange(YEARS_PER_PAGE),
-            i18nNextYearRange(YEARS_PER_PAGE)[this._language.current],
-            this._nextYearRangeDisabled(),
-          )}
-          ${this._getArrow(
-            'down',
-            () => this._resetCalendarViewAndEmitMonthChange(),
-            i18nCalendarDateSelection[this._language.current],
-          )}
+          ${this._fixedMonth
+            ? []
+            : [
+                this._getArrow(
+                  'left',
+                  () => this._goToDifferentYearRange(-YEARS_PER_PAGE),
+                  i18nPreviousYearRange(YEARS_PER_PAGE)[this._language.current],
+                  this._previousYearRangeDisabled(),
+                ),
+                this._getArrow(
+                  'right',
+                  () => this._goToDifferentYearRange(YEARS_PER_PAGE),
+                  i18nNextYearRange(YEARS_PER_PAGE)[this._language.current],
+                  this._nextYearRangeDisabled(),
+                ),
+                this._getArrow(
+                  'down',
+                  () => this._resetCalendarViewAndEmitMonthChange(),
+                  i18nCalendarDateSelection[this._language.current],
+                ),
+              ]}
           <span class="sbb-screen-reader-only" role="status">${yearLabel}</span>
         </div>
         <table class="sbb-calendar__table">

--- a/src/elements/calendar/calendar/calendar.spec.ts
+++ b/src/elements/calendar/calendar/calendar.spec.ts
@@ -2187,6 +2187,13 @@ describe(`sbb-calendar`, () => {
           const day = element.shadowRoot!.querySelector('sbb-calendar-day');
           expect(defaultDateAdapter.sameDate(day?.value ?? null, new Date(2023, 9, 1))).to.be.true;
         });
+
+        it('should change the month on fixed-month attribute change', async () => {
+          element.fixedMonth = '2024-02';
+          await waitForLitRender(element);
+          const day = element.shadowRoot!.querySelector('sbb-calendar-day');
+          expect(defaultDateAdapter.sameDate(day?.value ?? null, new Date(2024, 1, 1))).to.be.true;
+        });
       });
     });
   });

--- a/src/elements/calendar/calendar/calendar.spec.ts
+++ b/src/elements/calendar/calendar/calendar.spec.ts
@@ -2161,6 +2161,33 @@ describe(`sbb-calendar`, () => {
           });
         });
       });
+
+      describe('fixed-month', () => {
+        beforeEach(async () => {
+          element = await fixture(
+            html` <sbb-calendar fixed-month="2023-10">
+              ${variant === 'default'
+                ? nothing
+                : variant === 'enhanced'
+                  ? createSlottedDays(2023, 10, true)
+                  : html`
+                      <sbb-calendar-day slot=${toIso8601(new Date('2023-10-15'))}>
+                        ${createPrice(true)}
+                      </sbb-calendar-day>
+                    `}
+            </sbb-calendar>`,
+          );
+        });
+
+        it('should not render control buttons', () => {
+          expect(element.shadowRoot!.querySelector('.sbb-calendar__control')).to.be.null;
+        });
+
+        it('should render the given month', () => {
+          const day = element.shadowRoot!.querySelector('sbb-calendar-day');
+          expect(defaultDateAdapter.sameDate(day?.value ?? null, new Date(2023, 9, 1))).to.be.true;
+        });
+      });
     });
   });
 });

--- a/src/elements/calendar/calendar/calendar.visual.spec.ts
+++ b/src/elements/calendar/calendar/calendar.visual.spec.ts
@@ -233,6 +233,30 @@ describe('sbb-calendar', () => {
                   }),
                 );
               }
+
+              it(
+                'fixed-month',
+                visualDiffDefault.with(async (setup) => {
+                  await setup.withFixture(html`
+                    <sbb-calendar
+                      fixed-month="2023-01"
+                      orientation=${orientation}
+                      amount=${amount}
+                      .value=${new Date(2023, 0, 20)}
+                      >${variant === 'default'
+                        ? nothing
+                        : html`${Array.from({ length: amount }, (_, i) => {
+                            const date = defaultDateAdapter.addCalendarMonths(today, i);
+                            return createSlottedDays(
+                              defaultDateAdapter.getYear(date),
+                              defaultDateAdapter.getMonth(date),
+                              true,
+                            );
+                          })}`}
+                    </sbb-calendar>
+                  `);
+                }),
+              );
             });
           }
         });

--- a/src/elements/calendar/readme.md
+++ b/src/elements/calendar/readme.md
@@ -160,8 +160,9 @@ all the days in the week.
 
 ### Fixed month
 
-In the case where a fixed month should be displayed, the `fixedMonth` property should be used.
-With this configuration, the currently displayed month cannot be changed.
+In the case where a fixed month (or months with `amount`) should be displayed,
+the `fixedMonth` property should be used.
+With this configuration, the currently displayed month cannot be changed by the user.
 
 The value must be provided as a valid ISO format with `YYYY-MM`.
 

--- a/src/elements/calendar/readme.md
+++ b/src/elements/calendar/readme.md
@@ -158,6 +158,17 @@ all the days in the week.
 <sbb-calendar multiple week-numbers></sbb-calendar>
 ```
 
+### Fixed month
+
+In the case where a fixed month should be displayed, the `fixedMonth` property should be used.
+With this configuration, the currently displayed month cannot be changed.
+
+The value must be provided as a valid ISO format with `YYYY-MM`.
+
+```html
+<sbb-calendar fixed-month="2025-01"></sbb-calendar>
+```
+
 ## Style
 
 The component displays by default a single month in the `day` view, a list of twenty-four years
@@ -272,6 +283,7 @@ For accessibility purposes, the component is rendered as a native table element 
 | ------------------- | -------------- | ------- | ---------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `amount`            | `amount`       | public  | `number`                                 | `1`            | The amount of months to display in this calendar.                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `dateFilter`        | `date-filter`  | public  | `((date: T \| null) => boolean) \| null` | `null`         | A function used to filter out dates.                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `fixedMonth`        | `fixed-month`  | public  | `string`                                 | `null`         | Set this with the format `YYYY-MM` to limit the calendar to a specific month, and prevent navigation to other months.                                                                                                                                                                                                                                                                                                                                   |
 | `form`              | -              | public  | `HTMLFormElement \| null`                |                | Returns the form owner of this element.                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `max`               | `max`          | public  | `T \| null`                              | `null`         | The maximum valid date. Accepts a date object or null. Accepts an ISO8601 formatted string (e.g. 2024-12-24) as attribute.                                                                                                                                                                                                                                                                                                                              |
 | `min`               | `min`          | public  | `T \| null`                              | `null`         | The minimum valid date. Accepts a date object or null. Accepts an ISO8601 formatted string (e.g. 2024-12-24) as attribute.                                                                                                                                                                                                                                                                                                                              |


### PR DESCRIPTION
This enables a use case where you want to allow users to edit a fixed range of days.