### PR TITLE
build(visual-regression-app): fix header spacing and introduce keyboard navigation

### DIFF
--- a/src/visual-regression-app/src/components/overview/overview.ts
+++ b/src/visual-regression-app/src/components/overview/overview.ts
@@ -11,6 +11,7 @@ import { customElement } from 'lit/decorators.js';
 import { meta } from 'virtual:meta';
 
 import { screenshots } from '../../screenshots.ts';
+import { sharedStyles } from '../../shared-styles.ts';
 
 import style from './overview.scss?inline';
 
@@ -30,7 +31,7 @@ import '@sbb-esta/lyne-elements/title.js';
 export
 @customElement('app-overview')
 class Overview extends LitElement {
-  public static override styles: CSSResultGroup = [unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [sharedStyles, unsafeCSS(style)];
 
   protected override render(): TemplateResult {
     return html`

--- a/src/visual-regression-app/src/components/test-case/image-diff/fullscreen-diff/fullscreen-diff.ts
+++ b/src/visual-regression-app/src/components/test-case/image-diff/fullscreen-diff/fullscreen-diff.ts
@@ -12,6 +12,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { meta } from 'virtual:meta';
 
 import type { ScreenshotFiles } from '../../../../interfaces.ts';
+import { sharedStyles } from '../../../../shared-styles.ts';
 
 import style from './fullscreen-diff.scss?inline';
 
@@ -27,7 +28,7 @@ export type DiffFileType = 'baselineFile' | 'failedFile' | 'diffFile';
 export
 @customElement('app-fullscreen-diff')
 class FullscreenDiff extends LitElement {
-  public static override styles: CSSResultGroup = [unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [sharedStyles, unsafeCSS(style)];
 
   @property() public accessor screenshotFiles: ScreenshotFiles | null = null;
 

--- a/src/visual-regression-app/src/components/test-case/image-diff/image-diff.ts
+++ b/src/visual-regression-app/src/components/test-case/image-diff/image-diff.ts
@@ -14,6 +14,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { meta } from 'virtual:meta';
 
 import type { ScreenshotFiles } from '../../../interfaces.ts';
+import { sharedStyles } from '../../../shared-styles.ts';
 
 import style from './image-diff.scss?inline';
 
@@ -33,7 +34,7 @@ const getImageDimension = (img: HTMLImageElement): string =>
 export
 @customElement('app-image-diff')
 class ImageDiff extends LitElement {
-  public static override styles: CSSResultGroup = [unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [sharedStyles, unsafeCSS(style)];
 
   @property({ attribute: false }) public accessor screenshotFiles: ScreenshotFiles | null = null;
 

--- a/src/visual-regression-app/src/components/test-case/test-case-filter/test-case-filter.ts
+++ b/src/visual-regression-app/src/components/test-case/test-case-filter/test-case-filter.ts
@@ -3,6 +3,7 @@ import { type CSSResultGroup, html, LitElement, type TemplateResult, unsafeCSS }
 import { customElement, property } from 'lit/decorators.js';
 
 import { type ScreenshotTestCase } from '../../../screenshots.ts';
+import { sharedStyles } from '../../../shared-styles.ts';
 
 import style from './test-case-filter.scss?inline';
 
@@ -15,7 +16,7 @@ import '@sbb-esta/lyne-elements/tag.js';
 export
 @customElement('app-test-case-filter')
 class TestCaseFilter extends LitElement {
-  public static override styles: CSSResultGroup = [unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [sharedStyles, unsafeCSS(style)];
 
   @property() public accessor testCase: ScreenshotTestCase | null = null;
 

--- a/src/visual-regression-app/src/components/test-case/test-case.ts
+++ b/src/visual-regression-app/src/components/test-case/test-case.ts
@@ -11,6 +11,7 @@ import {
 import { customElement, property, state } from 'lit/decorators.js';
 
 import { screenshots, type ScreenshotTestCase } from '../../screenshots.ts';
+import { sharedStyles } from '../../shared-styles.ts';
 
 import type { TestCaseFilter } from './test-case-filter/test-case-filter.ts';
 import style from './test-case.scss?inline';
@@ -38,7 +39,7 @@ interface Filter {
 export
 @customElement('app-test-case')
 class TestCase extends LitElement {
-  public static override styles: CSSResultGroup = [unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [sharedStyles, unsafeCSS(style)];
 
   @property({ attribute: false }) public accessor params: {
     componentName: string;
@@ -49,6 +50,25 @@ class TestCase extends LitElement {
   @state() private accessor _testCaseIndex: number = -1;
   @state() private accessor _filter: Filter = {};
   @state() private accessor _showGlobalDiff = true;
+
+  public constructor() {
+    super();
+
+    // For expert usage we handle arrow left and right keyboard events on the arrow buttons for a faster navigation between test cases.
+    this.addEventListener('keydown', (evt) => {
+      const previous = this.shadowRoot?.querySelector<HTMLElement>('#previous');
+      const next = this.shadowRoot?.querySelector<HTMLElement>('#next');
+      const composedPath = evt.composedPath();
+      if (!previous || !next || !(composedPath.includes(previous) || composedPath.includes(next))) {
+        return;
+      }
+      if (evt.key === 'ArrowLeft') {
+        previous.click();
+      } else if (evt.key === 'ArrowRight') {
+        next.click();
+      }
+    });
+  }
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     super.willUpdate(changedProperties);
@@ -101,7 +121,7 @@ class TestCase extends LitElement {
 
   protected override render(): TemplateResult {
     return html`
-      <sbb-header expanded>
+      <sbb-header expanded size="m">
         <div class="app-progress" style="--app-progress: ${this._progressFraction()}"></div>
         <div class="app-file-name-box sbb-header-shrinkable">
           <sbb-chip-label color="charcoal">${this.params?.componentName}</sbb-chip-label>
@@ -119,12 +139,14 @@ class TestCase extends LitElement {
             size="s"
             icon-name="arrow-left-small"
             ?disabled=${!this._previous()}
+            id="previous"
           ></sbb-secondary-button-link>
           <sbb-secondary-button-link
             href="/compare/${this._next()?.path}"
             size="s"
             icon-name="arrow-right-small"
             ?disabled=${!this._next()}
+            id="next"
           ></sbb-secondary-button-link>
         </div>
       </sbb-header>

--- a/src/visual-regression-app/src/components/test-case/test-title-chip-list/test-title-chip-list.ts
+++ b/src/visual-regression-app/src/components/test-case/test-title-chip-list/test-title-chip-list.ts
@@ -8,8 +8,9 @@ import {
 } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import '@sbb-esta/lyne-elements/chip-label.js';
 import { sharedStyles } from '../../../shared-styles.ts';
+
+import '@sbb-esta/lyne-elements/chip-label.js';
 
 import style from './test-title-chip-list.scss?inline';
 

--- a/src/visual-regression-app/src/components/test-case/test-title-chip-list/test-title-chip-list.ts
+++ b/src/visual-regression-app/src/components/test-case/test-title-chip-list/test-title-chip-list.ts
@@ -9,6 +9,8 @@ import {
 import { customElement, property } from 'lit/decorators.js';
 
 import '@sbb-esta/lyne-elements/chip-label.js';
+import { sharedStyles } from '../../../shared-styles.ts';
+
 import style from './test-title-chip-list.scss?inline';
 
 /**
@@ -37,7 +39,7 @@ interface DescribeEachItem {
 export
 @customElement('app-test-title-chip-list')
 class TestTitleChipList extends LitElement {
-  public static override styles: CSSResultGroup = [unsafeCSS(style)];
+  public static override styles: CSSResultGroup = [sharedStyles, unsafeCSS(style)];
 
   @property()
   public set testCaseName(name: string) {

--- a/src/visual-regression-app/src/main.ts
+++ b/src/visual-regression-app/src/main.ts
@@ -3,7 +3,7 @@ import { html, LitElement, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 import '@sbb-esta/lyne-elements/core.js';
-import '@sbb-esta/lyne-elements/core/styles/standard-theme.scss';
+import '@sbb-esta/lyne-elements/core/styles/lean-theme.scss';
 
 // Lit Router uses URLPattern which is not defined so far in Firefox and Safari.
 // TODO: Remove as soon as possible

--- a/src/visual-regression-app/src/shared-styles.scss
+++ b/src/visual-regression-app/src/shared-styles.scss
@@ -1,0 +1,3 @@
+@use '@sbb-esta/lyne-elements' as sbb;
+
+@include sbb.box-sizing;

--- a/src/visual-regression-app/src/shared-styles.ts
+++ b/src/visual-regression-app/src/shared-styles.ts
@@ -1,0 +1,5 @@
+import { unsafeCSS } from 'lit';
+
+import sharedStylesString from './shared-styles.scss?inline';
+
+export const sharedStyles = unsafeCSS(sharedStylesString);


### PR DESCRIPTION
As the visual regression app uses shadow DOM, we have to add border-box sizing in order to correctly display the header spacing.
Additionally I added some kind of keyboard navigation as I often miss this during my own usage :)