### PR TITLE
fix(tag): dispatch change event on deselected tags in exclusive mode

### DIFF
--- a/src/elements/tag/tag-group/tag-group.component.ts
+++ b/src/elements/tag/tag-group/tag-group.component.ts
@@ -81,7 +81,10 @@ export class SbbTagGroupElement<T = string> extends SbbDisabledMixin(
 
   /** The child instances of sbb-tag as an array. */
   public get tags(): SbbTagElement<T>[] {
-    return Array.from(this.querySelectorAll?.<SbbTagElement<T>>('sbb-tag') ?? []);
+    return Array.from(this.querySelectorAll?.<SbbTagElement<T>>('sbb-tag') ?? [], (t) => {
+      customElements.upgrade(t);
+      return t;
+    });
   }
 
   public constructor() {

--- a/src/elements/tag/tag-group/tag-group.spec.ts
+++ b/src/elements/tag/tag-group/tag-group.spec.ts
@@ -447,8 +447,8 @@ describe(`sbb-tag-group`, () => {
         await inputSpy.calledOnce();
         expect(inputSpy.count).to.be.equal(1);
 
-        await changeSpy.calledOnce();
-        expect(changeSpy.count).to.be.equal(1);
+        await changeSpy.calledTimes(2);
+        expect(changeSpy.count).to.be.equal(2);
 
         expect(element.value).to.be.equal('tag3');
         expect(
@@ -464,8 +464,16 @@ describe(`sbb-tag-group`, () => {
         const tag1 = element.querySelector('sbb-tag#sbb-tag-1') as SbbTagElement;
         const tag2 = element.querySelector('sbb-tag#sbb-tag-2') as SbbTagElement;
 
+        const changePromise = new Promise((resolve) => {
+          tag2.addEventListener('change', resolve, { once: true });
+        });
+
         tag1.click();
-        await waitForLitRender(element);
+        await inputSpy.calledOnce();
+        expect(inputSpy.count).to.be.equal(1);
+
+        // If the first change event occurs, every tag should be configured
+        await changePromise;
 
         expect(elementInternals.get(tag1)!.ariaChecked).to.equal('true');
         expect(tag1.checked).to.be.equal(true);
@@ -473,18 +481,22 @@ describe(`sbb-tag-group`, () => {
         expect(elementInternals.get(tag2)!.ariaChecked).to.equal('false');
         expect(tag2.checked).to.be.equal(false);
 
-        await inputSpy.calledOnce();
-        expect(inputSpy.count).to.be.equal(1);
-
-        await changeSpy.calledOnce();
-        expect(changeSpy.count).to.be.equal(1);
-
         expect(element.value).to.be.equal('tag1');
         expect(
           Array.from(element.querySelectorAll('sbb-tag')).filter(
             (t) => elementInternals.get(t)!.ariaChecked === 'true',
           ).length,
         ).to.be.equal(1);
+
+        expect(changeSpy.count).to.be.equal(2);
+
+        // Programmatic change after a user change should not trigger events.
+        tag2.checked = true;
+        await waitForLitRender(element);
+
+        // Counts should stay like they were before
+        expect(inputSpy.count).to.be.equal(1);
+        expect(changeSpy.count).to.be.equal(2);
       });
 
       it('should select another tag programmatically and uncheck others', async () => {

--- a/src/elements/tag/tag/tag.component.ts
+++ b/src/elements/tag/tag/tag.component.ts
@@ -1,6 +1,7 @@
 import {
   type CSSResultGroup,
   html,
+  type PropertyDeclaration,
   type PropertyValues,
   type TemplateResult,
   unsafeCSS,
@@ -61,12 +62,16 @@ export class SbbTagElement<T = string> extends SbbIconNameMixin(
   @property({ reflect: true })
   public accessor size: 's' | 'm' | null = null;
 
+  // Tracks whether the most recent `checked` change was initiated by the user
+  // (via _setCheckedFromUser / click).
+  private _checkedChangedByUser = false;
+
   public constructor() {
     super();
     this.addEventListener?.('click', () => this._handleClick());
     this.addController(
       new SbbPropertyWatcherController(this, () => this._tagGroup(), {
-        multiple: () => this._updateAriaRole(),
+        multiple: (g) => this._updateAriaRole(g),
         size: (g) => {
           this.size = g.size;
         },
@@ -78,8 +83,7 @@ export class SbbTagElement<T = string> extends SbbIconNameMixin(
     return this.closest?.('sbb-tag-group') ?? null;
   }
 
-  private _updateAriaRole(): void {
-    const tagGroup = this._tagGroup();
+  private _updateAriaRole(tagGroup = this._tagGroup()): void {
     if (tagGroup && !tagGroup.multiple) {
       this.internals.role = 'radio';
       this.internals.ariaChecked = `${this.checked}`;
@@ -106,14 +110,24 @@ export class SbbTagElement<T = string> extends SbbIconNameMixin(
     if (tagGroup && !tagGroup.multiple && this.checked) {
       return;
     }
-    this.checked = !this.checked;
+    this._setCheckedFromUser(!this.checked);
     this.dispatchEvent(
       new InputEvent('input', {
         bubbles: true,
         composed: true,
       }),
     );
+  }
 
+  private _setCheckedFromUser(checked: boolean): void {
+    if (this.checked === checked) {
+      return;
+    }
+    this._checkedChangedByUser = true;
+    this.checked = checked;
+  }
+
+  private _dispatchChangeEvents(): void {
     /**
      * The change event is fired when the user modifies the element's value.
      * Unlike the input event, the change event is not necessarily fired
@@ -128,24 +142,52 @@ export class SbbTagElement<T = string> extends SbbIconNameMixin(
     this.dispatchEvent(new Event('didChange', { bubbles: true }));
   }
 
-  protected override willUpdate(changedProperties: PropertyValues<this>): void {
-    super.willUpdate(changedProperties);
-    const tagGroup = this._tagGroup();
+  public override requestUpdate(
+    name?: PropertyKey,
+    oldValue?: unknown,
+    options?: PropertyDeclaration,
+  ): void {
+    super.requestUpdate(name, oldValue, options);
 
-    if (changedProperties.has('checked')) {
-      this._updateAriaRole();
+    if (name === 'checked') {
       this.toggleState('checked', this.checked);
       this.updateFormValue();
+      this._updateAriaRole();
     }
+  }
 
-    if (tagGroup && !tagGroup.multiple && changedProperties.has('checked')) {
-      if (this.checked) {
-        tagGroup.tags.forEach((t) => {
-          t.tabIndex = t === this ? 0 : -1;
-          t.checked = t === this;
-        });
-      } else if (!tagGroup.tags.some((t) => t.checked)) {
-        tagGroup['updateExclusiveTabIndex']();
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    super.willUpdate(changedProperties);
+    const checkedChangedByUser = this._checkedChangedByUser;
+
+    if (changedProperties.has('checked')) {
+      const tagGroup = this._tagGroup();
+      if (tagGroup && !tagGroup.multiple) {
+        if (this.checked) {
+          tagGroup.tags.forEach((t) => {
+            t.tabIndex = t === this ? 0 : -1;
+            if (t !== this) {
+              if (checkedChangedByUser) {
+                t._setCheckedFromUser(false);
+              } else {
+                t.checked = false;
+              }
+            }
+          });
+        } else if (!tagGroup.tags.some((t) => t.checked)) {
+          tagGroup['updateExclusiveTabIndex']();
+        }
+      }
+    }
+  }
+
+  protected override updated(changedProperties: PropertyValues<this>): void {
+    super.updated(changedProperties);
+
+    if (changedProperties.has('checked')) {
+      if (this._checkedChangedByUser) {
+        this._dispatchChangeEvents();
+        this._checkedChangedByUser = false;
       }
     }
   }

--- a/src/elements/tag/tag/tag.component.ts
+++ b/src/elements/tag/tag/tag.component.ts
@@ -77,6 +77,13 @@ export class SbbTagElement<T = string> extends SbbIconNameMixin(
         },
       }),
     );
+    this._updateCheckedState();
+  }
+
+  private _updateCheckedState(): void {
+    this.toggleState('checked', this.checked);
+    this.updateFormValue();
+    this._updateAriaRole();
   }
 
   private _tagGroup(): SbbTagGroupElement | null {
@@ -150,9 +157,7 @@ export class SbbTagElement<T = string> extends SbbIconNameMixin(
     super.requestUpdate(name, oldValue, options);
 
     if (name === 'checked') {
-      this.toggleState('checked', this.checked);
-      this.updateFormValue();
-      this._updateAriaRole();
+      this._updateCheckedState();
     }
   }
 


### PR DESCRIPTION
As the tags are our form associated elements, in exclusive mode we should also trigger a change event on tags when a tag was deselected through user selection of another tag. This then helps to keep the state updated in lyne-angular.