### PR TITLE
fix(clock): made `start` and `stop` method synchronous

### DIFF
--- a/src/elements/clock/__snapshots__/clock.snapshot.spec.snap.js
+++ b/src/elements/clock/__snapshots__/clock.snapshot.spec.snap.js
@@ -12,10 +12,7 @@ snapshots["sbb-clock renders Shadow DOM"] =
 </span>
 <span class="sbb-clock__hand-hours sbb-clock__hand-hours--initial-hour">
 </span>
-<span
-  class="sbb-clock__hand-minutes sbb-clock__hand-minutes--no-transition"
-  style="transform: rotateZ(96deg);"
->
+<span class="sbb-clock__hand-minutes sbb-clock__hand-minutes--no-transition">
 </span>
 <span class="sbb-clock__hand-seconds sbb-clock__hand-seconds--initial-minute">
 </span>

--- a/src/elements/clock/__snapshots__/clock.snapshot.spec.snap.js
+++ b/src/elements/clock/__snapshots__/clock.snapshot.spec.snap.js
@@ -10,11 +10,14 @@ snapshots["sbb-clock renders DOM"] =
 snapshots["sbb-clock renders Shadow DOM"] = 
 `<span class="sbb-clock__face">
 </span>
-<span class="sbb-clock__hand-hours">
+<span class="sbb-clock__hand-hours sbb-clock__hand-hours--initial-hour">
 </span>
-<span class="sbb-clock__hand-minutes sbb-clock__hand-minutes--no-transition">
+<span
+  class="sbb-clock__hand-minutes sbb-clock__hand-minutes--no-transition"
+  style="transform: rotateZ(96deg);"
+>
 </span>
-<span class="sbb-clock__hand-seconds">
+<span class="sbb-clock__hand-seconds sbb-clock__hand-seconds--initial-minute">
 </span>
 `;
 /* end snapshot sbb-clock renders Shadow DOM */

--- a/src/elements/clock/clock.component.ts
+++ b/src/elements/clock/clock.component.ts
@@ -108,8 +108,11 @@ export class SbbClockElement extends SbbElement {
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     super.willUpdate(changedProperties);
+    if (isServer || !this.hasUpdated) {
+      return;
+    }
 
-    if (!isServer && changedProperties.has('now')) {
+    if (changedProperties.has('now')) {
       this._startOrConfigureClock();
     }
   }
@@ -129,30 +132,30 @@ export class SbbClockElement extends SbbElement {
     clearInterval(this._resetIntervalId);
   }
 
-  private _handlePageVisibilityChange = async (): Promise<void> => {
+  private _handlePageVisibilityChange = (): void => {
     if (this.now) {
       return;
     }
 
     if (document.visibilityState === 'hidden') {
-      await this._stopClock();
+      this._stopClock();
     } else {
-      await this._startClock();
+      this._startClock();
     }
   };
 
-  private async _startOrConfigureClock(): Promise<void> {
+  private _startOrConfigureClock(): void {
     if (this.now) {
-      await this._stopClock();
+      this._stopClock();
       this._resetSecondsHandAnimation();
       this._setHandsStartingPosition();
     } else {
-      await this._startClock();
+      this._startClock();
     }
   }
 
   /** Starts the clock by defining the hands starting position then starting the animations. */
-  private async _startClock(): Promise<void> {
+  private _startClock(): void {
     this._clockHandHours?.addEventListener(
       'animationend',
       this._moveHoursHandFn,
@@ -164,19 +167,14 @@ export class SbbClockElement extends SbbElement {
       ADD_EVENT_LISTENER_OPTIONS,
     );
 
-    await new Promise<void>((resolve) =>
-      setTimeout(() => {
-        this._setHandsStartingPosition();
+    this._setHandsStartingPosition();
 
-        this.style?.setProperty('--sbb-clock-animation-play-state', 'running');
-        this._state = 'running';
-        resolve();
-      }, INITIAL_TIMEOUT_DURATION),
-    );
+    this.style?.setProperty('--sbb-clock-animation-play-state', 'running');
+    this._state = 'running';
   }
 
   /** Stops the clock by removing all the animations. */
-  private async _stopClock(): Promise<void> {
+  private _stopClock(): void {
     clearInterval(this._handMovement);
 
     this._removeSecondsAnimationStyles();
@@ -198,8 +196,8 @@ export class SbbClockElement extends SbbElement {
     if (this._state !== 'running') {
       return;
     }
-    await this._stopClock();
-    await this._startClock();
+    this._stopClock();
+    setTimeout(() => this._startClock(), INITIAL_TIMEOUT_DURATION);
   }
 
   /** Set the starting position for the three hands on the clock face. */

--- a/src/elements/clock/clock.snapshot.spec.ts
+++ b/src/elements/clock/clock.snapshot.spec.ts
@@ -15,7 +15,7 @@ describe(`sbb-clock`, () => {
     });
 
     it('DOM', async () => {
-      await expect(element).dom.to.be.equalSnapshot();
+      await expect(element).dom.to.be.equalSnapshot({ ignoreAttributes: ['style'] });
     });
 
     it('Shadow DOM', async () => {

--- a/src/elements/clock/clock.snapshot.spec.ts
+++ b/src/elements/clock/clock.snapshot.spec.ts
@@ -19,7 +19,7 @@ describe(`sbb-clock`, () => {
     });
 
     it('Shadow DOM', async () => {
-      await expect(element).shadowDom.to.be.equalSnapshot();
+      await expect(element).shadowDom.to.be.equalSnapshot({ ignoreAttributes: ['style'] });
     });
 
     testA11yTreeSnapshot();


### PR DESCRIPTION
Improve the robustness of the start and stop methods, making them synchronous.

The current implementation lands in an inconsistent state if `start()` and `stop()` is called sequentially