### PR TITLE
fix: avoid inerting relevant overlays that don't use the inert controller

### DIFF
--- a/src/elements/core/controllers/__snapshots__/inert-controller.spec.snap.js
+++ b/src/elements/core/controllers/__snapshots__/inert-controller.spec.snap.js
@@ -265,3 +265,47 @@ snapshots["inert with shadow DOM should remove inert Shadow DOM"] =
 `;
 /* end snapshot inert with shadow DOM should remove inert Shadow DOM */
 
+snapshots["inert ignored elements as direct siblings should never mark ignored elements as inert"] = 
+`<div>
+  <div id="overlay">
+  </div>
+  <template>
+  </template>
+</div>
+`;
+/* end snapshot inert ignored elements as direct siblings should never mark ignored elements as inert */
+
+snapshots["inert ignored elements nested inside a wrapper should carve a path down to the ignored element, inerting its siblings instead"] = 
+`<div>
+  <div id="overlay">
+  </div>
+  <div id="wrapper">
+    <div class="sbb-overlay-outlet">
+    </div>
+    <div
+      aria-hidden="true"
+      data-sbb-aria-hidden=""
+      data-sbb-inert=""
+      id="sibling"
+      inert=""
+    >
+    </div>
+  </div>
+</div>
+`;
+/* end snapshot inert ignored elements nested inside a wrapper should carve a path down to the ignored element, inerting its siblings instead */
+
+snapshots["inert ignored elements nested inside a wrapper should fully remove the inert state again on deactivation"] = 
+`<div>
+  <div id="overlay">
+  </div>
+  <div id="wrapper">
+    <div class="sbb-overlay-outlet">
+    </div>
+    <div id="sibling">
+    </div>
+  </div>
+</div>
+`;
+/* end snapshot inert ignored elements nested inside a wrapper should fully remove the inert state again on deactivation */
+

--- a/src/elements/core/controllers/inert-controller.spec.ts
+++ b/src/elements/core/controllers/inert-controller.spec.ts
@@ -19,10 +19,40 @@ class ShadowElement extends LitElement {
 
 customElements.define('shadow-element', ShadowElement);
 
+class ShadowWrapperElement extends LitElement {
+  protected override render(): TemplateResult {
+    return html`<div class="sbb-live-announcer-element"></div>
+      <div id="sibling"></div>`;
+  }
+}
+
+customElements.define('shadow-wrapper-element', ShadowWrapperElement);
+
+/**
+ * `HTMLElement.inert` only reflects the element's own `inert` attribute, not whether it is
+ * effectively inert because an ancestor has `inert` set (native inert state is inherited by
+ * descendants). This helper walks up the (Shadow DOM piercing) ancestor chain to determine
+ * whether an element is effectively inert.
+ */
+function isEffectivelyInert(element: HTMLElement): boolean {
+  let current: HTMLElement | null = element;
+
+  while (current) {
+    if (current.inert) {
+      return true;
+    }
+    current =
+      current.parentElement ?? ((current.getRootNode() as ShadowRoot)?.host as HTMLElement) ?? null;
+  }
+
+  return false;
+}
+
 describe('inert', () => {
   let element: HTMLElement;
   let inertElements: Set<HTMLElement>;
   let inertOverlays: Set<HTMLElement>;
+  let exemptedElements: Set<HTMLElement>;
   let inertControllerOverlay: SbbInertController;
   let inertControllerOverlay2: SbbInertController;
 
@@ -31,12 +61,14 @@ describe('inert', () => {
       overlay as unknown as ReactiveControllerHost & SbbOpenCloseBaseElement,
       inertElements,
       inertOverlays,
+      exemptedElements,
     );
 
   // Reset state for each test
   beforeEach(() => {
     inertElements = new Set<HTMLElement>();
     inertOverlays = new Set<HTMLElement>();
+    exemptedElements = new Set<HTMLElement>();
   });
 
   describe('light DOM', () => {
@@ -110,6 +142,127 @@ describe('inert', () => {
     });
   });
 
+  describe('ignored elements', () => {
+    describe('as direct siblings', () => {
+      let scriptElement: HTMLScriptElement;
+      let templateElement: HTMLTemplateElement;
+      let styleElement: HTMLStyleElement;
+
+      beforeEach(async () => {
+        element = await fixture(
+          html`<div>
+            <div id="overlay"></div>
+            <script></script>
+            <template></template>
+            <style></style>
+          </div>`,
+        );
+
+        scriptElement = element.querySelector<HTMLScriptElement>('script')!;
+        templateElement = element.querySelector<HTMLTemplateElement>('template')!;
+        styleElement = element.querySelector<HTMLStyleElement>('style')!;
+        inertControllerOverlay = createInertController(
+          element.querySelector<HTMLDivElement>('#overlay')!,
+        );
+      });
+
+      it('should never mark ignored elements as inert', async () => {
+        inertControllerOverlay.activate();
+
+        for (const ignored of [scriptElement, templateElement, styleElement]) {
+          expect(ignored.inert).to.be.false;
+          expect(ignored.hasAttribute('aria-hidden')).to.be.false;
+        }
+        await expect(element).dom.to.equalSnapshot();
+      });
+    });
+
+    describe('nested inside a wrapper', () => {
+      let wrapperElement: HTMLDivElement;
+      let overlayOutlet: HTMLTemplateElement;
+      let siblingElement: HTMLDivElement;
+
+      beforeEach(async () => {
+        element = await fixture(
+          html`<div>
+            <div id="overlay"></div>
+            <div id="wrapper">
+              <div class="sbb-overlay-outlet"></div>
+              <div id="sibling"></div>
+            </div>
+          </div>`,
+        );
+
+        wrapperElement = element.querySelector<HTMLDivElement>('#wrapper')!;
+        overlayOutlet = wrapperElement.querySelector<HTMLTemplateElement>('.sbb-overlay-outlet')!;
+        siblingElement = element.querySelector<HTMLDivElement>('#sibling')!;
+        inertControllerOverlay = createInertController(
+          element.querySelector<HTMLDivElement>('#overlay')!,
+        );
+      });
+
+      it('should carve a path down to the ignored element, inerting its siblings instead', async () => {
+        inertControllerOverlay.activate();
+
+        expect(wrapperElement.inert).to.be.false;
+        expect(isEffectivelyInert(overlayOutlet)).to.be.false;
+        expect(isEffectivelyInert(siblingElement)).to.be.true;
+        await expect(element).dom.to.equalSnapshot();
+      });
+
+      it('should fully remove the inert state again on deactivation', async () => {
+        inertControllerOverlay.activate();
+        inertControllerOverlay.deactivate();
+
+        expect(wrapperElement.inert).to.be.false;
+        expect(siblingElement.inert).to.be.false;
+        await expect(element).dom.to.equalSnapshot();
+      });
+    });
+
+    describe('nested through Shadow DOM', () => {
+      let shadowWrapperElement: ShadowWrapperElement;
+      let announcerElement: HTMLStyleElement;
+      let siblingElement: HTMLDivElement;
+
+      beforeEach(async () => {
+        element = await fixture(
+          html`<div>
+            <div id="overlay"></div>
+            <shadow-wrapper-element></shadow-wrapper-element>
+          </div>`,
+        );
+
+        shadowWrapperElement =
+          element.querySelector<ShadowWrapperElement>('shadow-wrapper-element')!;
+        announcerElement = shadowWrapperElement.shadowRoot!.querySelector<HTMLStyleElement>(
+          '.sbb-live-announcer-element',
+        )!;
+        siblingElement =
+          shadowWrapperElement.shadowRoot!.querySelector<HTMLDivElement>('#sibling')!;
+        inertControllerOverlay = createInertController(
+          element.querySelector<HTMLDivElement>('#overlay')!,
+        );
+      });
+
+      it('should pierce the Shadow DOM boundary to protect the ignored element', async () => {
+        inertControllerOverlay.activate();
+
+        expect(shadowWrapperElement.inert).to.be.false;
+        expect(isEffectivelyInert(announcerElement)).to.be.false;
+        expect(isEffectivelyInert(siblingElement)).to.be.true;
+      });
+
+      it('should fully remove the inert state again on deactivation', async () => {
+        inertControllerOverlay.activate();
+        inertControllerOverlay.deactivate();
+
+        expect(shadowWrapperElement.inert).to.be.false;
+        expect(siblingElement.inert).to.be.false;
+      });
+    });
+  });
+
   describe('with shadow DOM', () => {
     let shadowElement: ShadowElement;
 
@@ -167,5 +320,7 @@ declare global {
   interface HTMLElementTagNameMap {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     'shadow-element': ShadowElement;
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    'shadow-wrapper-element': ShadowWrapperElement;
   }
 }

--- a/src/elements/core/controllers/inert-controller.spec.ts
+++ b/src/elements/core/controllers/inert-controller.spec.ts
@@ -179,7 +179,7 @@ describe('inert', () => {
 
     describe('nested inside a wrapper', () => {
       let wrapperElement: HTMLDivElement;
-      let overlayOutlet: HTMLTemplateElement;
+      let overlayOutlet: HTMLDivElement;
       let siblingElement: HTMLDivElement;
 
       beforeEach(async () => {
@@ -194,7 +194,7 @@ describe('inert', () => {
         );
 
         wrapperElement = element.querySelector<HTMLDivElement>('#wrapper')!;
-        overlayOutlet = wrapperElement.querySelector<HTMLTemplateElement>('.sbb-overlay-outlet')!;
+        overlayOutlet = wrapperElement.querySelector<HTMLDivElement>('.sbb-overlay-outlet')!;
         siblingElement = element.querySelector<HTMLDivElement>('#sibling')!;
         inertControllerOverlay = createInertController(
           element.querySelector<HTMLDivElement>('#overlay')!,
@@ -222,7 +222,7 @@ describe('inert', () => {
 
     describe('nested through Shadow DOM', () => {
       let shadowWrapperElement: ShadowWrapperElement;
-      let announcerElement: HTMLStyleElement;
+      let announcerElement: HTMLDivElement;
       let siblingElement: HTMLDivElement;
 
       beforeEach(async () => {
@@ -235,7 +235,7 @@ describe('inert', () => {
 
         shadowWrapperElement =
           element.querySelector<ShadowWrapperElement>('shadow-wrapper-element')!;
-        announcerElement = shadowWrapperElement.shadowRoot!.querySelector<HTMLStyleElement>(
+        announcerElement = shadowWrapperElement.shadowRoot!.querySelector<HTMLDivElement>(
           '.sbb-live-announcer-element',
         )!;
         siblingElement =

--- a/src/elements/core/controllers/inert-controller.ts
+++ b/src/elements/core/controllers/inert-controller.ts
@@ -3,6 +3,9 @@ import type { ReactiveController, ReactiveControllerHost } from 'lit';
 import type { SbbOpenCloseBaseElement } from '../base-elements/open-close-base-element.ts';
 
 const IGNORED_ELEMENTS = ['script', 'head', 'template', 'style'];
+
+const DEEP_IGNORED_ELEMENTS_SELECTOR =
+  'sbb-toast,.sbb-overlay-outlet,.sbb-live-announcer-element,.cdk-overlay-container';
 const inertElements = new Set<HTMLElement>();
 const exemptedElements = new Set<HTMLElement>();
 const inertOverlays = new Set<HTMLElement>();
@@ -113,6 +116,14 @@ export class SbbInertController implements ReactiveController {
     }
   }
 
+  /**
+   * Applies the inert state to every element on the page except the current overlay
+   * (and its ancestors).
+   *
+   * This walks the tree bottom-up, starting at the overlay and stepping towards
+   * `document.documentElement` one ancestor at a time, inerting every *sibling* branch
+   * along the way (`_addInertOrCarveIgnoredElements`).
+   */
   private _addAllInertAttributes(): void {
     let element: Element | null = this._currentOverlay();
 
@@ -121,17 +132,59 @@ export class SbbInertController implements ReactiveController {
         .filter(
           (child): child is HTMLElement =>
             child !== element &&
-            child instanceof window.HTMLElement &&
-            !IGNORED_ELEMENTS.includes(child.localName) &&
-            !child.classList.contains('sbb-live-announcer-element'),
+            this._isHTMLElement(child) &&
+            !IGNORED_ELEMENTS.includes(child.localName),
         )
-        .forEach((element) => {
-          this._addInertAttributes(element);
-        });
+        .forEach((sibling) => this._addInertOrCarveIgnoredElements(sibling));
 
       // We need to pierce through Shadow DOM boundary
       element = element?.parentElement ?? (element?.getRootNode() as ShadowRoot)?.host ?? null;
     }
+  }
+
+  /**
+   * Ignored elements (matching `IGNORED_ELEMENTS_SELECTOR`, e.g. `script`, `head`, `template`,
+   * `style`) must never be inert, no matter how deeply nested they are within the tree (looking
+   * from `document.documentElement` down). As inert is inherited by descendants, simply excluding
+   * them from being marked inert themselves is not enough if one of their ancestors is inert. In
+   * that case, the whole path from the ignored element up to `element` needs to stay "carved
+   * free", while every other branch along that path is properly inert instead.
+   */
+  private _addInertOrCarveIgnoredElements(element: HTMLElement): void {
+    if (!this._containsIgnoredElement(element)) {
+      this._addInertAttributes(element);
+      return;
+    }
+
+    // `element` contains an ignored element somewhere in its subtree: don't inert it, but
+    // carve a tunnel through its children (including a potential Shadow DOM) instead.
+    [...element.childNodes, ...(element.shadowRoot?.childNodes ?? [])]
+      .filter((child) => this._isHTMLElement(child))
+      .forEach((child) => this._addInertOrCarveIgnoredElements(child));
+  }
+
+  /**
+   * Recursively (Shadow DOM piercing) checks whether `element` itself, or one of its
+   * descendants, matches `IGNORED_ELEMENTS_SELECTOR`.
+   */
+  private _containsIgnoredElement(element: HTMLElement): boolean {
+    if (
+      element.matches?.(DEEP_IGNORED_ELEMENTS_SELECTOR) ||
+      element.querySelector?.(DEEP_IGNORED_ELEMENTS_SELECTOR) ||
+      element.shadowRoot?.querySelector(DEEP_IGNORED_ELEMENTS_SELECTOR)
+    ) {
+      return true;
+    }
+
+    return (
+      element.shadowRoot ? Array.from(element.shadowRoot.querySelectorAll<HTMLElement>('*')) : []
+    )
+      .concat(Array.from(element.querySelectorAll<HTMLElement>('*')))
+      .some((candidate) => !!candidate.shadowRoot && this._containsIgnoredElement(candidate));
+  }
+
+  private _isHTMLElement(child: Node): child is HTMLElement {
+    return child instanceof window.HTMLElement;
   }
 
   private _addInertAttributes(element: HTMLElement): void {

--- a/src/elements/core/controllers/inert-controller.ts
+++ b/src/elements/core/controllers/inert-controller.ts
@@ -143,8 +143,8 @@ export class SbbInertController implements ReactiveController {
   }
 
   /**
-   * Ignored elements (matching `IGNORED_ELEMENTS_SELECTOR`, e.g. `script`, `head`, `template`,
-   * `style`) must never be inert, no matter how deeply nested they are within the tree (looking
+   * Ignored elements (matching `DEEP_IGNORED_ELEMENTS_SELECTOR`)
+   * must never be inert, no matter how deeply nested they are within the tree (looking
    * from `document.documentElement` down). As inert is inherited by descendants, simply excluding
    * them from being marked inert themselves is not enough if one of their ancestors is inert. In
    * that case, the whole path from the ignored element up to `element` needs to stay "carved
@@ -165,7 +165,7 @@ export class SbbInertController implements ReactiveController {
 
   /**
    * Recursively (Shadow DOM piercing) checks whether `element` itself, or one of its
-   * descendants, matches `IGNORED_ELEMENTS_SELECTOR`.
+   * descendants, matches `DEEP_IGNORED_ELEMENTS_SELECTOR`.
    */
   private _containsIgnoredElement(element: HTMLElement): boolean {
     if (
@@ -176,11 +176,21 @@ export class SbbInertController implements ReactiveController {
       return true;
     }
 
-    return (
-      element.shadowRoot ? Array.from(element.shadowRoot.querySelectorAll<HTMLElement>('*')) : []
-    )
-      .concat(Array.from(element.querySelectorAll<HTMLElement>('*')))
-      .some((candidate) => !!candidate.shadowRoot && this._containsIgnoredElement(candidate));
+    for (const candidate of element.querySelectorAll<HTMLElement>('*')) {
+      if (candidate.shadowRoot && this._containsIgnoredElement(candidate)) {
+        return true;
+      }
+    }
+
+    if (element.shadowRoot) {
+      for (const candidate of element.shadowRoot.querySelectorAll<HTMLElement>('*')) {
+        if (candidate.shadowRoot && this._containsIgnoredElement(candidate)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 
   private _isHTMLElement(child: Node): child is HTMLElement {

--- a/src/elements/core/controllers/inert-controller.ts
+++ b/src/elements/core/controllers/inert-controller.ts
@@ -5,7 +5,7 @@ import type { SbbOpenCloseBaseElement } from '../base-elements/open-close-base-e
 const IGNORED_ELEMENTS = ['script', 'head', 'template', 'style'];
 
 const DEEP_IGNORED_ELEMENTS_SELECTOR =
-  'sbb-toast,.sbb-overlay-outlet,.sbb-live-announcer-element,.cdk-overlay-container';
+  'sbb-toast,.sbb-overlay-outlet,.sbb-live-announcer-element,.cdk-live-announcer-element,.cdk-overlay-container';
 const inertElements = new Set<HTMLElement>();
 const exemptedElements = new Set<HTMLElement>();
 const inertOverlays = new Set<HTMLElement>();


### PR DESCRIPTION
Closes #5165 