### PR TITLE
style(calendar): fix style for month/year view with multiple months

### DIFF
--- a/src/elements/calendar/calendar/calendar.scss
+++ b/src/elements/calendar/calendar/calendar.scss
@@ -31,7 +31,7 @@
 
 .sbb-calendar__day-view {
   :host(:not(:state(view-day))) & {
-    visibility: hidden;
+    display: none;
   }
 }
 


### PR DESCRIPTION
There's a bug on calendar when not in day view and amount > 1:

<img width="2143" height="891" alt="image" src="https://github.com/user-attachments/assets/0bc9aa43-3020-4b04-8fdc-deb76a484881" />