### PR TITLE
feat(pearl-chain, time-table-row): support cancelledExpected legs

### DIFF
--- a/src/elements-experimental/core/timetable/timetable-properties.ts
+++ b/src/elements-experimental/core/timetable/timetable-properties.ts
@@ -25,6 +25,8 @@ export interface ServiceAlteration {
    *
    */
   delayText: string;
+  /** Cancelled Expected Flag */
+  cancelledExpected?: boolean;
 
   /** Journey is partially cancelled at beginning or end */
   partiallyCancelled: boolean;

--- a/src/elements-experimental/pearl-chain/pearl-chain.component.ts
+++ b/src/elements-experimental/pearl-chain/pearl-chain.component.ts
@@ -258,6 +258,10 @@ export class SbbPearlChainElement extends SbbElement {
               ? 'sbb-pearl-chain__leg--disruption'
               : '';
 
+          const cancelledExpected = leg.serviceJourney?.serviceAlteration?.cancelledExpected
+            ? 'sbb-pearl-chain__leg--cancelled-expected'
+            : '';
+
           const legDepartureWithDelay = { time: departure, delay: leg.departure?.delay ?? 0 };
           const legArrivalWithDelay = { time: arrival, delay: leg.arrival?.delay ?? 0 };
           const status = this._getStatus(now, legDepartureWithDelay, legArrivalWithDelay);
@@ -266,7 +270,7 @@ export class SbbPearlChainElement extends SbbElement {
           const legStyle = (): Record<string, string> => {
             return {
               '--sbb-pearl-chain-leg-width': `${duration}%`,
-              ...(status === 'progress' && !cancelled && !skippedLeg
+              ...(status === 'progress' && !cancelled && !skippedLeg && !cancelledExpected
                 ? {
                     '--sbb-pearl-chain-leg-status': `${this._getProgress(now, legDepartureWithDelay, legArrivalWithDelay)}%`,
                   }
@@ -275,7 +279,8 @@ export class SbbPearlChainElement extends SbbElement {
           };
 
           return html` <div
-            class="sbb-pearl-chain__leg ${legStatus || ''} ${cancelled} ${skippedLeg}"
+            class="sbb-pearl-chain__leg ${legStatus ||
+            ''} ${cancelled} ${skippedLeg} ${cancelledExpected}"
             style=${styleMap(legStyle())}
           >
             ${index > 0 && index < rideLegs.length

--- a/src/elements-experimental/pearl-chain/pearl-chain.sample-data.private.ts
+++ b/src/elements-experimental/pearl-chain/pearl-chain.sample-data.private.ts
@@ -16,6 +16,10 @@ const defaultService = {
 
 const busService = { ...defaultService, quayTypeName: 'Stand', quayTypeShortName: 'Stand' };
 const cancelledService = { ...defaultService, serviceAlteration: { cancelled: true } };
+const cancelledExpectedService = {
+  ...defaultService,
+  serviceAlteration: { cancelledExpected: true },
+};
 const partiallyCancelledService = {
   ...defaultService,
   serviceAlteration: { partiallyCancelled: true },
@@ -90,6 +94,13 @@ export const cancelledLeg: any = {
   arrival: { time: future2 },
   departure: { time: future },
   serviceJourney: cancelledService,
+};
+
+export const cancelledExpectedLeg: any = {
+  __typename: 'PTRideLeg',
+  arrival: { time: future2 },
+  departure: { time: future },
+  serviceJourney: cancelledExpectedService,
 };
 
 export const partiallyCancelledLeg: any = {

--- a/src/elements-experimental/pearl-chain/pearl-chain.scss
+++ b/src/elements-experimental/pearl-chain/pearl-chain.scss
@@ -141,6 +141,10 @@
   @include sbb.pearl-chain-bullet-past;
 }
 
+.sbb-pearl-chain__leg--cancelled-expected::after {
+  @include sbb-pearl-chain-dotted;
+}
+
 .sbb-pearl-chain__leg--disruption::after {
   @include sbb-pearl-chain-dotted;
 }

--- a/src/elements-experimental/timetable-row/__snapshots__/timetable-row.snapshot.spec.snap.js
+++ b/src/elements-experimental/timetable-row/__snapshots__/timetable-row.snapshot.spec.snap.js
@@ -9,7 +9,7 @@ snapshots["sbb-timetable-row renders defaultTrip DOM"] =
 
 snapshots["sbb-timetable-row renders defaultTrip Shadow DOM"] = 
 `<sbb-card
-  class="sbb-card-spacing-4x-xxs"
+  class="sbb-card-spacing-4x-xxs sbb-timetable__row-card"
   color="white"
 >
   <sbb-card-button
@@ -76,7 +76,7 @@ snapshots["sbb-timetable-row renders platform DOM"] =
 
 snapshots["sbb-timetable-row renders platform Shadow DOM"] = 
 `<sbb-card
-  class="sbb-card-spacing-4x-xxs"
+  class="sbb-card-spacing-4x-xxs sbb-timetable__row-card"
   color="white"
 >
   <sbb-card-button
@@ -162,7 +162,7 @@ snapshots["sbb-timetable-row renders bus strip DOM"] =
 
 snapshots["sbb-timetable-row renders bus strip Shadow DOM"] = 
 `<sbb-card
-  class="sbb-card-spacing-4x-xxs"
+  class="sbb-card-spacing-4x-xxs sbb-timetable__row-card"
   color="white"
 >
   <sbb-card-button
@@ -249,7 +249,7 @@ snapshots["sbb-timetable-row renders loading state DOM"] =
 
 snapshots["sbb-timetable-row renders loading state Shadow DOM"] = 
 `<sbb-card
-  class="sbb-card-spacing-4x-xxs sbb-loading"
+  class="sbb-card-spacing-4x-xxs sbb-loading sbb-timetable__row-card"
   color="white"
 >
   <div
@@ -293,7 +293,7 @@ snapshots["sbb-timetable-row renders trip with access leg DOM"] =
 
 snapshots["sbb-timetable-row renders trip with access leg Shadow DOM"] = 
 `<sbb-card
-  class="sbb-card-spacing-4x-xxs"
+  class="sbb-card-spacing-4x-xxs sbb-timetable__row-card"
   color="white"
 >
   <sbb-card-button

--- a/src/elements-experimental/timetable-row/timetable-row.component.ts
+++ b/src/elements-experimental/timetable-row/timetable-row.component.ts
@@ -162,6 +162,9 @@ export const getCus = (trip: ITripItem, currentLanguage: string): HimCus => {
   if (tripStatus?.cancelled || tripStatus?.partiallyCancelled) {
     return { name: 'cancellation', text: tripStatus?.cancelledText };
   }
+  if (rideLegs?.some((leg) => leg.serviceJourney?.serviceAlteration?.cancelledExpected)) {
+    return { name: 'disruption', text: tripStatus?.cancelledText };
+  }
   if (getReachableText(rideLegs)) {
     return { name: 'missed-connection', text: getReachableText(rideLegs) };
   }
@@ -335,7 +338,7 @@ export class SbbTimetableRowElement extends SbbElement {
   /** The skeleton render function for the loading state */
   private _renderSkeleton(): TemplateResult {
     return html`
-      <sbb-card class="sbb-loading sbb-card-spacing-4x-xxs">
+      <sbb-card class="sbb-loading sbb-card-spacing-4x-xxs sbb-timetable__row-card">
         ${this.loadingPrice ? html`<div class="sbb-loading__badge" slot="badge"></div>` : nothing}
         <div class="sbb-loading__wrapper">
           <div class="sbb-loading__row"></div>
@@ -578,7 +581,7 @@ export class SbbTimetableRowElement extends SbbElement {
     const durationObj = duration ? durationToTime(duration, this._language.current) : null;
 
     return html`
-      <sbb-card class="sbb-card-spacing-4x-xxs" id=${id}>
+      <sbb-card class="sbb-card-spacing-4x-xxs sbb-timetable__row-card" id=${id}>
         <sbb-card-button
           ?active=${this.active}
           aria-expanded=${this.accessibilityExpanded ? 'true' : nothing}

--- a/src/elements-experimental/timetable-row/timetable-row.sample-data.private.ts
+++ b/src/elements-experimental/timetable-row/timetable-row.sample-data.private.ts
@@ -1,6 +1,7 @@
 import type { ITripItem } from '../core.ts';
 import {
   accessLeg,
+  cancelledExpectedLeg,
   cancelledLeg,
   connectionLeg,
   defaultBusLeg,
@@ -70,6 +71,35 @@ export const cancelledTrip: DeepPartial<ITripItem> = {
     },
     tripStatus: {
       cancelled: true,
+      partiallyCancelled: false,
+      delayedUnknown: false,
+      delayed: false,
+      quayChanged: false,
+    },
+  },
+};
+
+export const cancelledExpectedTrip: DeepPartial<ITripItem> = {
+  legs: [cancelledExpectedLeg],
+  situations: [],
+  summary: {
+    arrival: {
+      time: '2022-11-30T12:13:00+01:00',
+    },
+    departure: {
+      time: '2022-11-30T11:08:00+01:00',
+      quayFormatted: '14',
+    },
+    direction: 'Basel SBB',
+    product: {
+      line: '37',
+      vehicleMode: 'TRAIN',
+      vehicleSubModeShortName: 'IR',
+      corporateIdentityIcon: 'ir-37',
+      corporateIdentityPictogram: 'train-right',
+    },
+    tripStatus: {
+      cancelled: false,
       partiallyCancelled: false,
       delayedUnknown: false,
       delayed: false,

--- a/src/elements-experimental/timetable-row/timetable-row.scss
+++ b/src/elements-experimental/timetable-row/timetable-row.scss
@@ -71,6 +71,10 @@ li {
   animation: none;
 }
 
+.sbb-timetable__row-card {
+  --sbb-card-padding-block: var(--sbb-card-with-badge-padding-block);
+}
+
 .sbb-timetable__row-header {
   display: flex;
   gap: var(--sbb-spacing-fixed-2x);

--- a/src/elements-experimental/timetable-row/timetable-row.stories.ts
+++ b/src/elements-experimental/timetable-row/timetable-row.stories.ts
@@ -11,6 +11,7 @@ import {
   a11yFootpathTrip,
   busTrip,
   cancelledTrip,
+  cancelledExpectedTrip,
   defaultTrip,
   disturbanceTrip,
   extendedEnterTimeTrip,
@@ -239,6 +240,15 @@ export const Cancelled: StoryObj = {
   args: {
     ...defaultArgs,
     trip: cancelledTrip,
+  },
+};
+
+export const CancelledExpected: StoryObj = {
+  render: Template,
+  argTypes: defaultArgTypes,
+  args: {
+    ...defaultArgs,
+    trip: cancelledExpectedTrip,
   },
 };
 

--- a/src/elements-experimental/timetable-row/timetable-row.visual.spec.ts
+++ b/src/elements-experimental/timetable-row/timetable-row.visual.spec.ts
@@ -12,6 +12,7 @@ import type { Boarding, Price } from './timetable-row.component.ts';
 import {
   a11yFootpathTrip,
   busTrip,
+  cancelledExpectedTrip,
   cancelledTrip,
   type DeepPartial,
   defaultTrip,
@@ -49,6 +50,7 @@ describe(`sbb-timetable-row`, () => {
   const cases = [
     { name: 'position', trip: progressTrip },
     { name: 'cancelled', trip: cancelledTrip },
+    { name: 'cancelledExpected', trip: cancelledExpectedTrip },
     { name: 'partially cancelled', trip: partiallyCancelled },
     { name: 'past', trip: pastTrip, now: new Date('2023-12-01T12:11:00') },
     { name: 'disturbance', trip: disturbanceTrip, now: new Date('2022-12-05T12:11:00') },


### PR DESCRIPTION
This PR adds a new state for cancelledExpected legs for the timetable row and fixes a style issue while loading trips. The chances have to go to the 4.x version as well. 
