### PR TITLE
fix(dialog): ignore consumer set dimension on mobile view

### DIFF
--- a/src/elements/core/testing/private/breakpoints.ts
+++ b/src/elements/core/testing/private/breakpoints.ts
@@ -2,10 +2,12 @@ import {
   SbbBreakpointLargeMin,
   SbbBreakpointSmallMin,
   SbbBreakpointUltraMin,
+  SbbBreakpointZeroMax,
 } from '@sbb-esta/lyne-design-tokens';
 
 const baseFontSizePx = 16;
 
+export const sbbBreakpointZeroMaxPx = parseFloat(SbbBreakpointZeroMax) * baseFontSizePx;
 export const sbbBreakpointSmallMinPx = parseFloat(SbbBreakpointSmallMin) * baseFontSizePx;
 export const sbbBreakpointLargeMinPx = parseFloat(SbbBreakpointLargeMin) * baseFontSizePx;
 export const sbbBreakpointUltraMinPx = parseFloat(SbbBreakpointUltraMin) * baseFontSizePx;

--- a/src/elements/dialog/_dialog.global.scss
+++ b/src/elements/dialog/_dialog.global.scss
@@ -9,8 +9,6 @@ $theme: 'standard' !default;
   --sbb-dialog-block-shadow: var(--sbb-box-shadow-level-9-soft);
   --sbb-dialog-color-negative: var(--sbb-color-2-negative);
   --sbb-dialog-block-shadow-negative: var(--sbb-box-shadow-level-9-soft-negative);
-  --sbb-dialog-width: auto;
-  --sbb-dialog-height: auto;
   --sbb-dialog-inset-block: 0 auto;
   --sbb-dialog-inset-inline: 0 auto;
   --sbb-dialog-border-radius: var(--sbb-border-radius-8x);
@@ -22,18 +20,15 @@ $theme: 'standard' !default;
   --sbb-dialog-actions-border-color: var(--sbb-background-color-4);
   --sbb-dialog-close-button-inset-inline-end: var(--sbb-spacing-fixed-4x);
   --sbb-dialog-close-button-margin-inline: var(--sbb-spacing-fixed-2x) var(--sbb-spacing-fixed-4x);
