### PR TITLE
docs: add missing aria-label on card-badge

### DIFF
--- a/src/docs/pages/lean/lean.stories.ts
+++ b/src/docs/pages/lean/lean.stories.ts
@@ -152,7 +152,7 @@ const leanExampleTemplate = (): TemplateResult => html`
             ></sbb-icon>
             <span class="sbb-text-m sbb-text--bold"> CHF 40.00 </span>
           </span>
-          <sbb-card-badge>%</sbb-card-badge>
+          <sbb-card-badge aria-label="Special offer">%</sbb-card-badge>
         </sbb-checkbox-panel>
       </div>
     </section>

--- a/src/elements/checkbox-group/checkbox-group.stories.ts
+++ b/src/elements/checkbox-group/checkbox-group.stories.ts
@@ -29,7 +29,8 @@ const suffixStyle: Readonly<StyleInfo> = {
   alignItems: 'center',
 };
 
-const cardBadge = (): TemplateResult => html`<sbb-card-badge>%</sbb-card-badge>`;
+const cardBadge = (): TemplateResult =>
+  html`<sbb-card-badge aria-label="Special offer">%</sbb-card-badge>`;
 
 const suffixAndSubtext = (): TemplateResult => html`
   <span slot="subtext">Subtext</span>

--- a/src/elements/checkbox-panel/checkbox-panel.stories.ts
+++ b/src/elements/checkbox-panel/checkbox-panel.stories.ts
@@ -101,7 +101,8 @@ const defaultArgs: Args = {
   size: undefined,
 };
 
-const cardBadge = (): TemplateResult => html`<sbb-card-badge>%</sbb-card-badge>`;
+const cardBadge = (): TemplateResult =>
+  html`<sbb-card-badge aria-label="Special offer">%</sbb-card-badge>`;
 
 const Template = ({ label, checked, ...args }: Args): TemplateResult =>
   html`<sbb-checkbox-panel .checked=${checked} ?checked=${checked} ${sbbSpread(args)}>

--- a/src/elements/radio-button-group/radio-button-group.stories.ts
+++ b/src/elements/radio-button-group/radio-button-group.stories.ts
@@ -24,7 +24,8 @@ const suffixStyle: Readonly<StyleInfo> = {
   marginInlineStart: 'auto',
 };
 
-const cardBadge = (): TemplateResult => html`<sbb-card-badge>%</sbb-card-badge>`;
+const cardBadge = (): TemplateResult =>
+  html`<sbb-card-badge aria-label="Special offer">%</sbb-card-badge>`;
 
 const suffixAndSubtext = (): TemplateResult => html`
   <span slot="subtext">Subtext</span>

--- a/src/elements/radio-button-panel/radio-button-panel.stories.ts
+++ b/src/elements/radio-button-panel/radio-button-panel.stories.ts
@@ -94,7 +94,8 @@ const defaultArgs: Args = {
   'allow-empty-selection': false,
 };
 
-const cardBadge = (): TemplateResult => html`<sbb-card-badge>%</sbb-card-badge>`;
+const cardBadge = (): TemplateResult =>
+  html`<sbb-card-badge aria-label="Special offer">%</sbb-card-badge>`;
 
 const DefaultTemplate = ({ labelBoldClass, ...args }: Args): TemplateResult =>
   html`<sbb-radio-button-panel ${sbbSpread(args)} name=${args.name || nothing}

--- a/src/elements/selection-expansion-panel/selection-expansion-panel.stories.ts
+++ b/src/elements/selection-expansion-panel/selection-expansion-panel.stories.ts
@@ -112,7 +112,8 @@ const suffixStyle: Readonly<StyleInfo> = {
   marginInlineStart: 'auto',
 };
 
-const cardBadge = (): TemplateResult => html`<sbb-card-badge>%</sbb-card-badge>`;
+const cardBadge = (): TemplateResult =>
+  html`<sbb-card-badge aria-label="Special offer">%</sbb-card-badge>`;
 
 const suffixAndSubtext = (size: string): TemplateResult => html`
   <span slot="subtext">Subtext</span>


### PR DESCRIPTION
As per the card readme, it's recommended to use an aria-label attribute on the card-badge component.