### PR TITLE
docs(checkbox-panel): add backticks to badge tag

### DIFF
--- a/src/elements/checkbox-panel/readme.md
+++ b/src/elements/checkbox-panel/readme.md
@@ -7,7 +7,7 @@ The `<sbb-checkbox-panel>` component provides the same functionality as a native
 It is possible to provide a label via an unnamed slot;
 additionally the slots named `subtext` can be used to provide a subtext and
 the slot named `suffix` can be used to provide suffix items.
-If you use a <sbb-card-badge>, the slot `badge` is automatically assigned.
+If you use a `<sbb-card-badge>`, the slot `badge` is automatically assigned.
 
 ```html
 <sbb-checkbox-panel>


### PR DESCRIPTION
Badge tag without backticks is wrongly interpreted in the lyne-angular docs rendering.

<img width="1145" height="221" alt="image" src="https://github.com/user-attachments/assets/147b8ca4-ae61-45e2-af62-7fac694168ae" />
