### PR TITLE
fix(calendar): improve initialization robustness

### DIFF
--- a/src/elements/calendar/calendar-day/calendar-day.component.ts
+++ b/src/elements/calendar/calendar-day/calendar-day.component.ts
@@ -62,15 +62,17 @@ export class SbbCalendarDayElement<T = Date> extends SbbCalendarCellBaseElement<
     );
   }
 
-  protected setSelectedState(parent: SbbCalendarElement<T>): void {
-    const selected = parent.multiple
-      ? (parent.value as Date[]).some((selDay) => this.dateAdapter.sameDate(this.value, selDay))
-      : !!parent.value && this.dateAdapter.compareDate(this.value, parent.value) === 0;
+  protected override setSelectedState(parent: SbbCalendarElement<T>): void {
+    const selected =
+      !!this.value &&
+      (parent.multiple
+        ? (parent.value as Date[]).some((selDay) => this.dateAdapter.sameDate(this.value, selDay))
+        : !!parent.value && this.dateAdapter.compareDate(this.value, parent.value) === 0);
     this.toggleState('selected', selected);
     this.internals.ariaPressed = String(selected);
   }
 
-  protected setDisabledFilteredState(parent: SbbCalendarElement<T>): void {
+  protected override setDisabledFilteredState(parent: SbbCalendarElement<T>): void {
     const isFilteredOut = !this._isActiveDate(parent.dateFilter);
     const isOutOfRange = !this._isDayInRange(parent.min, parent.max);
     this.disabled = isFilteredOut || isOutOfRange;

--- a/src/elements/calendar/calendar-month/calendar-month.component.ts
+++ b/src/elements/calendar/calendar-month/calendar-month.component.ts
@@ -51,15 +51,17 @@ export class SbbCalendarMonthElement<T = Date> extends SbbCalendarCellBaseElemen
   }
 
   protected override setSelectedState(parent: SbbCalendarElement<T>): void {
-    const selected = parent.multiple
-      ? ((parent.value as Date[])?.some(
-          (date: Date) =>
-            this._yearValue === this.dateAdapter.getYear(date) &&
-            this._monthValue === this.dateAdapter.getMonth(date),
-        ) ?? false)
-      : !!parent.value &&
-        this.dateAdapter.getYear(parent.value) === this._yearValue &&
-        this.dateAdapter.getMonth(parent.value) === this._monthValue;
+    const selected =
+      !!this.value &&
+      (parent.multiple
+        ? ((parent.value as Date[])?.some(
+            (date: Date) =>
+              this._yearValue === this.dateAdapter.getYear(date) &&
+              this._monthValue === this.dateAdapter.getMonth(date),
+          ) ?? false)
+        : !!parent.value &&
+          this.dateAdapter.getYear(parent.value) === this._yearValue &&
+          this.dateAdapter.getMonth(parent.value) === this._monthValue);
     this.toggleState('selected', selected);
     this.internals.ariaPressed = String(selected);
   }

--- a/src/elements/calendar/calendar-year/calendar-year.component.ts
+++ b/src/elements/calendar/calendar-year/calendar-year.component.ts
@@ -41,11 +41,13 @@ export class SbbCalendarYearElement<T = Date> extends SbbCalendarCellBaseElement
   }
 
   protected override setSelectedState(parent: SbbCalendarElement<T>): void {
-    const selected = parent.multiple
-      ? ((parent.value as Date[])?.some(
-          (date: Date) => Number(this.value) === this.dateAdapter.getYear(date),
-        ) ?? false)
-      : !!parent.value && this.dateAdapter.getYear(parent.value) === Number(this.value);
+    const selected =
+      !!this.value &&
+      (parent.multiple
+        ? ((parent.value as Date[])?.some(
+            (date: Date) => Number(this.value) === this.dateAdapter.getYear(date),
+          ) ?? false)
+        : !!parent.value && this.dateAdapter.getYear(parent.value) === Number(this.value));
     this.toggleState('selected', selected);
     this.internals.ariaPressed = String(selected);
   }


### PR DESCRIPTION
This helps in an angular envinroment where the `[slot]="..."` binding is processed after the initialization