-
-  @include sbb.mq($to: small) {
-    --_sbb-dialog-max-width: 100%;
-    --_sbb-dialog-max-height: calc(100vh - var(--sbb-spacing-fixed-6x));
-  }
+  --_sbb-dialog-max-width: 100%;
+  --_sbb-dialog-max-height: calc(100vh - var(--sbb-spacing-fixed-6x));
 }
 
 @mixin breakpoint-small {
   --sbb-dialog-padding-inline: var(--sbb-spacing-fixed-8x);
-  --sbb-dialog-max-height: calc(100vh - 2 * var(--sbb-spacing-fixed-6x));
-  --sbb-dialog-max-width: 90vw;
   --sbb-dialog-translate-y: var(--sbb-spacing-fixed-4x);
+  --_sbb-dialog-max-height: calc(100vh - 2 * var(--sbb-spacing-fixed-6x));
+  --_sbb-dialog-max-width: 90vw;
 }
 
 @mixin rules {

--- a/src/elements/dialog/_dialog.global.scss
+++ b/src/elements/dialog/_dialog.global.scss
@@ -10,9 +10,7 @@ $theme: 'standard' !default;
   --sbb-dialog-color-negative: var(--sbb-color-2-negative);
   --sbb-dialog-block-shadow-negative: var(--sbb-box-shadow-level-9-soft-negative);
   --sbb-dialog-width: auto;
-  --sbb-dialog-max-width: 100%;
   --sbb-dialog-height: auto;
-  --sbb-dialog-max-height: calc(100vh - var(--sbb-spacing-fixed-6x));
   --sbb-dialog-inset-block: 0 auto;
   --sbb-dialog-inset-inline: 0 auto;
   --sbb-dialog-border-radius: var(--sbb-border-radius-8x);
@@ -24,6 +22,11 @@ $theme: 'standard' !default;
   --sbb-dialog-actions-border-color: var(--sbb-background-color-4);
   --sbb-dialog-close-button-inset-inline-end: var(--sbb-spacing-fixed-4x);
   --sbb-dialog-close-button-margin-inline: var(--sbb-spacing-fixed-2x) var(--sbb-spacing-fixed-4x);
+
+  @include sbb.mq($to: small) {
+    --_sbb-dialog-max-width: 100%;
+    --_sbb-dialog-max-height: calc(100vh - var(--sbb-spacing-fixed-6x));
+  }
 }
 
 @mixin breakpoint-small {

--- a/src/elements/dialog/dialog/dialog.scss
+++ b/src/elements/dialog/dialog/dialog.scss
@@ -100,8 +100,8 @@
   inset-block: auto 0;
   border: none;
   border-radius: var(--sbb-dialog-border-radius) var(--sbb-dialog-border-radius) 0 0;
-  max-width: var(--sbb-dialog-max-width);
-  max-height: var(--sbb-dialog-max-height);
+  max-width: var(--_sbb-dialog-max-width, var(--sbb-dialog-max-width));
+  max-height: var(--_sbb-dialog-max-height, var(--sbb-dialog-max-height));
   color: var(--_sbb-dialog-color);
   background-color: var(--sbb-dialog-background-color);
 
@@ -135,7 +135,7 @@
 
 :host(:state(has-intermediate-element)) ::slotted(:first-child),
 .sbb-dialog__wrapper {
-  max-height: var(--sbb-dialog-max-height);
+  max-height: var(--_sbb-dialog-max-height, var(--sbb-dialog-max-height));
 
   @include sbb.mq($from: small) {
     width: var(--sbb-dialog-width);

--- a/src/elements/dialog/dialog/dialog.scss
+++ b/src/elements/dialog/dialog/dialog.scss
@@ -100,13 +100,14 @@
   inset-block: auto 0;
   border: none;
   border-radius: var(--sbb-dialog-border-radius) var(--sbb-dialog-border-radius) 0 0;
-  max-width: var(--_sbb-dialog-max-width, var(--sbb-dialog-max-width));
-  max-height: var(--_sbb-dialog-max-height, var(--sbb-dialog-max-height));
+  max-width: var(--_sbb-dialog-max-width);
+  max-height: var(--_sbb-dialog-max-height);
   color: var(--_sbb-dialog-color);
   background-color: var(--sbb-dialog-background-color);
+  flex-direction: column;
 
   :host(:is(:state(state-opening), :state(state-opened), :state(state-closing))) & {
-    display: block;
+    display: flex;
 
     animation: {
       name: open;
@@ -125,8 +126,10 @@
   }
 
   @include sbb.mq($from: small) {
-    height: var(--sbb-dialog-height);
     width: var(--sbb-dialog-width);
+    height: var(--sbb-dialog-height);
+    max-width: var(--sbb-dialog-max-width, var(--_sbb-dialog-max-width));
+    max-height: var(--sbb-dialog-max-height, var(--_sbb-dialog-max-height));
     inset: unset;
     border-radius: var(--sbb-dialog-border-radius);
     overflow: hidden;
@@ -135,12 +138,12 @@
 
 :host(:state(has-intermediate-element)) ::slotted(:first-child),
 .sbb-dialog__wrapper {
-  max-height: var(--_sbb-dialog-max-height, var(--sbb-dialog-max-height));
+  display: flex;
+  flex-direction: column;
 
-  @include sbb.mq($from: small) {
-    width: var(--sbb-dialog-width);
-    height: var(--sbb-dialog-height);
-  }
+  // Width min-height: 0 we allow the container to be adapted to the parent's height
+  min-height: 0;
+  max-height: 100%;
 }
 
 :host(:state(has-intermediate-element)) ::slotted(:first-child),

--- a/src/elements/dialog/dialog/dialog.spec.ts
+++ b/src/elements/dialog/dialog/dialog.spec.ts
@@ -5,11 +5,7 @@ import type { Context } from 'mocha';
 
 import type { SbbAutocompleteElement } from '../../autocomplete.pure.ts';
 import type { SbbButtonElement } from '../../button.ts';
-import {
-  sbbBreakpointLargeMinPx,
-  sbbBreakpointZeroMaxPx,
-  tabKey,
-} from '../../core/testing/private.ts';
+import { sbbBreakpointLargeMinPx, tabKey } from '../../core/testing/private.ts';
 import { EventSpy, waitForCondition, waitForLitRender } from '../../core/testing.ts';
 import { i18nDialog } from '../../core.ts';
 import { SbbStepElement } from '../../stepper/step/step.component.ts';
@@ -468,39 +464,6 @@ describe('sbb-dialog', () => {
       element.announceTitle();
 
       expect(ariaLiveRef.textContent!.trim()).to.be.equal(`${i18nDialog.en}, Special Dialog`);
-    });
-  });
-
-  describe('mobile view', () => {
-    let element: SbbDialogElement;
-
-    beforeEach(async () => {
-      await setViewport({ width: sbbBreakpointZeroMaxPx, height: 600 });
-      const root = await fixture(html`
-        <div>
-          <button id="trigger"></button>
-          <sbb-dialog trigger="trigger">
-            <sbb-dialog-title>Title</sbb-dialog-title>
-            <sbb-dialog-content>Dialog content</sbb-dialog-content>
-            <sbb-dialog-actions>Action group</sbb-dialog-actions>
-          </sbb-dialog>
-        </div>
-      `);
-      element = root.querySelector('sbb-dialog')!;
-    });
-
-    it('setting the max-width does not change the dialog dimensions', async () => {
-      await openDialog(element);
-      const innerDialog = element.shadowRoot!.querySelector('.sbb-dialog')!;
-
-      expect(getComputedStyle(innerDialog).getPropertyValue('width')).to.be.equal(
-        `${sbbBreakpointZeroMaxPx}px`,
-      );
-
-      element.style.setProperty('--sbb-dialog-max-width', '50px');
-      expect(getComputedStyle(innerDialog).getPropertyValue('width')).to.be.equal(
-        `${sbbBreakpointZeroMaxPx}px`,
-      );
     });
   });
 

--- a/src/elements/dialog/dialog/dialog.spec.ts
+++ b/src/elements/dialog/dialog/dialog.spec.ts
@@ -5,7 +5,11 @@ import type { Context } from 'mocha';
 
 import type { SbbAutocompleteElement } from '../../autocomplete.pure.ts';
 import type { SbbButtonElement } from '../../button.ts';
-import { sbbBreakpointLargeMinPx, tabKey } from '../../core/testing/private.ts';
+import {
+  sbbBreakpointLargeMinPx,
+  sbbBreakpointZeroMaxPx,
+  tabKey,
+} from '../../core/testing/private.ts';
 import { EventSpy, waitForCondition, waitForLitRender } from '../../core/testing.ts';
 import { i18nDialog } from '../../core.ts';
 import { SbbStepElement } from '../../stepper/step/step.component.ts';
@@ -464,6 +468,39 @@ describe('sbb-dialog', () => {
       element.announceTitle();
 
       expect(ariaLiveRef.textContent!.trim()).to.be.equal(`${i18nDialog.en}, Special Dialog`);
+    });
+  });
+
+  describe('mobile view', () => {
+    let element: SbbDialogElement;
+
+    beforeEach(async () => {
+      await setViewport({ width: sbbBreakpointZeroMaxPx, height: 600 });
+      const root = await fixture(html`
+        <div>
+          <button id="trigger"></button>
+          <sbb-dialog trigger="trigger">
+            <sbb-dialog-title>Title</sbb-dialog-title>
+            <sbb-dialog-content>Dialog content</sbb-dialog-content>
+            <sbb-dialog-actions>Action group</sbb-dialog-actions>
+          </sbb-dialog>
+        </div>
+      `);
+      element = root.querySelector('sbb-dialog')!;
+    });
+
+    it('setting the max-width does not change the dialog dimensions', async () => {
+      await openDialog(element);
+      const innerDialog = element.shadowRoot!.querySelector('.sbb-dialog')!;
+
+      expect(getComputedStyle(innerDialog).getPropertyValue('width')).to.be.equal(
+        `${sbbBreakpointZeroMaxPx}px`,
+      );
+
+      element.style.setProperty('--sbb-dialog-max-width', '50px');
+      expect(getComputedStyle(innerDialog).getPropertyValue('width')).to.be.equal(
+        `${sbbBreakpointZeroMaxPx}px`,
+      );
     });
   });
 

--- a/src/elements/dialog/dialog/dialog.visual.spec.ts
+++ b/src/elements/dialog/dialog/dialog.visual.spec.ts
@@ -237,8 +237,8 @@ describe(`sbb-dialog`, () => {
         );
         setup.withPostSetupAction(() => {
           const dialog = setup.snapshotElement.querySelector<SbbDialogElement>('#dialog')!;
-          dialog.style.setProperty('--sbb-dialog-max-width', '50%');
-          dialog.style.setProperty('--sbb-dialog-max-height', '400px');
+          dialog.style.setProperty('--sbb-dialog-width', '50%');
+          dialog.style.setProperty('--sbb-dialog-height', '400px');
           const button = setup.snapshotElement.querySelector<SbbButtonElement>('#trigger')!;
           button.click();
         });

--- a/src/elements/dialog/dialog/dialog.visual.spec.ts
+++ b/src/elements/dialog/dialog/dialog.visual.spec.ts
@@ -2,6 +2,7 @@ import { html, nothing, type TemplateResult } from 'lit';
 
 import type { SbbButtonElement } from '../../button.ts';
 import { describeEach, describeViewports, visualDiffDefault } from '../../core/testing/private.ts';
+import type { SbbDialogElement } from '../../dialog.ts';
 
 import '../../dialog.ts';
 
@@ -222,6 +223,27 @@ describe(`sbb-dialog`, () => {
         });
       }),
     );
