### PR TITLE
style(icon): reserve space when changing name

### DIFF
--- a/src/elements/icon/icon-base.ts
+++ b/src/elements/icon/icon-base.ts
@@ -60,6 +60,7 @@ export abstract class SbbIconBase extends SbbElement {
     }
 
     const svgIcon = this.fetchSvgIcon(this._svgNamespace, name);
+    this.toggleState('empty', true);
     this._svgIcon = svgIcon.then((v) => unsafeHTML(v));
     try {
       this.toggleState('empty', !(await svgIcon));


### PR DESCRIPTION
Currently, when changing the icon name, e.g. if the type of the `sbb-status` changes, the width collapses. With this solution the empty state (which was only set in the constructor) is now set before every reload again.