### PR TITLE
docs(carousel): improve 'link' use case a11y

### DIFF
--- a/src/elements/carousel/_carousel.global.scss
+++ b/src/elements/carousel/_carousel.global.scss
@@ -9,3 +9,9 @@ $theme: 'standard' !default;
   --sbb-carousel-paginator-padding: var(--sbb-spacing-responsive-xs);
   --sbb-carousel-list-border-radius: var(--sbb-border-radius-4x);
 }
+
+@mixin rules {
+  sbb-carousel-item sbb-image {
+    border-radius: unset;
+  }
+}

--- a/src/elements/carousel/carousel-item/carousel-item.scss
+++ b/src/elements/carousel/carousel-item/carousel-item.scss
@@ -5,7 +5,3 @@
   scroll-snap-align: start;
   flex-shrink: 0;
 }
-
-::slotted(sbb-image) {
-  border-radius: unset;
-}

--- a/src/elements/carousel/carousel.stories.ts
+++ b/src/elements/carousel/carousel.stories.ts
@@ -109,6 +109,7 @@ const Template = ({ imgType, ...args }: Args): TemplateResult => html`
                     href="https://github.com/sbb-design-systems/lyne-components"
                     target="_blank"
                     aria-label="Navigate to lyne-angular repo"
+                    style="border-radius: var(--sbb-carousel-border-radius)"
                   >
                     <sbb-image
                       image-src=${img}

--- a/src/elements/carousel/carousel.stories.ts
+++ b/src/elements/carousel/carousel.stories.ts
@@ -108,7 +108,7 @@ const Template = ({ imgType, ...args }: Args): TemplateResult => html`
                   <a
                     href="https://github.com/sbb-design-systems/lyne-components"
                     target="_blank"
-                    tabindex="-1"
+                    aria-label="Navigate to lyne-angular repo"
                   >
                     <sbb-image
                       image-src=${img}

