### PR TITLE
fix(calendar): prevent null day crash with min/max updates

### DIFF
--- a/src/elements/calendar/calendar-day/calendar-day.component.ts
+++ b/src/elements/calendar/calendar-day/calendar-day.component.ts
@@ -85,6 +85,9 @@ export class SbbCalendarDayElement<T = Date> extends SbbCalendarCellBaseElement<
   }
 
   private _isDayInRange(min: T | null, max: T | null): boolean {
+    if (!this.value) {
+      return true;
+    }
     if (!min && !max) {
       return true;
     }
@@ -97,7 +100,7 @@ export class SbbCalendarDayElement<T = Date> extends SbbCalendarCellBaseElement<
 
   protected override renderTemplate(): TemplateResult {
     return html` <span class="sbb-calendar-day__value" aria-hidden="true">
-        ${this.dateAdapter.getDate(this.value)}
+        ${this.value ? this.dateAdapter.getDate(this.value) : ''}
       </span>
       <span class="sbb-calendar-day__extra">
         <slot @slotchange=${(event: Event) => this._handleSlotchange(event)}></slot>

--- a/src/elements/calendar/calendar-day/calendar-day.component.ts
+++ b/src/elements/calendar/calendar-day/calendar-day.component.ts
@@ -85,10 +85,7 @@ export class SbbCalendarDayElement<T = Date> extends SbbCalendarCellBaseElement<
   }
 
   private _isDayInRange(min: T | null, max: T | null): boolean {
-    if (!this.value) {
-      return true;
-    }
-    if (!min && !max) {
+    if (!this.value || (!min && !max)) {
       return true;
     }
     return this.dateAdapter.sameDate(this.value, this.dateAdapter.clampDate(this.value, min, max));

--- a/src/elements/calendar/calendar-day/calendar-day.spec.ts
+++ b/src/elements/calendar/calendar-day/calendar-day.spec.ts
@@ -29,6 +29,23 @@ describe('sbb-calendar-day', () => {
     assert.instanceOf(todayElement, SbbCalendarDayElement);
   });
 
+  it('does not crash when parent min/max updates before slotted day value is initialized', async () => {
+    root = await fixture(html`
+      <sbb-calendar>
+        <sbb-calendar-day></sbb-calendar-day>
+      </sbb-calendar>
+    `);
+    const min = defaultDateAdapter.createDate(year, month, 10);
+    const max = defaultDateAdapter.createDate(year, month, 20);
+
+    root.min = min;
+    root.max = max;
+    await waitForLitRender(root);
+    const day = root.querySelector<SbbCalendarDayElement>('sbb-calendar-day');
+    expect(day).to.exist;
+    expect(day?.disabled).to.be.false;
+  });
+
   it('should have the correct properties on todayElement', async () => {
     expect(todayElement).to.match(':state(current)');
     expect(todayElement).not.to.match(':state(crossed-out)');

--- a/src/elements/calendar/calendar-day/calendar-day.spec.ts
+++ b/src/elements/calendar/calendar-day/calendar-day.spec.ts
@@ -29,23 +29,6 @@ describe('sbb-calendar-day', () => {
     assert.instanceOf(todayElement, SbbCalendarDayElement);
   });
 
-  it('does not crash when parent min/max updates before slotted day value is initialized', async () => {
-    root = await fixture(html`
-      <sbb-calendar>
-        <sbb-calendar-day></sbb-calendar-day>
-      </sbb-calendar>
-    `);
-    const min = defaultDateAdapter.createDate(year, month, 10);
-    const max = defaultDateAdapter.createDate(year, month, 20);
-
-    root.min = min;
-    root.max = max;
-    await waitForLitRender(root);
-    const day = root.querySelector<SbbCalendarDayElement>('sbb-calendar-day');
-    expect(day).to.exist;
-    expect(day?.disabled).to.be.false;
-  });
-
   it('should have the correct properties on todayElement', async () => {
     expect(todayElement).to.match(':state(current)');
     expect(todayElement).not.to.match(':state(crossed-out)');

--- a/src/elements/calendar/calendar/calendar.spec.ts
+++ b/src/elements/calendar/calendar/calendar.spec.ts
@@ -2244,4 +2244,23 @@ describe(`sbb-calendar`, () => {
       });
     });
   });
+
+  describe('misconfiguration', () => {
+    it('handles days with no slot', async () => {
+      const elem = await fixture(html`
+        <sbb-calendar min="2026-01-10" max="2026-01-20">
+          <sbb-calendar-day></sbb-calendar-day>
+        </sbb-calendar>
+      `);
+
+      const day = elem.querySelector<SbbCalendarDayElement>('sbb-calendar-day')!;
+      // also, expect not to raise errors
+      expect(day.disabled).to.be.false;
+
+      day.slot = '2026-01-25';
+      await waitForLitRender(elem);
+
+      expect(day.disabled).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- guard `sbb-calendar-day` range checks when the day value is temporarily null/uninitialized
- guard day rendering so `dateAdapter.getDate` is not called with `null`
- add regression test for slotted `sbb-calendar-day` without initialized slot while `min`/`max` are set

## Root cause
`SbbCalendarDayElement` may run update logic before `slot` has initialized `value`. In that transient state, date adapter methods were called with `null`, which could crash in either rendering (`getDate`) or range checks (`_isDayInRange` -> `clampDate` -> `compareDate`).

## Verification
- `yarn -s wtr --group default src/elements/calendar/calendar-day/calendar-day.spec.ts`

Closes #5122