+
+    it('set dimensions', () => {
+      visualDiffDefault.with(async (setup) => {
+        await setup.withFixture(
+          html`
+            <sbb-button id="trigger">Trigger</sbb-button>
+            <sbb-dialog id="dialog" trigger="trigger">
+              ${dialogTitle()} ${dialogContent()}
+            </sbb-dialog>
+          `,
+          { minHeight: '600px' },
+        );
+        setup.withPostSetupAction(() => {
+          const dialog = setup.snapshotElement.querySelector<SbbDialogElement>('#dialog')!;
+          dialog.style.setProperty('--sbb-dialog-max-width', '50%');
+          dialog.style.setProperty('--sbb-dialog-max-height', '400px');
+          const button = setup.snapshotElement.querySelector<SbbButtonElement>('#trigger')!;
+          button.click();
+        });
+      });
+    });
 
     describeEach(
       {

--- a/src/elements/dialog/dialog/dialog.visual.spec.ts
+++ b/src/elements/dialog/dialog/dialog.visual.spec.ts
@@ -224,7 +224,8 @@ describe(`sbb-dialog`, () => {
       }),
     );
 
-    it('set dimensions', () => {
+    it(
+      'set dimensions',
       visualDiffDefault.with(async (setup) => {
         await setup.withFixture(
           html`
@@ -242,8 +243,8 @@ describe(`sbb-dialog`, () => {
           const button = setup.snapshotElement.querySelector<SbbButtonElement>('#trigger')!;
           button.click();
         });
-      });
-    });
+      }),
+    );
 
     describeEach(
       {


### PR DESCRIPTION
Part of https://github.com/sbb-design-systems/lyne-angular/pull/551