--- a/src/elements/carousel/carousel.stories.ts
+++ b/src/elements/carousel/carousel.stories.ts
@@ -109,7 +109,6 @@ const Template = ({ imgType, ...args }: Args): TemplateResult => html`
                     href="https://github.com/sbb-design-systems/lyne-components"
                     target="_blank"
                     aria-label="Navigate to lyne-angular repo"
-                    style="border-radius: var(--sbb-carousel-border-radius)"
                   >
                     <sbb-image
                       image-src=${img}

--- a/src/elements/carousel/carousel/carousel.visual.spec.ts
+++ b/src/elements/carousel/carousel/carousel.visual.spec.ts
@@ -1,10 +1,14 @@
 import { aTimeout } from '@open-wc/testing';
 import { html } from 'lit';
+import { choose } from 'lit/directives/choose.js';
+import { repeat } from 'lit/directives/repeat.js';
 
 import { describeViewports, visualDiffDefault } from '../../core/testing/private.ts';
 import { waitForImageReady } from '../../core/testing.ts';
+import type { SbbImageElement } from '../../image.ts';
 
 import '../../carousel.ts';
+import '../../chip-label.ts';
 import '../../image.ts';
 import '../../paginator.ts';
 
@@ -14,100 +18,97 @@ describe('sbb-carousel', () => {
   describeViewports(() => {
     for (const shadow of [false, true]) {
       describe(`shadow=${shadow}`, () => {
-        it(
-          'default',
-          visualDiffDefault.with(async (setup) => {
-            await setup.withFixture(
-              html`
-                <sbb-carousel ?shadow=${shadow}>
-                  <sbb-carousel-list>
-                    <sbb-carousel-item>
-                      <img src=${imageUrl} alt="SBB image" height="300" width="400" />
-                    </sbb-carousel-item>
-                    <sbb-carousel-item>
-                      <img src=${imageUrl} alt="SBB image" height="300" width="400" />
-                    </sbb-carousel-item>
-                    <sbb-carousel-item>
-                      <img src=${imageUrl} alt="SBB image" height="300" width="400" />
-                    </sbb-carousel-item>
-                  </sbb-carousel-list>
-                  <sbb-compact-paginator></sbb-compact-paginator>
-                </sbb-carousel>
-              `,
-              {
-                backgroundColor: shadow
-                  ? 'var(--sbb-background-color-3)'
-                  : 'var(--sbb-background-color-1)',
-              },
-            );
-
-            setup.withPostSetupAction(async () => {
-              await Promise.all(
-                Array.from(setup.snapshotElement.querySelectorAll<HTMLImageElement>('img'), (el) =>
-                  waitForImageReady(el),
-                ),
+        for (const imgType of ['native', 'sbb-image', 'figure', 'link']) {
+          it(
+            imgType,
+            visualDiffDefault.with(async (setup) => {
+              await setup.withFixture(
+                html`
+                  <sbb-carousel ?shadow=${shadow}>
+                    <sbb-carousel-list>
+                      ${repeat(
+                        new Array(3),
+                        () => html`
+                          <sbb-carousel-item>
+                            ${choose(imgType, [
+                              [
+                                'native',
+                                () => html`
+                                  <img src=${imageUrl} alt="SBB image" height="300" width="400" />
+                                `,
+                              ],
+                              [
+                                'sbb-image',
+                                () => html`
+                                  <sbb-image
+                                    image-src=${imageUrl}
+                                    alt="SBB image"
+                                    style="width: 400px; height: 300px;"
+                                  ></sbb-image>
+                                `,
+                              ],
+                              [
+                                'figure',
+                                () => html`
+                                  <figure class="sbb-figure" style="width: 400px; height: 300px;">
+                                    <sbb-chip-label class="sbb-figure-overlap-start-start">
+                                      Chip label
+                                    </sbb-chip-label>
+                                    <img src=${imageUrl} alt="SBB image" />
+                                    <figcaption style="text-align: center;">
+                                      Caption for picture
+                                    </figcaption>
+                                  </figure>
+                                `,
+                              ],
+                              [
+                                'link',
+                                () => html`
+                                  <a
+                                    href="https://github.com/sbb-design-systems/lyne-components"
+                                    target="_blank"
+                                    aria-label="Navigate to lyne-angular repo"
+                                  >
+                                    <sbb-image
+                                      image-src=${imageUrl}
+                                      alt="SBB image"
+                                      style="width: 400px; height: 300px;"
+                                    ></sbb-image>
+                                  </a>
+                                `,
+                              ],
+                            ])}
+                          </sbb-carousel-item>
+                        `,
+                      )}
+                    </sbb-carousel-list>
+                    <sbb-compact-paginator></sbb-compact-paginator>
+                  </sbb-carousel>
+                `,
+                {
+                  backgroundColor: shadow
+                    ? 'var(--sbb-background-color-3)'
+                    : 'var(--sbb-background-color-1)',
+                },
               );
-              setup.snapshotElement
-                .querySelectorAll('sbb-carousel-item')[0]!
-                .scrollIntoView({ behavior: 'instant' });
-              await aTimeout(10);
-            });
-          }),
-        );
 
-        it(
-          'sbb-image',
-          visualDiffDefault.with(async (setup) => {
-            await setup.withFixture(
-              html`
-                <sbb-carousel ?shadow=${shadow}>
-                  <sbb-carousel-list>
-                    <sbb-carousel-item>
-                      <sbb-image
-                        image-src=${imageUrl}
-                        alt="SBB image"
-                        style="width: 400px; height: 300px;"
-                      ></sbb-image>
-                    </sbb-carousel-item>
-                    <sbb-carousel-item>
-                      <sbb-image
-                        image-src=${imageUrl}
-                        alt="SBB image"
-                        style="width: 400px; height: 300px;"
-                      ></sbb-image>
-                    </sbb-carousel-item>
-                    <sbb-carousel-item>
-                      <sbb-image
-                        image-src=${imageUrl}
-                        alt="SBB image"
-                        style="width: 400px; height: 300px;"
-                      ></sbb-image>
-                    </sbb-carousel-item>
-                  </sbb-carousel-list>
-                  <sbb-compact-paginator></sbb-compact-paginator>
-                </sbb-carousel>
-              `,
-              {
-                backgroundColor: shadow
-                  ? 'var(--sbb-background-color-3)'
-                  : 'var(--sbb-background-color-1)',
-              },
-            );
-
-            setup.withPostSetupAction(async () => {
-              await Promise.all(
-                Array.from(
-                  setup.snapshotElement.querySelectorAll<HTMLImageElement>('sbb-image'),
-                  (el) => waitForImageReady(el),
-                ),
-              );
-              setup.snapshotElement
-                .querySelectorAll('sbb-carousel-item')[0]!
-                .scrollIntoView({ behavior: 'instant' });
-              await aTimeout(10);
-            });
-          }),
-        );
+              setup.withPostSetupAction(async () => {
+                await Promise.all(
+                  Array.from(
+                    setup.snapshotElement.querySelectorAll<HTMLImageElement | SbbImageElement>(
+                      'img, sbb-image',
+                    ),
+                    (el) => waitForImageReady(el),
+                  ),
+                );
+                setup.snapshotElement
+                  .querySelectorAll('sbb-carousel-item')[0]!
+                  .scrollIntoView({ behavior: 'instant' });
+                await aTimeout(10);
+              });
+            }),
+          );
+        }
       });
     }
   });
@@ -120,15 +121,14 @@ describe('sbb-carousel', () => {
           html`
             <sbb-carousel>
               <sbb-carousel-list>
-                <sbb-carousel-item>
-                  <img src=${imageUrl} alt="SBB image" height="300" width="400" />
-                </sbb-carousel-item>
-                <sbb-carousel-item>
-                  <img src=${imageUrl} alt="SBB image" height="300" width="400" />
-                </sbb-carousel-item>
-                <sbb-carousel-item>
-                  <img src=${imageUrl} alt="SBB image" height="300" width="400" />
-                </sbb-carousel-item>
+                ${repeat(
+                  new Array(3),
+                  () => html`
+                    <sbb-carousel-item>
+                      <img src=${imageUrl} alt="SBB image" height="300" width="400" />
+                    </sbb-carousel-item>
+                  `,
+                )}
               </sbb-carousel-list>
               <sbb-compact-paginator></sbb-compact-paginator>
             </sbb-carousel>

--- a/src/elements/core/styles/_theme.scss
+++ b/src/elements/core/styles/_theme.scss
@@ -338,6 +338,7 @@ $theme: 'standard' !default;
 @include badge.rules;
 @include breadcrumb.rules;
 @include card.rules;
+@include carousel.rules;
 @include container.rules;
 @include dialog.rules;
 @include flip-card.rules;


### PR DESCRIPTION
Open topic:
- The focus outline of the image is not visible because it's contained in an overflow element. Solving it is a bit complicated :/
  We could either leave it as it is or, as a compromise, add an `outline-offset: -1px` on the <a> element