### PR TITLE
fix(date-input, time-input): avoid setCursorAt exception

### DIFF
--- a/src/elements/core/mixins/form-associated-input-mixin.ts
+++ b/src/elements/core/mixins/form-associated-input-mixin.ts
@@ -425,12 +425,12 @@ export const SbbFormAssociatedInputMixin = <
 
     private _setCursorAt(position: number): void {
       const selection = window.getSelection();
-      if (!selection) {
+      if (!this.firstChild || !selection) {
         return;
       }
 
       const range = document.createRange();
-      range.setStart(this.firstChild!, position);
+      range.setStart(this.firstChild, position);
       range.collapse(true);
       selection.removeAllRanges();
       selection.addRange(range);


### PR DESCRIPTION
Bug #5044 has been replicated on Chrome with mobile emulation and it's caused by the keyup listener;
a possible tested solution was add a nbsp as done in the touchend listener, but it causes the placholder to flicker.

Simply checking that the firstChild is available solves the issue; however we do not have specific tests for the _requiresEmptyPatch function, which is Blink-dependant